### PR TITLE
feat: add OAuth authentication and document search support

### DIFF
--- a/cmd/auth.go
+++ b/cmd/auth.go
@@ -1,0 +1,18 @@
+package cmd
+
+import (
+	"github.com/spf13/cobra"
+)
+
+// authCmd 认证命令组
+var authCmd = &cobra.Command{
+	Use:   "auth",
+	Short: "管理飞书用户认证",
+	Long: `管理飞书用户认证，包括登录、刷新 token、查看状态等操作。
+
+User Access Token 用于需要用户身份的 API 操作，如搜索消息、搜索应用等。`,
+}
+
+func init() {
+	rootCmd.AddCommand(authCmd)
+}

--- a/cmd/auth_login.go
+++ b/cmd/auth_login.go
@@ -1,0 +1,233 @@
+package cmd
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"net/http"
+	"os"
+	"os/signal"
+	"syscall"
+	"time"
+
+	"github.com/riba2534/feishu-cli/internal/client"
+	"github.com/riba2534/feishu-cli/internal/config"
+	"github.com/riba2534/feishu-cli/internal/token"
+	"github.com/spf13/cobra"
+)
+
+var (
+	loginPort  int
+	loginHost  string
+	loginScope string
+)
+
+// authLoginCmd 登录命令
+var authLoginCmd = &cobra.Command{
+	Use:   "login",
+	Short: "登录飞书账号，获取 User Access Token",
+	Long: `启动 OAuth 2.0 授权流程，获取 User Access Token。
+
+流程说明:
+1. 启动本地 HTTP 服务器接收授权码
+2. 打开浏览器访问飞书授权页面
+3. 用户授权后，飞书重定向到本地服务器
+4. 自动换取并保存 User Access Token
+
+Token 将保存到 ~/.lark_user_token 文件，后续命令可自动使用。`,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		// 1. 检查 App ID 和 App Secret 配置
+		if err := config.Validate(); err != nil {
+			return err
+		}
+
+		cfg := config.Get()
+
+		// 2. 确定回调地址
+		redirectURI := fmt.Sprintf("http://%s:%d/callback", loginHost, loginPort)
+
+		// 3. 创建 OAuth 客户端
+		oauthClient, err := client.NewOAuthClient(redirectURI)
+		if err != nil {
+			return err
+		}
+
+		// 4. 创建 channel 用于接收授权码
+		codeChan := make(chan string, 1)
+		errChan := make(chan error, 1)
+
+		// 5. 启动 HTTP 服务器
+		mux := http.NewServeMux()
+		server := &http.Server{
+			Addr:    fmt.Sprintf("%s:%d", loginHost, loginPort),
+			Handler: mux,
+		}
+
+		// 处理回调
+		mux.HandleFunc("/callback", func(w http.ResponseWriter, r *http.Request) {
+			code := r.URL.Query().Get("code")
+			state := r.URL.Query().Get("state")
+			errorMsg := r.URL.Query().Get("error")
+
+			if errorMsg != "" {
+				errChan <- fmt.Errorf("授权失败: %s", errorMsg)
+				http.Error(w, "授权失败，请返回终端查看错误信息", http.StatusBadRequest)
+				return
+			}
+
+			if code == "" {
+				errChan <- fmt.Errorf("未收到授权码")
+				http.Error(w, "未收到授权码", http.StatusBadRequest)
+				return
+			}
+
+			// 简单的 state 验证（可选）
+			_ = state
+
+			codeChan <- code
+
+			// 返回成功页面
+			w.Header().Set("Content-Type", "text/html; charset=utf-8")
+			fmt.Fprint(w, `<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="UTF-8">
+    <title>授权成功</title>
+    <style>
+        body { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif; display: flex; justify-content: center; align-items: center; height: 100vh; margin: 0; background: #f5f5f5; }
+        .container { text-align: center; background: white; padding: 40px; border-radius: 8px; box-shadow: 0 2px 10px rgba(0,0,0,0.1); }
+        .success-icon { font-size: 64px; color: #52c41a; margin-bottom: 20px; }
+        h1 { color: #333; margin-bottom: 10px; }
+        p { color: #666; }
+    </style>
+</head>
+<body>
+    <div class="container">
+        <div class="success-icon">✓</div>
+        <h1>授权成功</h1>
+        <p>请返回终端查看 token 信息</p>
+        <p>您可以关闭此页面</p>
+    </div>
+</body>
+</html>`)
+		})
+
+		// 6. 启动服务器
+		listener, err := net.Listen("tcp", server.Addr)
+		if err != nil {
+			return fmt.Errorf("启动本地服务器失败: %w", err)
+		}
+		actualPort := listener.Addr().(*net.TCPAddr).Port
+		actualAddr := fmt.Sprintf("http://%s:%d/callback", loginHost, actualPort)
+
+		// 更新 OAuth 客户端的 redirect URI
+		oauthClient.RedirectURI = actualAddr
+
+		go func() {
+			if err := server.Serve(listener); err != nil && err != http.ErrServerClosed {
+				errChan <- fmt.Errorf("服务器错误: %w", err)
+			}
+		}()
+
+		// 7. 生成授权 URL 并提示用户
+		authorizeURL := oauthClient.GetAuthorizeURL("random-state", loginScope)
+
+		fmt.Println("=")
+		fmt.Println("飞书用户授权")
+		fmt.Println("=")
+		fmt.Println()
+		fmt.Printf("应用 ID: %s\n", cfg.AppID)
+		fmt.Printf("回调地址: %s\n", actualAddr)
+		fmt.Println()
+		fmt.Println("请在浏览器中访问以下链接进行授权:")
+		fmt.Println()
+		fmt.Println(authorizeURL)
+		fmt.Println()
+		fmt.Println("等待授权...")
+		fmt.Println()
+
+		// 8. 等待授权码或错误
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+
+		// 处理信号
+		sigChan := make(chan os.Signal, 1)
+		signal.Notify(sigChan, syscall.SIGINT, syscall.SIGTERM)
+
+		var authCode string
+		select {
+		case authCode = <-codeChan:
+			// 收到授权码
+		case err := <-errChan:
+			return err
+		case <-sigChan:
+			fmt.Println("\n已取消授权")
+			server.Shutdown(ctx)
+			return nil
+		case <-time.After(5 * time.Minute):
+			server.Shutdown(ctx)
+			return fmt.Errorf("授权超时，请重新运行命令")
+		}
+
+		// 9. 关闭服务器
+		shutdownCtx, shutdownCancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer shutdownCancel()
+		server.Shutdown(shutdownCtx)
+
+		fmt.Println("已收到授权码，正在换取 token...")
+
+		// 10. 用授权码换取 token
+		userToken, err := oauthClient.ExchangeCodeForToken(authCode)
+		if err != nil {
+			return fmt.Errorf("换取 token 失败: %w", err)
+		}
+
+		// 11. 保存 token
+		if err := token.SaveToken(userToken); err != nil {
+			return err
+		}
+
+		// 12. 显示成功信息
+		fmt.Println()
+		fmt.Println("=")
+		fmt.Println("授权成功！")
+		fmt.Println("=")
+		fmt.Println()
+		fmt.Printf("Access Token: %s...%s\n",
+			userToken.AccessToken[:min(10, len(userToken.AccessToken))],
+			userToken.AccessToken[max(0, len(userToken.AccessToken)-10):])
+		fmt.Printf("Refresh Token: %s...%s\n",
+			userToken.RefreshToken[:min(10, len(userToken.RefreshToken))],
+			userToken.RefreshToken[max(0, len(userToken.RefreshToken)-10):])
+		fmt.Printf("过期时间: %s\n", userToken.FormatExpiry())
+		fmt.Println()
+		fmt.Printf("Token 已保存到: ~/.lark_user_token\n")
+		fmt.Println()
+		fmt.Println("现在您可以使用需要 User Access Token 的命令，如:")
+		fmt.Println("  feishu-cli search messages \"关键词\"")
+		fmt.Println()
+
+		return nil
+	},
+}
+
+func init() {
+	authCmd.AddCommand(authLoginCmd)
+	authLoginCmd.Flags().IntVarP(&loginPort, "port", "p", 8080, "本地服务器端口（0 表示随机端口）")
+	authLoginCmd.Flags().StringVarP(&loginHost, "host", "H", "127.0.0.1", "本地服务器主机地址")
+	authLoginCmd.Flags().StringVarP(&loginScope, "scope", "s", "", "OAuth scope（多个 scope 用空格分隔，如：\"contact:user.read chat:message\"）")
+}
+
+func min(a, b int) int {
+	if a < b {
+		return a
+	}
+	return b
+}
+
+func max(a, b int) int {
+	if a > b {
+		return a
+	}
+	return b
+}

--- a/cmd/auth_refresh.go
+++ b/cmd/auth_refresh.go
@@ -1,0 +1,77 @@
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/riba2534/feishu-cli/internal/client"
+	"github.com/riba2534/feishu-cli/internal/token"
+	"github.com/spf13/cobra"
+)
+
+// authRefreshCmd 刷新 token 命令
+var authRefreshCmd = &cobra.Command{
+	Use:   "refresh",
+	Short: "刷新 User Access Token",
+	Long: `使用 refresh_token 换取新的 access_token。
+
+当 access_token 过期时，可以使用 refresh_token 获取新的 token，
+无需重新登录。refresh_token 的有效期通常为 30 天。`,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		// 1. 加载现有 token
+		tok, err := token.LoadToken()
+		if err != nil {
+			return fmt.Errorf("加载 token 失败: %w", err)
+		}
+
+		fmt.Println("=")
+		fmt.Println("刷新 User Access Token")
+		fmt.Println("=")
+		fmt.Println()
+
+		// 2. 显示当前 token 状态
+		fmt.Println("当前 Token 状态:")
+		fmt.Printf("  Access Token: %s...%s\n",
+			tok.AccessToken[:min(10, len(tok.AccessToken))],
+			tok.AccessToken[max(0, len(tok.AccessToken)-10):])
+		fmt.Printf("  过期状态: %s\n", tok.FormatExpiry())
+		fmt.Println()
+
+		// 3. 创建 OAuth 客户端
+		oauthClient, err := client.NewOAuthClient("")
+		if err != nil {
+			return err
+		}
+
+		// 4. 刷新 token
+		fmt.Println("正在刷新 token...")
+		newToken, err := oauthClient.RefreshUserAccessToken(tok.RefreshToken)
+		if err != nil {
+			return fmt.Errorf("刷新 token 失败: %w", err)
+		}
+
+		// 5. 保存新 token
+		if err := token.SaveToken(newToken); err != nil {
+			return err
+		}
+
+		// 6. 显示成功信息
+		fmt.Println()
+		fmt.Println("=")
+		fmt.Println("刷新成功！")
+		fmt.Println("=")
+		fmt.Println()
+		fmt.Printf("新的 Access Token: %s...%s\n",
+			newToken.AccessToken[:min(10, len(newToken.AccessToken))],
+			newToken.AccessToken[max(0, len(newToken.AccessToken)-10):])
+		fmt.Printf("新的过期时间: %s\n", newToken.FormatExpiry())
+		fmt.Println()
+		fmt.Println("Token 已更新到: ~/.lark_user_token")
+		fmt.Println()
+
+		return nil
+	},
+}
+
+func init() {
+	authCmd.AddCommand(authRefreshCmd)
+}

--- a/cmd/auth_status.go
+++ b/cmd/auth_status.go
@@ -1,0 +1,92 @@
+package cmd
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/riba2534/feishu-cli/internal/config"
+	"github.com/riba2534/feishu-cli/internal/token"
+	"github.com/spf13/cobra"
+)
+
+// authStatusCmd 查看 token 状态命令
+var authStatusCmd = &cobra.Command{
+	Use:   "status",
+	Short: "查看 User Access Token 状态",
+	Long: `显示当前 User Access Token 的信息和过期状态。
+
+检查以下位置的 token（按优先级排序）:
+1. FEISHU_USER_ACCESS_TOKEN 环境变量
+2. 配置文件中的 user_access_token
+3. ~/.lark_user_token 文件`,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		fmt.Println("=")
+		fmt.Println("User Access Token 状态")
+		fmt.Println("=")
+		fmt.Println()
+
+		// 1. 检查环境变量
+		envToken := os.Getenv("FEISHU_USER_ACCESS_TOKEN")
+		if envToken != "" {
+			fmt.Println("Token 来源: 环境变量 FEISHU_USER_ACCESS_TOKEN")
+			fmt.Printf("Token: %s...%s\n",
+				envToken[:min(10, len(envToken))],
+				envToken[max(0, len(envToken)-10):])
+			fmt.Println("状态: 可用（环境变量优先级最高）")
+			fmt.Println()
+			fmt.Println("提示: 环境变量设置的 token 不会自动刷新，过期后需要手动更新")
+			return nil
+		}
+
+		// 2. 检查配置文件
+		cfg := config.Get()
+		if cfg.UserAccessToken != "" {
+			fmt.Println("Token 来源: 配置文件")
+			fmt.Printf("Token: %s...%s\n",
+				cfg.UserAccessToken[:min(10, len(cfg.UserAccessToken))],
+				cfg.UserAccessToken[max(0, len(cfg.UserAccessToken)-10):])
+			fmt.Println("状态: 可用")
+			fmt.Println()
+			fmt.Println("提示: 配置文件中的 token 不会自动刷新，过期后需要手动更新")
+			return nil
+		}
+
+		// 3. 检查 token 文件
+		tok, err := token.LoadToken()
+		if err != nil {
+			fmt.Println("状态: 未登录")
+			fmt.Println()
+			fmt.Println("未找到 User Access Token，请运行以下命令进行授权:")
+			fmt.Println("  feishu-cli auth login")
+			fmt.Println()
+			return nil
+		}
+
+		fmt.Println("Token 来源: ~/.lark_user_token")
+		fmt.Println()
+		fmt.Println("Token 信息:")
+		fmt.Printf("  Access Token:  %s...%s\n",
+			tok.AccessToken[:min(10, len(tok.AccessToken))],
+			tok.AccessToken[max(0, len(tok.AccessToken)-10):])
+		fmt.Printf("  Refresh Token: %s...%s\n",
+			tok.RefreshToken[:min(10, len(tok.RefreshToken))],
+			tok.RefreshToken[max(0, len(tok.RefreshToken)-10):])
+		fmt.Println()
+		fmt.Println("状态:")
+		if tok.IsExpired() {
+			fmt.Printf("  ⚠️ 已过期 (%s)\n", tok.FormatExpiry())
+			fmt.Println()
+			fmt.Println("建议运行以下命令刷新 token:")
+			fmt.Println("  feishu-cli auth refresh")
+		} else {
+			fmt.Printf("  ✅ 有效，剩余 %s\n", tok.FormatExpiry())
+		}
+		fmt.Println()
+
+		return nil
+	},
+}
+
+func init() {
+	authCmd.AddCommand(authStatusCmd)
+}

--- a/cmd/search_docs.go
+++ b/cmd/search_docs.go
@@ -1,0 +1,168 @@
+package cmd
+
+import (
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/riba2534/feishu-cli/internal/client"
+	"github.com/riba2534/feishu-cli/internal/config"
+	"github.com/spf13/cobra"
+)
+
+var searchDocsCmd = &cobra.Command{
+	Use:   "docs <query>",
+	Short: "搜索文档",
+	Long: `搜索飞书文档、表格、幻灯片等。
+
+注意：此功能需要 User Access Token（用户授权令牌）和 search:docs:read 权限。
+
+参数:
+  query           搜索关键词（必需）
+
+选项:
+  --doc-types     文档类型过滤（doc/sheet/slides/wiki_database/wiki_doc/wiki_note/wiki_sheet，逗号分隔）
+  --owner-ids     文档所有者用户 ID 列表（逗号分隔）
+  --creator-ids   文档创建者用户 ID 列表（逗号分隔）
+  --chat-ids      文档所在群组 ID 列表（逗号分隔）
+  --doc-created   文档创建时间筛选（如: >=2024-01-01, <=2024-12-31）
+  --doc-updated   文档更新时间筛选
+  --page-size     每页数量（默认 20）
+  --page-token    分页 token
+  --user-id-type  用户 ID 类型（open_id/union_id/user_id，默认 open_id）
+
+示例:
+  # 搜索包含"项目"的文档
+  feishu-cli search docs "项目"
+
+  # 搜索特定创建者的文档
+  feishu-cli search docs "项目" --creator-ids ou_xxx
+
+  # 搜索特定类型的文档（仅文档和表格）
+  feishu-cli search docs "项目" --doc-types doc,sheet
+
+  # 搜索最近更新的文档
+  feishu-cli search docs "项目" --doc-updated ">=2024-01-01"`,
+	Args: cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		if err := config.Validate(); err != nil {
+			return err
+		}
+
+		query := args[0]
+
+		// 获取 user access token
+		userAccessToken, _ := cmd.Flags().GetString("user-access-token")
+		if userAccessToken == "" {
+			userAccessToken = config.Get().UserAccessToken
+		}
+		if userAccessToken == "" {
+			userAccessToken = os.Getenv("FEISHU_USER_ACCESS_TOKEN")
+		}
+		if userAccessToken == "" {
+			// 尝试从 token 文件获取（支持自动刷新）
+			var err error
+			userAccessToken, err = client.GetUserAccessToken()
+			if err != nil {
+				return fmt.Errorf("缺少 User Access Token，请通过以下方式之一提供:\n"+
+					"  1. 命令行参数: --user-access-token <token>\n"+
+					"  2. 环境变量: export FEISHU_USER_ACCESS_TOKEN=<token>\n"+
+					"  3. 配置文件: user_access_token: <token>\n"+
+					"  4. 运行授权命令: feishu-cli auth login\n"+
+					"\n错误: %w", err)
+			}
+		}
+
+		// 获取其他参数
+		docTypesStr, _ := cmd.Flags().GetString("doc-types")
+		ownerIDsStr, _ := cmd.Flags().GetString("owner-ids")
+		creatorIDsStr, _ := cmd.Flags().GetString("creator-ids")
+		chatIDsStr, _ := cmd.Flags().GetString("chat-ids")
+		docCreated, _ := cmd.Flags().GetString("doc-created")
+		docUpdated, _ := cmd.Flags().GetString("doc-updated")
+		pageSize, _ := cmd.Flags().GetInt("page-size")
+		pageToken, _ := cmd.Flags().GetString("page-token")
+		userIDType, _ := cmd.Flags().GetString("user-id-type")
+		output, _ := cmd.Flags().GetString("output")
+
+		// 解析逗号分隔的列表
+		var docTypes, ownerIDs, creatorIDs, chatIDs []string
+		if docTypesStr != "" {
+			docTypes = strings.Split(docTypesStr, ",")
+		}
+		if ownerIDsStr != "" {
+			ownerIDs = strings.Split(ownerIDsStr, ",")
+		}
+		if creatorIDsStr != "" {
+			creatorIDs = strings.Split(creatorIDsStr, ",")
+		}
+		if chatIDsStr != "" {
+			chatIDs = strings.Split(chatIDsStr, ",")
+		}
+
+		opts := client.SearchDocsOptions{
+			Query:        query,
+			DocTypes:     docTypes,
+			OwnerIDs:     ownerIDs,
+			CreatorIDs:   creatorIDs,
+			ChatIDs:      chatIDs,
+			DocCreatedAt: docCreated,
+			DocUpdatedAt: docUpdated,
+			PageSize:     pageSize,
+			PageToken:    pageToken,
+			UserIDType:   userIDType,
+		}
+
+		result, err := client.SearchDocs(opts, userAccessToken)
+		if err != nil {
+			return err
+		}
+
+		if output == "json" {
+			if err := printJSON(result); err != nil {
+				return err
+			}
+		} else {
+			if len(result.Docs) == 0 {
+				fmt.Println("未找到匹配的文档")
+				return nil
+			}
+
+			fmt.Printf("搜索结果（共 %d 条）:\n\n", len(result.Docs))
+			for i, doc := range result.Docs {
+				fmt.Printf("[%d] %s\n", i+1, doc.DocName)
+				fmt.Printf("    类型: %s\n", doc.DocType)
+				fmt.Printf("    Token: %s\n", doc.DocToken)
+				if doc.CreatorID != "" {
+					fmt.Printf("    创建者: %s\n", doc.CreatorID)
+				}
+				if doc.OwnerName != "" {
+					fmt.Printf("    所有者: %s\n", doc.OwnerName)
+				}
+				fmt.Println()
+			}
+
+			if result.HasMore {
+				fmt.Printf("还有更多结果，使用 --page-token %s 获取下一页\n", result.PageToken)
+			}
+		}
+
+		return nil
+	},
+}
+
+func init() {
+	searchCmd.AddCommand(searchDocsCmd)
+
+	searchDocsCmd.Flags().String("user-access-token", "", "User Access Token（用户授权令牌）")
+	searchDocsCmd.Flags().String("doc-types", "", "文档类型（doc/sheet/slides/wiki_database/wiki_doc/wiki_note/wiki_sheet，逗号分隔）")
+	searchDocsCmd.Flags().String("owner-ids", "", "文档所有者用户 ID 列表（逗号分隔）")
+	searchDocsCmd.Flags().String("creator-ids", "", "文档创建者用户 ID 列表（逗号分隔）")
+	searchDocsCmd.Flags().String("chat-ids", "", "文档所在群组 ID 列表（逗号分隔）")
+	searchDocsCmd.Flags().String("doc-created", "", "文档创建时间筛选（如: \u003e=2024-01-01）")
+	searchDocsCmd.Flags().String("doc-updated", "", "文档更新时间筛选（如: \u003e=2024-01-01）")
+	searchDocsCmd.Flags().Int("page-size", 20, "每页数量")
+	searchDocsCmd.Flags().String("page-token", "", "分页 token")
+	searchDocsCmd.Flags().String("user-id-type", "open_id", "用户 ID 类型（open_id/union_id/user_id）")
+	searchDocsCmd.Flags().StringP("output", "o", "", "输出格式（json）")
+}

--- a/cmd/search_messages.go
+++ b/cmd/search_messages.go
@@ -65,10 +65,17 @@ var searchMessagesCmd = &cobra.Command{
 			userAccessToken = os.Getenv("FEISHU_USER_ACCESS_TOKEN")
 		}
 		if userAccessToken == "" {
-			return fmt.Errorf("缺少 User Access Token，请通过以下方式之一提供:\n" +
-				"  1. 命令行参数: --user-access-token <token>\n" +
-				"  2. 环境变量: export FEISHU_USER_ACCESS_TOKEN=<token>\n" +
-				"  3. 配置文件: user_access_token: <token>")
+			// 尝试从 token 文件获取（支持自动刷新）
+			var err error
+			userAccessToken, err = client.GetUserAccessToken()
+			if err != nil {
+				return fmt.Errorf("缺少 User Access Token，请通过以下方式之一提供:\n" +
+					"  1. 命令行参数: --user-access-token <token>\n" +
+					"  2. 环境变量: export FEISHU_USER_ACCESS_TOKEN=<token>\n" +
+					"  3. 配置文件: user_access_token: <token>\n" +
+					"  4. 运行授权命令: feishu-cli auth login\n" +
+					"\n错误: %w", err)
+			}
 		}
 
 		// 获取其他参数

--- a/internal/client/auth.go
+++ b/internal/client/auth.go
@@ -1,0 +1,208 @@
+package client
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/url"
+	"time"
+
+	"github.com/riba2534/feishu-cli/internal/config"
+	"github.com/riba2534/feishu-cli/internal/token"
+)
+
+const (
+	// OAuth 授权相关 URL
+	oauthAuthorizeURL = "https://open.feishu.cn/open-apis/authen/v1/authorize"
+	tokenURL          = "https://open.feishu.cn/open-apis/authen/v1/oidc/access_token"
+	refreshTokenURL   = "https://open.feishu.cn/open-apis/authen/v1/oidc/refresh_access_token"
+)
+
+// OAuthClient OAuth 客户端
+type OAuthClient struct {
+	AppID       string
+	AppSecret   string
+	RedirectURI string
+	HTTPClient  *http.Client
+}
+
+// NewOAuthClient 创建 OAuth 客户端
+func NewOAuthClient(redirectURI string) (*OAuthClient, error) {
+	cfg := config.Get()
+	if cfg.AppID == "" || cfg.AppSecret == "" {
+		return nil, fmt.Errorf("缺少 App ID 或 App Secret，请先配置应用凭证")
+	}
+
+	return &OAuthClient{
+		AppID:       cfg.AppID,
+		AppSecret:   cfg.AppSecret,
+		RedirectURI: redirectURI,
+		HTTPClient: &http.Client{
+			Timeout: 30 * time.Second,
+		},
+	}, nil
+}
+
+// GetAuthorizeURL 生成授权 URL
+func (c *OAuthClient) GetAuthorizeURL(state string, scope string) string {
+	authURL := fmt.Sprintf("%s?app_id=%s&redirect_uri=%s&state=%s",
+		oauthAuthorizeURL,
+		c.AppID,
+		url.QueryEscape(c.RedirectURI),
+		state,
+	)
+	if scope != "" {
+		authURL = fmt.Sprintf("%s&scope=%s", authURL, url.QueryEscape(scope))
+	}
+	return authURL
+}
+
+// ExchangeCodeForToken 用授权码换取 access token
+func (c *OAuthClient) ExchangeCodeForToken(code string) (*token.UserToken, error) {
+	reqBody := map[string]string{
+		"grant_type": "authorization_code",
+		"code":       code,
+	}
+
+	return c.doTokenRequest(tokenURL, reqBody)
+}
+
+// RefreshUserAccessToken 刷新用户访问令牌
+func (c *OAuthClient) RefreshUserAccessToken(refreshToken string) (*token.UserToken, error) {
+	reqBody := map[string]string{
+		"grant_type":    "refresh_token",
+		"refresh_token": refreshToken,
+	}
+
+	return c.doTokenRequest(refreshTokenURL, reqBody)
+}
+
+// getAppAccessToken 获取应用级 Access Token
+func (c *OAuthClient) getAppAccessToken() (string, error) {
+	reqBody := map[string]string{
+		"app_id":     c.AppID,
+		"app_secret": c.AppSecret,
+	}
+
+	jsonData, err := json.Marshal(reqBody)
+	if err != nil {
+		return "", fmt.Errorf("序列化请求失败: %w", err)
+	}
+
+	req, err := http.NewRequest("POST", "https://open.feishu.cn/open-apis/auth/v3/app_access_token/internal", bytes.NewBuffer(jsonData))
+	if err != nil {
+		return "", fmt.Errorf("创建请求失败: %w", err)
+	}
+
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := c.HTTPClient.Do(req)
+	if err != nil {
+		return "", fmt.Errorf("请求失败: %w", err)
+	}
+	defer resp.Body.Close()
+
+	var result struct {
+		Code           int    `json:"code"`
+		Msg            string `json:"msg"`
+		AppAccessToken string `json:"app_access_token"`
+		Expire         int    `json:"expire"`
+	}
+
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		return "", fmt.Errorf("解析响应失败: %w", err)
+	}
+
+	if result.Code != 0 {
+		return "", fmt.Errorf("获取 app_access_token 失败: code=%d, msg=%s", result.Code, result.Msg)
+	}
+
+	return result.AppAccessToken, nil
+}
+
+// doTokenRequest 执行 token 请求
+func (c *OAuthClient) doTokenRequest(apiURL string, reqBody map[string]string) (*token.UserToken, error) {
+	// 1. 获取 App Access Token
+	appAccessToken, err := c.getAppAccessToken()
+	if err != nil {
+		return nil, err
+	}
+
+	// 2. 构造请求体
+	jsonData, err := json.Marshal(reqBody)
+	if err != nil {
+		return nil, fmt.Errorf("序列化请求失败: %w", err)
+	}
+
+	// 3. 创建请求
+	req, err := http.NewRequest("POST", apiURL, bytes.NewBuffer(jsonData))
+	if err != nil {
+		return nil, fmt.Errorf("创建请求失败: %w", err)
+	}
+
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", appAccessToken))
+
+	// 4. 发送请求
+	resp, err := c.HTTPClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("请求失败: %w", err)
+	}
+	defer resp.Body.Close()
+
+	var tokenResp token.TokenResponse
+	if err := json.NewDecoder(resp.Body).Decode(&tokenResp); err != nil {
+		return nil, fmt.Errorf("解析响应失败: %w", err)
+	}
+
+	if tokenResp.Code != 0 {
+		return nil, fmt.Errorf("获取 token 失败: code=%d, msg=%s", tokenResp.Code, tokenResp.Msg)
+	}
+
+	userToken := &token.UserToken{
+		AccessToken:  tokenResp.Data.AccessToken,
+		RefreshToken: tokenResp.Data.RefreshToken,
+		ExpiresIn:    tokenResp.Data.ExpiresIn,
+		ExpiresAt:    time.Now().Unix() + tokenResp.Data.ExpiresIn,
+	}
+
+	return userToken, nil
+}
+
+// GetUserAccessToken 获取用户访问令牌（优先从文件加载，过期则刷新）
+func GetUserAccessToken() (string, error) {
+	// 1. 检查环境变量
+	if envToken := config.Get().UserAccessToken; envToken != "" {
+		return envToken, nil
+	}
+
+	// 2. 检查 token 文件
+	tok, err := token.LoadToken()
+	if err != nil {
+		return "", fmt.Errorf("未找到 User Access Token，请先运行 'feishu-cli auth login' 进行授权: %w", err)
+	}
+
+	// 3. 检查是否过期
+	if !tok.IsExpired() {
+		return tok.AccessToken, nil
+	}
+
+	// 4. 过期则刷新
+	oauthClient, err := NewOAuthClient("")
+	if err != nil {
+		return "", err
+	}
+
+	newToken, err := oauthClient.RefreshUserAccessToken(tok.RefreshToken)
+	if err != nil {
+		return "", fmt.Errorf("刷新 token 失败: %w", err)
+	}
+
+	// 5. 保存新 token
+	if err := token.SaveToken(newToken); err != nil {
+		return "", fmt.Errorf("保存刷新后的 token 失败: %w", err)
+	}
+
+	return newToken.AccessToken, nil
+}

--- a/internal/client/search.go
+++ b/internal/client/search.go
@@ -1,7 +1,12 @@
 package client
 
 import (
+	"bytes"
+	"encoding/json"
 	"fmt"
+	"io"
+	"net/http"
+	"time"
 
 	larkcore "github.com/larksuite/oapi-sdk-go/v3/core"
 	larksearch "github.com/larksuite/oapi-sdk-go/v3/service/search/v2"
@@ -155,4 +160,173 @@ func SearchApps(opts SearchAppsOptions, userAccessToken string) (*SearchAppsResu
 	}
 
 	return result, nil
+}
+
+// SearchDocsOptions 搜索文档的选项
+type SearchDocsOptions struct {
+	Query        string   // 搜索关键词
+	DocTypes     []string // 文档类型（doc/sheet/slides/wiki_database/wiki_doc/wiki_note/wiki_sheet）
+	OwnerIDs     []string // 文档所有者 ID 列表
+	ChatIDs      []string // 文档所在群组 ID 列表
+	CreatorIDs   []string // 文档创建者 ID 列表
+	DocCreatedAt string   // 文档创建时间筛选（格式: >=yyyy-MM-dd 或 <=yyyy-MM-dd）
+	DocUpdatedAt string   // 文档更新时间筛选
+	PageSize     int      // 每页数量
+	PageToken    string   // 分页 token
+	UserIDType   string   // 用户 ID 类型
+}
+
+// DocInfo 文档信息
+type DocInfo struct {
+	DocToken  string // 文档 token
+	DocType   string // 文档类型
+	DocName   string // 文档名称
+	OwnerID   string // 所有者 ID
+	OwnerName string // 所有者名称
+	CreatorID string // 创建者 ID
+	CreateTime int64 // 创建时间
+	UpdateTime int64 // 更新时间
+}
+
+// SearchDocsResult 搜索文档的结果
+type SearchDocsResult struct {
+	Docs      []*DocInfo // 文档列表
+	PageToken string     // 分页 token
+	HasMore   bool       // 是否有更多
+}
+
+// SearchDocs 搜索文档
+// 注意：此 API 需要 User Access Token 和 search:docs:read 权限
+func SearchDocs(opts SearchDocsOptions, userAccessToken string) (*SearchDocsResult, error) {
+	httpClient := &http.Client{Timeout: 30 * time.Second}
+
+	// 构建请求体
+	reqBody := map[string]interface{}{
+		"search_key": opts.Query,
+	}
+
+	// 分页参数
+	if opts.PageSize > 0 {
+		reqBody["count"] = opts.PageSize
+	} else {
+		reqBody["count"] = 20
+	}
+
+	// 解析 page_token 作为 offset
+	if opts.PageToken != "" {
+		var offset int
+		fmt.Sscanf(opts.PageToken, "%d", &offset)
+		reqBody["offset"] = offset
+	} else {
+		reqBody["offset"] = 0
+	}
+
+	if len(opts.DocTypes) > 0 {
+		reqBody["docs_types"] = opts.DocTypes
+	}
+	if len(opts.OwnerIDs) > 0 {
+		reqBody["owner_ids"] = opts.OwnerIDs
+	}
+	if len(opts.ChatIDs) > 0 {
+		reqBody["chat_ids"] = opts.ChatIDs
+	}
+	// 注意：此 API 不支持 creator_ids、doc_created_at、doc_updated_at 参数
+
+	jsonData, err := json.Marshal(reqBody)
+	if err != nil {
+		return nil, fmt.Errorf("序列化请求失败: %w", err)
+	}
+
+	// 构建 URL - 使用云文档搜索 API
+	apiURL := "https://open.feishu.cn/open-apis/suite/docs-api/search/object"
+
+	req, err := http.NewRequest("POST", apiURL, bytes.NewBuffer(jsonData))
+	if err != nil {
+		return nil, fmt.Errorf("创建请求失败: %w", err)
+	}
+
+	req.Header.Set("Content-Type", "application/json; charset=utf-8")
+	req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", userAccessToken))
+
+	resp, err := httpClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("搜索文档请求失败: %w", err)
+	}
+	defer resp.Body.Close()
+
+	// 读取响应体
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("读取响应失败: %w", err)
+	}
+
+	// 使用 map 解析响应
+	var result map[string]interface{}
+	if err := json.Unmarshal(body, &result); err != nil {
+		return nil, fmt.Errorf("解析响应失败: %w", err)
+	}
+
+	// 检查 code
+	code, _ := result["code"].(float64)
+	if code != 0 {
+		msg, _ := result["msg"].(string)
+		return nil, fmt.Errorf("搜索文档失败: code=%d, msg=%s", int(code), msg)
+	}
+
+	// 解析数据
+	searchResult := &SearchDocsResult{
+		Docs:    []*DocInfo{},
+		HasMore: false,
+	}
+
+	data, ok := result["data"].(map[string]interface{})
+	if !ok {
+		return searchResult, nil
+	}
+
+	// 解析 docs_entities (API 文档中的字段名)
+	docsEntities, ok := data["docs_entities"].([]interface{})
+	if !ok {
+		return searchResult, nil
+	}
+
+	for _, item := range docsEntities {
+		itemMap, ok := item.(map[string]interface{})
+		if !ok {
+			continue
+		}
+
+		doc := &DocInfo{}
+		// API 返回的是 docs_token, docs_type, title, owner_id
+		if v, ok := itemMap["docs_token"].(string); ok {
+			doc.DocToken = v
+		}
+		if v, ok := itemMap["docs_type"].(string); ok {
+			doc.DocType = v
+		}
+		if v, ok := itemMap["title"].(string); ok {
+			doc.DocName = v
+		}
+		if v, ok := itemMap["owner_id"].(string); ok {
+			doc.OwnerID = v
+		}
+
+		searchResult.Docs = append(searchResult.Docs, doc)
+	}
+
+	// 解析分页信息
+	if v, ok := data["has_more"].(bool); ok {
+		searchResult.HasMore = v
+	}
+	// 计算下一页的 offset
+	if searchResult.HasMore {
+		totalDocs := len(searchResult.Docs)
+		currentOffset := 0
+		if opts.PageToken != "" {
+			fmt.Sscanf(opts.PageToken, "%d", &currentOffset)
+		}
+		searchResult.PageToken = fmt.Sprintf("%d", currentOffset+totalDocs)
+	}
+
+	return searchResult, nil
 }

--- a/internal/token/token.go
+++ b/internal/token/token.go
@@ -1,0 +1,171 @@
+package token
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"time"
+)
+
+// UserToken 存储用户访问令牌信息
+type UserToken struct {
+	AccessToken  string `json:"access_token"`
+	RefreshToken string `json:"refresh_token"`
+	ExpiresAt    int64  `json:"expires_at"`
+	ExpiresIn    int64  `json:"expires_in"`
+}
+
+// TokenResponse 飞书 OAuth API 响应
+type TokenResponse struct {
+	Code int    `json:"code"`
+	Msg  string `json:"msg"`
+	Data struct {
+		AccessToken  string `json:"access_token"`
+		RefreshToken string `json:"refresh_token"`
+		ExpiresIn    int64  `json:"expires_in"`
+	} `json:"data"`
+}
+
+// RefreshResponse 飞书刷新 Token API 响应
+type RefreshResponse struct {
+	Code int    `json:"code"`
+	Msg  string `json:"msg"`
+	Data struct {
+		AccessToken  string `json:"access_token"`
+		RefreshToken string `json:"refresh_token"`
+		ExpiresIn    int64  `json:"expires_in"`
+	} `json:"data"`
+}
+
+// tokenFilePath 返回 token 文件路径
+func tokenFilePath() (string, error) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", fmt.Errorf("获取用户目录失败: %w", err)
+	}
+	return filepath.Join(home, ".lark_user_token"), nil
+}
+
+// SaveToken 保存 token 到文件
+func SaveToken(token *UserToken) error {
+	path, err := tokenFilePath()
+	if err != nil {
+		return err
+	}
+
+	// 确保目录存在
+	dir := filepath.Dir(path)
+	if err := os.MkdirAll(dir, 0700); err != nil {
+		return fmt.Errorf("创建目录失败: %w", err)
+	}
+
+	data, err := json.MarshalIndent(token, "", "  ")
+	if err != nil {
+		return fmt.Errorf("序列化 token 失败: %w", err)
+	}
+
+	// 使用 0600 权限，仅所有者可读写
+	if err := os.WriteFile(path, data, 0600); err != nil {
+		return fmt.Errorf("写入 token 文件失败: %w", err)
+	}
+
+	return nil
+}
+
+// LoadToken 从文件加载 token
+func LoadToken() (*UserToken, error) {
+	path, err := tokenFilePath()
+	if err != nil {
+		return nil, err
+	}
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, fmt.Errorf("token 文件不存在，请先运行登录命令")
+		}
+		return nil, fmt.Errorf("读取 token 文件失败: %w", err)
+	}
+
+	var token UserToken
+	if err := json.Unmarshal(data, &token); err != nil {
+		return nil, fmt.Errorf("解析 token 文件失败: %w", err)
+	}
+
+	return &token, nil
+}
+
+// IsExpired 检查 token 是否过期（提前 5 分钟视为过期）
+func (t *UserToken) IsExpired() bool {
+	if t.ExpiresAt == 0 {
+		return true
+	}
+	// 提前 5 分钟视为过期，避免边界问题
+	return time.Now().Unix() >= (t.ExpiresAt - 300)
+}
+
+// GetRemainingTime 获取 token 剩余有效时间
+func (t *UserToken) GetRemainingTime() time.Duration {
+	if t.IsExpired() {
+		return 0
+	}
+	return time.Until(time.Unix(t.ExpiresAt, 0))
+}
+
+// FormatExpiry 格式化过期时间显示
+func (t *UserToken) FormatExpiry() string {
+	if t.ExpiresAt == 0 {
+		return "未知"
+	}
+	expiryTime := time.Unix(t.ExpiresAt, 0)
+	remaining := t.GetRemainingTime()
+
+	if t.IsExpired() {
+		return fmt.Sprintf("已过期 (%s)", expiryTime.Format("2006-01-02 15:04:05"))
+	}
+
+	// 格式化剩余时间
+	hours := int(remaining.Hours())
+	minutes := int(remaining.Minutes()) % 60
+	seconds := int(remaining.Seconds()) % 60
+
+	var timeStr string
+	if hours > 0 {
+		timeStr = fmt.Sprintf("%d小时%d分钟", hours, minutes)
+	} else if minutes > 0 {
+		timeStr = fmt.Sprintf("%d分钟%d秒", minutes, seconds)
+	} else {
+		timeStr = fmt.Sprintf("%d秒", seconds)
+	}
+
+	return fmt.Sprintf("%s (过期时间: %s)", timeStr, expiryTime.Format("2006-01-02 15:04:05"))
+}
+
+// DeleteToken 删除 token 文件
+func DeleteToken() error {
+	path, err := tokenFilePath()
+	if err != nil {
+		return err
+	}
+
+	if err := os.Remove(path); err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+		return fmt.Errorf("删除 token 文件失败: %w", err)
+	}
+
+	return nil
+}
+
+// TokenExists 检查 token 文件是否存在
+func TokenExists() bool {
+	path, err := tokenFilePath()
+	if err != nil {
+		return false
+	}
+
+	_, err = os.Stat(path)
+	return err == nil
+}

--- a/skills/feishu-cli-auth/SKILL.md
+++ b/skills/feishu-cli-auth/SKILL.md
@@ -1,0 +1,135 @@
+---
+name: feishu-auth
+description: |
+  飞书用户认证管理工具。帮助用户通过 OAuth 2.0 授权流程获取 User Access Token，
+  支持自动刷新和状态查看。获取的 Token 可用于搜索消息、搜索应用等需要用户身份的操作。
+argument-hint: "[login|refresh|status]"
+user-invocable: true
+allowed-tools: ["Bash"]
+---
+
+# 飞书用户认证 Skill
+
+## 功能概述
+
+此 Skill 帮助用户完成飞书 OAuth 2.0 授权流程，获取 User Access Token。
+
+## 授权流程
+
+1. 用户运行 `/feishu-auth login`
+2. Skill 检查 App ID 和 App Secret 是否配置
+3. 启动本地 HTTP 服务器监听指定端口（默认 8080）
+4. 生成授权 URL 并提示用户访问
+5. 用户在浏览器中授权后，飞书重定向到本地服务器
+6. 服务器接收授权码，调用 API 换取 token
+7. 保存 token 到 `~/.lark_user_token` 文件
+8. 显示 token 信息和使用说明
+
+## 使用方法
+
+### 登录获取 Token
+
+```
+/feishu-auth login
+```
+
+选项：
+- `-p, --port`: 指定本地服务器端口（默认 8080，0 表示随机端口）
+- `-H, --host`: 指定本地服务器主机（默认 127.0.0.1）
+
+示例：
+```
+/feishu-auth login --port 3000
+```
+
+### 刷新 Token
+
+当 access_token 过期时，使用 refresh_token 获取新的 token：
+
+```
+/feishu-auth refresh
+```
+
+### 查看 Token 状态
+
+```
+/feishu-auth status
+```
+
+显示当前 token 的来源、过期时间等信息。
+
+## 命令详解
+
+### login 命令
+
+启动完整的 OAuth 授权流程：
+
+1. 检查应用凭证（App ID 和 App Secret）
+2. 启动本地 HTTP 服务器
+3. 生成授权链接
+4. 等待用户授权
+5. 自动获取并保存 token
+
+Token 文件位置：`~/.lark_user_token`
+
+### refresh 命令
+
+使用 refresh_token 换取新的 access_token：
+- 无需重新登录
+- refresh_token 有效期通常为 30 天
+- 刷新后会更新 token 文件
+
+### status 命令
+
+显示 token 状态，按以下优先级检查：
+1. `FEISHU_USER_ACCESS_TOKEN` 环境变量
+2. 配置文件中的 `user_access_token`
+3. `~/.lark_user_token` 文件
+
+## Token 文件格式
+
+`~/.lark_user_token` (JSON 格式):
+```json
+{
+  "access_token": "u-xxx",
+  "refresh_token": "ur-xxx",
+  "expires_at": 1704067200,
+  "expires_in": 7200
+}
+```
+
+文件权限：0600（仅所有者可读写）
+
+## 与其他命令集成
+
+其他需要 User Access Token 的命令（如 search）将自动：
+1. 检查 `FEISHU_USER_ACCESS_TOKEN` 环境变量
+2. 检查配置文件中的 `user_access_token`
+3. 检查 `~/.lark_user_token` 文件
+4. 按优先级使用第一个找到的 token
+5. 如果 token 过期且来自文件，自动刷新
+
+## 前置要求
+
+1. 已配置飞书应用凭证（App ID 和 App Secret）
+2. 应用需要在飞书开放平台开启"网页应用"能力
+3. 需要在应用设置中配置正确的回调地址（如 `http://127.0.0.1:8080/callback`）
+
+## 常见问题
+
+### Q: 授权时提示"回调地址不匹配"？
+A: 请确保在飞书开放平台应用设置的"安全设置"中添加了正确的回调地址，
+   例如 `http://127.0.0.1:8080/callback`。
+
+### Q: Token 过期了怎么办？
+A: 运行 `/feishu-auth refresh` 刷新 token，或重新运行 `/feishu-auth login`。
+
+### Q: 如何切换账号？
+A: 删除 `~/.lark_user_token` 文件，然后重新运行 `/feishu-auth login`。
+
+### Q: 端口被占用怎么办？
+A: 使用 `--port` 指定其他端口，如 `/feishu-auth login --port 3000`。
+
+## 相关链接
+
+- 飞书 OAuth 文档: https://open.feishu.cn/document/server-side-identification/authen/login


### PR DESCRIPTION
This commit introduces User Access Token management through OAuth 2.0 flow and adds document search capabilities.

New Features:
- Add `feishu-cli auth` command group with login/refresh/status subcommands
- Implement OAuth 2.0 authorization flow with local HTTP callback server
- Store tokens securely in ~/.lark_user_token with 0600 permissions
- Support automatic token refresh when expired
- Add `feishu-cli search docs` command to search cloud documents
- Integrate token file lookup in search commands

New Files:
- cmd/auth.go: auth command group definition
- cmd/auth_login.go: OAuth login flow implementation
- cmd/auth_refresh.go: token refresh functionality
- cmd/auth_status.go: token status display
- cmd/search_docs.go: document search command
- internal/client/auth.go: OAuth API client
- internal/token/token.go: token storage and management
- skills/feishu-cli-auth/SKILL.md: skill documentation

Modified Files:
- cmd/search_messages.go: add token file lookup integration
- internal/client/search.go: add SearchDocs function

Testing:
- Verified OAuth flow with search:docs:read and base:record:retrieve scopes
- Confirmed token persistence and automatic refresh