### PR TITLE
Add OAuth 2.0 login support for user-authenticated API calls

### DIFF
--- a/cmd/login.go
+++ b/cmd/login.go
@@ -1,0 +1,110 @@
+package cmd
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/riba2534/feishu-cli/internal/auth"
+	"github.com/riba2534/feishu-cli/internal/config"
+	"github.com/spf13/cobra"
+)
+
+var loginCmd = &cobra.Command{
+	Use:   "login",
+	Short: "通过 OAuth 登录飞书，获取用户令牌",
+	Long: `通过 OAuth 2.0 授权码流程登录飞书，获取 user_access_token。
+
+登录后，feishu-cli 将以用户身份调用飞书 API，无需将应用逐个添加为文档协作者。
+
+前置条件:
+  1. 已配置 FEISHU_APP_ID 和 FEISHU_APP_SECRET
+  2. 在飞书开放平台的应用配置中添加重定向 URL: http://localhost:<port>/callback
+
+示例:
+  # 使用默认端口 (3000) 登录
+  feishu-cli login
+
+  # 指定端口和权限范围
+  feishu-cli login --port 8080 --scope "docx:document wiki:wiki:readonly"
+
+  # 查看当前登录状态
+  feishu-cli login --status`,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		statusOnly, _ := cmd.Flags().GetBool("status")
+		if statusOnly {
+			return showLoginStatus()
+		}
+
+		cfg := config.Get()
+		if cfg.AppID == "" || cfg.AppSecret == "" {
+			return fmt.Errorf("缺少 app_id 或 app_secret 配置，请先配置后再登录:\n" +
+				"  export FEISHU_APP_ID=cli_xxx\n" +
+				"  export FEISHU_APP_SECRET=xxx")
+		}
+
+		port, _ := cmd.Flags().GetInt("port")
+		scope, _ := cmd.Flags().GetString("scope")
+
+		oauthCfg := auth.OAuthConfig{
+			AppID:     cfg.AppID,
+			AppSecret: cfg.AppSecret,
+			BaseURL:   cfg.BaseURL,
+			Port:      port,
+			Scope:     scope,
+		}
+
+		token, err := auth.Login(oauthCfg)
+		if err != nil {
+			return fmt.Errorf("登录失败: %w", err)
+		}
+
+		if err := auth.SaveToken(token); err != nil {
+			return fmt.Errorf("保存令牌失败: %w", err)
+		}
+
+		fmt.Println("登录成功！用户令牌已保存。")
+		fmt.Printf("  Access Token 有效期至: %s\n", time.Unix(token.ExpiresAt, 0).Format("2006-01-02 15:04:05"))
+		fmt.Printf("  Refresh Token 有效期至: %s\n", time.Unix(token.RefreshExpiresAt, 0).Format("2006-01-02 15:04:05"))
+		if token.Scope != "" {
+			fmt.Printf("  授权范围: %s\n", token.Scope)
+		}
+		fmt.Println("\n后续命令将自动使用用户身份调用 API（可通过 --token-mode 切换）。")
+
+		return nil
+	},
+}
+
+func showLoginStatus() error {
+	token, err := auth.LoadToken()
+	if err != nil {
+		return fmt.Errorf("读取令牌失败: %w", err)
+	}
+
+	if token == nil {
+		fmt.Println("当前未登录。请执行 feishu-cli login 进行登录。")
+		return nil
+	}
+
+	fmt.Println("当前登录状态:")
+	if token.IsValid() {
+		fmt.Println("  状态: 已登录（令牌有效）")
+	} else if token.IsRefreshable() {
+		fmt.Println("  状态: 令牌已过期（可自动刷新）")
+	} else {
+		fmt.Println("  状态: 令牌已过期（需重新登录）")
+	}
+	fmt.Printf("  Access Token 有效期至: %s\n", time.Unix(token.ExpiresAt, 0).Format("2006-01-02 15:04:05"))
+	fmt.Printf("  Refresh Token 有效期至: %s\n", time.Unix(token.RefreshExpiresAt, 0).Format("2006-01-02 15:04:05"))
+	if token.Scope != "" {
+		fmt.Printf("  授权范围: %s\n", token.Scope)
+	}
+
+	return nil
+}
+
+func init() {
+	rootCmd.AddCommand(loginCmd)
+	loginCmd.Flags().Int("port", 3000, "本地回调服务器端口")
+	loginCmd.Flags().String("scope", "", "权限范围（空格分隔，如 \"docx:document wiki:wiki:readonly\"）")
+	loginCmd.Flags().Bool("status", false, "查看当前登录状态")
+}

--- a/cmd/logout.go
+++ b/cmd/logout.go
@@ -1,0 +1,30 @@
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/riba2534/feishu-cli/internal/auth"
+	"github.com/spf13/cobra"
+)
+
+var logoutCmd = &cobra.Command{
+	Use:   "logout",
+	Short: "退出登录，清除缓存的用户令牌",
+	Long: `退出飞书 OAuth 登录，删除本地缓存的 user_access_token。
+
+退出后，feishu-cli 将回退到使用应用身份（tenant_access_token）调用 API。
+
+示例:
+  feishu-cli logout`,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		if err := auth.DeleteToken(); err != nil {
+			return fmt.Errorf("退出登录失败: %w", err)
+		}
+		fmt.Println("已退出登录，用户令牌已清除。")
+		return nil
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(logoutCmd)
+}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 
+	"github.com/riba2534/feishu-cli/internal/auth"
 	"github.com/riba2534/feishu-cli/internal/config"
 	"github.com/spf13/cobra"
 )
@@ -11,6 +12,7 @@ import (
 var (
 	cfgFile   string
 	debug     bool
+	tokenMode string
 	version   = "dev"
 	buildTime = "unknown"
 )
@@ -42,6 +44,8 @@ var rootCmd = &cobra.Command{
   calendar  日历操作（日历、日程管理）
   search    搜索操作（消息、应用搜索，需要用户授权）
   config    配置管理（初始化配置）
+  login     OAuth 登录（获取用户令牌）
+  logout    退出登录（清除用户令牌）
 
 配置方式:
   1. 环境变量（推荐）:
@@ -66,6 +70,12 @@ var rootCmd = &cobra.Command{
   # 发送消息
   feishu-cli msg send --receive-id-type email --receive-id user@example.com --text "你好"
 
+  # OAuth 登录（使用用户身份访问飞书资源）
+  feishu-cli login
+
+  # 使用用户身份模式执行命令
+  feishu-cli doc export <document_id> --token-mode user
+
 更多信息请访问: https://github.com/riba2534/feishu-cli`,
 	PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
 		// Skip config initialization for group commands (those with subcommands but no own RunE)
@@ -74,7 +84,7 @@ var rootCmd = &cobra.Command{
 			return nil
 		}
 		switch cmd.Name() {
-		case "init", "help", "completion", "version":
+		case "init", "help", "completion", "version", "logout":
 			return nil
 		}
 
@@ -86,6 +96,25 @@ var rootCmd = &cobra.Command{
 		if debug {
 			cfg := config.Get()
 			cfg.Debug = true
+		}
+
+		// 解析 token-mode（支持环境变量 FEISHU_TOKEN_MODE）
+		mode := tokenMode
+		if mode == "" {
+			mode = os.Getenv("FEISHU_TOKEN_MODE")
+		}
+		if mode != "" {
+			if _, err := auth.ParseTokenMode(mode); err != nil {
+				return err
+			}
+			cfg := config.Get()
+			cfg.TokenMode = mode
+		}
+
+		// 初始化令牌管理器（用于自动刷新 user_access_token）
+		cfg := config.Get()
+		if cfg.AppID != "" && cfg.AppSecret != "" {
+			auth.InitManager(cfg.AppID, cfg.AppSecret, cfg.BaseURL)
 		}
 
 		return nil
@@ -103,4 +132,5 @@ func Execute() {
 func init() {
 	rootCmd.PersistentFlags().StringVar(&cfgFile, "config", "", "配置文件路径（默认: ~/.feishu-cli/config.yaml）")
 	rootCmd.PersistentFlags().BoolVar(&debug, "debug", false, "启用调试模式")
+	rootCmd.PersistentFlags().StringVar(&tokenMode, "token-mode", "", "令牌模式: auto（默认，优先用户令牌）、user（强制用户令牌）、tenant（强制应用令牌）")
 }

--- a/internal/auth/manager.go
+++ b/internal/auth/manager.go
@@ -1,0 +1,150 @@
+package auth
+
+import (
+	"fmt"
+	"sync"
+
+	larkcore "github.com/larksuite/oapi-sdk-go/v3/core"
+)
+
+// TokenMode 令牌模式
+type TokenMode string
+
+const (
+	TokenModeAuto   TokenMode = "auto"   // 自动选择：优先 user_access_token，回退 tenant_access_token
+	TokenModeUser   TokenMode = "user"   // 强制使用 user_access_token
+	TokenModeTenant TokenMode = "tenant" // 强制使用 tenant_access_token
+)
+
+// ParseTokenMode 解析令牌模式字符串
+func ParseTokenMode(s string) (TokenMode, error) {
+	switch s {
+	case "", "auto":
+		return TokenModeAuto, nil
+	case "user":
+		return TokenModeUser, nil
+	case "tenant":
+		return TokenModeTenant, nil
+	default:
+		return "", fmt.Errorf("无效的 token-mode: %q（可选值: auto, user, tenant）", s)
+	}
+}
+
+// Manager 管理用户令牌的获取和刷新
+type Manager struct {
+	mu        sync.Mutex
+	appID     string
+	appSecret string
+	baseURL   string
+}
+
+var (
+	globalManager *Manager
+	managerMu     sync.Mutex
+)
+
+// InitManager 初始化全局令牌管理器
+func InitManager(appID, appSecret, baseURL string) {
+	managerMu.Lock()
+	defer managerMu.Unlock()
+	globalManager = &Manager{
+		appID:     appID,
+		appSecret: appSecret,
+		baseURL:   baseURL,
+	}
+}
+
+// GetUserAccessToken 获取有效的 user_access_token，过期时自动刷新
+// 返回空字符串表示未登录或令牌不可用
+func GetUserAccessToken() (string, error) {
+	token, err := LoadToken()
+	if err != nil {
+		return "", err
+	}
+	if token == nil {
+		return "", nil
+	}
+
+	// token 有效，直接返回
+	if token.IsValid() {
+		return token.AccessToken, nil
+	}
+
+	// token 过期但可刷新
+	if token.IsRefreshable() {
+		managerMu.Lock()
+		mgr := globalManager
+		managerMu.Unlock()
+
+		if mgr == nil {
+			return "", fmt.Errorf("令牌管理器未初始化")
+		}
+
+		return mgr.refreshToken(token)
+	}
+
+	// refresh_token 也过期了
+	return "", fmt.Errorf("用户令牌已过期，请执行 feishu-cli login 重新登录")
+}
+
+// refreshToken 刷新令牌并保存
+func (m *Manager) refreshToken(token *UserToken) (string, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	// 双重检查：可能在等锁期间已被其他 goroutine 刷新
+	freshToken, err := LoadToken()
+	if err == nil && freshToken != nil && freshToken.IsValid() {
+		return freshToken.AccessToken, nil
+	}
+
+	newToken, err := RefreshAccessToken(OAuthConfig{
+		AppID:     m.appID,
+		AppSecret: m.appSecret,
+		BaseURL:   m.baseURL,
+	}, token.RefreshToken)
+	if err != nil {
+		return "", fmt.Errorf("自动刷新令牌失败: %w\n请执行 feishu-cli login 重新登录", err)
+	}
+
+	if err := SaveToken(newToken); err != nil {
+		return "", fmt.Errorf("保存刷新后的令牌失败: %w", err)
+	}
+
+	return newToken.AccessToken, nil
+}
+
+// UserTokenRequestOption 根据令牌模式返回请求选项
+// 当使用 user 模式时，返回 WithUserAccessToken 选项
+// 当使用 tenant 模式时，返回 nil（使用默认的 tenant_access_token）
+// 当使用 auto 模式时，有 user_access_token 则使用，否则返回 nil
+func UserTokenRequestOption(mode TokenMode) (larkcore.RequestOptionFunc, error) {
+	switch mode {
+	case TokenModeTenant:
+		return nil, nil
+
+	case TokenModeUser:
+		token, err := GetUserAccessToken()
+		if err != nil {
+			return nil, err
+		}
+		if token == "" {
+			return nil, fmt.Errorf("未登录，请先执行 feishu-cli login 进行用户授权")
+		}
+		return larkcore.WithUserAccessToken(token), nil
+
+	case TokenModeAuto:
+		token, err := GetUserAccessToken()
+		if err != nil {
+			// auto 模式下获取失败不报错，回退到 tenant
+			return nil, nil
+		}
+		if token == "" {
+			return nil, nil
+		}
+		return larkcore.WithUserAccessToken(token), nil
+
+	default:
+		return nil, fmt.Errorf("未知的 token-mode: %q", mode)
+	}
+}

--- a/internal/auth/oauth.go
+++ b/internal/auth/oauth.go
@@ -1,0 +1,353 @@
+package auth
+
+import (
+	"context"
+	"crypto/rand"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"net/url"
+	"os/exec"
+	"runtime"
+	"strings"
+	"time"
+)
+
+// OAuthConfig OAuth 登录配置
+type OAuthConfig struct {
+	AppID     string
+	AppSecret string
+	BaseURL   string // 飞书 API 基础地址，默认 https://open.feishu.cn
+	Port      int    // 本地回调服务器端口，默认 3000
+	Scope     string // 权限范围（空格分隔）
+}
+
+// oauthTokenResponse 飞书 OAuth token 响应
+type oauthTokenResponse struct {
+	Code int    `json:"code"`
+	Msg  string `json:"msg"`
+	Data struct {
+		AccessToken      string `json:"access_token"`
+		RefreshToken     string `json:"refresh_token"`
+		TokenType        string `json:"token_type"`
+		ExpiresIn        int64  `json:"expires_in"`
+		RefreshExpiresIn int64  `json:"refresh_expires_in"`
+		Scope            string `json:"scope"`
+	} `json:"data"`
+}
+
+// Login 执行 OAuth 登录流程
+// 1. 启动本地 HTTP 服务器接收回调
+// 2. 打开浏览器跳转到飞书授权页
+// 3. 等待用户授权后获取 authorization_code
+// 4. 用 code 换取 user_access_token
+func Login(cfg OAuthConfig) (*UserToken, error) {
+	if cfg.BaseURL == "" {
+		cfg.BaseURL = "https://open.feishu.cn"
+	}
+	if cfg.Port == 0 {
+		cfg.Port = 3000
+	}
+
+	// 生成随机 state 参数防止 CSRF
+	state, err := generateState()
+	if err != nil {
+		return nil, fmt.Errorf("生成 state 参数失败: %w", err)
+	}
+
+	// 用于接收 authorization_code
+	codeChan := make(chan string, 1)
+	errChan := make(chan error, 1)
+
+	redirectURI := fmt.Sprintf("http://localhost:%d/callback", cfg.Port)
+
+	// 启动本地 HTTP 服务器
+	mux := http.NewServeMux()
+	mux.HandleFunc("/callback", func(w http.ResponseWriter, r *http.Request) {
+		// 验证 state 参数
+		if r.URL.Query().Get("state") != state {
+			errChan <- fmt.Errorf("state 参数不匹配，可能存在 CSRF 攻击")
+			w.WriteHeader(http.StatusBadRequest)
+			fmt.Fprint(w, htmlPage("授权失败", "state 参数不匹配，请重试。"))
+			return
+		}
+
+		code := r.URL.Query().Get("code")
+		if code == "" {
+			errChan <- fmt.Errorf("未收到 authorization_code")
+			w.WriteHeader(http.StatusBadRequest)
+			fmt.Fprint(w, htmlPage("授权失败", "未收到授权码，请重试。"))
+			return
+		}
+
+		w.Header().Set("Content-Type", "text/html; charset=utf-8")
+		fmt.Fprint(w, htmlPage("授权成功", "您已成功登录飞书，可以关闭此页面。"))
+		codeChan <- code
+	})
+
+	listener, err := net.Listen("tcp", fmt.Sprintf(":%d", cfg.Port))
+	if err != nil {
+		return nil, fmt.Errorf("启动本地服务器失败（端口 %d 可能被占用）: %w", cfg.Port, err)
+	}
+
+	server := &http.Server{Handler: mux}
+	go func() {
+		if err := server.Serve(listener); err != nil && err != http.ErrServerClosed {
+			errChan <- fmt.Errorf("本地服务器异常: %w", err)
+		}
+	}()
+	defer func() {
+		ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+		defer cancel()
+		server.Shutdown(ctx)
+	}()
+
+	// 构建授权 URL
+	authURL := buildAuthURL(cfg.BaseURL, cfg.AppID, redirectURI, state, cfg.Scope)
+
+	fmt.Println("正在打开浏览器进行飞书授权...")
+	fmt.Printf("如果浏览器未自动打开，请手动访问以下地址:\n\n%s\n\n", authURL)
+
+	// 尝试打开浏览器
+	openBrowser(authURL)
+
+	fmt.Println("等待授权回调...")
+
+	// 等待授权回调（超时 5 分钟）
+	var code string
+	select {
+	case code = <-codeChan:
+		// 收到 code
+	case err := <-errChan:
+		return nil, err
+	case <-time.After(5 * time.Minute):
+		return nil, fmt.Errorf("授权超时（5 分钟），请重新执行 login 命令")
+	}
+
+	fmt.Println("收到授权码，正在获取令牌...")
+
+	// 用 code 换取 token
+	token, err := exchangeToken(cfg, code, redirectURI)
+	if err != nil {
+		return nil, err
+	}
+
+	return token, nil
+}
+
+// RefreshAccessToken 使用 refresh_token 刷新 access_token
+func RefreshAccessToken(cfg OAuthConfig, refreshToken string) (*UserToken, error) {
+	if cfg.BaseURL == "" {
+		cfg.BaseURL = "https://open.feishu.cn"
+	}
+
+	apiURL := cfg.BaseURL + "/open-apis/authen/v1/oidc/refresh_access_token"
+
+	body := map[string]string{
+		"grant_type":    "refresh_token",
+		"refresh_token": refreshToken,
+	}
+	bodyBytes, _ := json.Marshal(body)
+
+	// 先获取 app_access_token
+	appToken, err := getAppAccessToken(cfg)
+	if err != nil {
+		return nil, fmt.Errorf("获取 app_access_token 失败: %w", err)
+	}
+
+	req, err := http.NewRequest("POST", apiURL, strings.NewReader(string(bodyBytes)))
+	if err != nil {
+		return nil, fmt.Errorf("创建请求失败: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json; charset=utf-8")
+	req.Header.Set("Authorization", "Bearer "+appToken)
+
+	client := &http.Client{Timeout: 30 * time.Second}
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("刷新 token 请求失败: %w", err)
+	}
+	defer resp.Body.Close()
+
+	respBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("读取响应失败: %w", err)
+	}
+
+	var tokenResp oauthTokenResponse
+	if err := json.Unmarshal(respBody, &tokenResp); err != nil {
+		return nil, fmt.Errorf("解析响应失败: %w", err)
+	}
+
+	if tokenResp.Code != 0 {
+		return nil, fmt.Errorf("刷新 token 失败: code=%d, msg=%s", tokenResp.Code, tokenResp.Msg)
+	}
+
+	now := time.Now().Unix()
+	token := &UserToken{
+		AccessToken:      tokenResp.Data.AccessToken,
+		RefreshToken:     tokenResp.Data.RefreshToken,
+		ExpiresAt:        now + tokenResp.Data.ExpiresIn,
+		RefreshExpiresAt: now + tokenResp.Data.RefreshExpiresIn,
+		TokenType:        tokenResp.Data.TokenType,
+		Scope:            tokenResp.Data.Scope,
+	}
+
+	return token, nil
+}
+
+// exchangeToken 用 authorization_code 换取 token
+func exchangeToken(cfg OAuthConfig, code, redirectURI string) (*UserToken, error) {
+	apiURL := cfg.BaseURL + "/open-apis/authen/v1/oidc/access_token"
+
+	body := map[string]string{
+		"grant_type": "authorization_code",
+		"code":       code,
+	}
+	bodyBytes, _ := json.Marshal(body)
+
+	// 先获取 app_access_token
+	appToken, err := getAppAccessToken(cfg)
+	if err != nil {
+		return nil, fmt.Errorf("获取 app_access_token 失败: %w", err)
+	}
+
+	req, err := http.NewRequest("POST", apiURL, strings.NewReader(string(bodyBytes)))
+	if err != nil {
+		return nil, fmt.Errorf("创建请求失败: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json; charset=utf-8")
+	req.Header.Set("Authorization", "Bearer "+appToken)
+
+	client := &http.Client{Timeout: 30 * time.Second}
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("换取 token 请求失败: %w", err)
+	}
+	defer resp.Body.Close()
+
+	respBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("读取响应失败: %w", err)
+	}
+
+	var tokenResp oauthTokenResponse
+	if err := json.Unmarshal(respBody, &tokenResp); err != nil {
+		return nil, fmt.Errorf("解析响应失败: %w", err)
+	}
+
+	if tokenResp.Code != 0 {
+		return nil, fmt.Errorf("换取 token 失败: code=%d, msg=%s", tokenResp.Code, tokenResp.Msg)
+	}
+
+	now := time.Now().Unix()
+	token := &UserToken{
+		AccessToken:      tokenResp.Data.AccessToken,
+		RefreshToken:     tokenResp.Data.RefreshToken,
+		ExpiresAt:        now + tokenResp.Data.ExpiresIn,
+		RefreshExpiresAt: now + tokenResp.Data.RefreshExpiresIn,
+		TokenType:        tokenResp.Data.TokenType,
+		Scope:            tokenResp.Data.Scope,
+	}
+
+	return token, nil
+}
+
+// appAccessTokenResponse app_access_token 响应
+type appAccessTokenResponse struct {
+	Code              int    `json:"code"`
+	Msg               string `json:"msg"`
+	AppAccessToken    string `json:"app_access_token"`
+	TenantAccessToken string `json:"tenant_access_token"`
+	Expire            int    `json:"expire"`
+}
+
+// getAppAccessToken 获取 app_access_token（用于 OAuth token 交换）
+func getAppAccessToken(cfg OAuthConfig) (string, error) {
+	apiURL := cfg.BaseURL + "/open-apis/auth/v3/app_access_token/internal"
+
+	body := map[string]string{
+		"app_id":     cfg.AppID,
+		"app_secret": cfg.AppSecret,
+	}
+	bodyBytes, _ := json.Marshal(body)
+
+	req, err := http.NewRequest("POST", apiURL, strings.NewReader(string(bodyBytes)))
+	if err != nil {
+		return "", fmt.Errorf("创建请求失败: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json; charset=utf-8")
+
+	client := &http.Client{Timeout: 30 * time.Second}
+	resp, err := client.Do(req)
+	if err != nil {
+		return "", fmt.Errorf("获取 app_access_token 失败: %w", err)
+	}
+	defer resp.Body.Close()
+
+	respBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return "", fmt.Errorf("读取响应失败: %w", err)
+	}
+
+	var tokenResp appAccessTokenResponse
+	if err := json.Unmarshal(respBody, &tokenResp); err != nil {
+		return "", fmt.Errorf("解析响应失败: %w", err)
+	}
+
+	if tokenResp.Code != 0 {
+		return "", fmt.Errorf("获取 app_access_token 失败: code=%d, msg=%s", tokenResp.Code, tokenResp.Msg)
+	}
+
+	return tokenResp.AppAccessToken, nil
+}
+
+// buildAuthURL 构建飞书 OAuth 授权 URL
+func buildAuthURL(baseURL, appID, redirectURI, state, scope string) string {
+	params := url.Values{}
+	params.Set("app_id", appID)
+	params.Set("redirect_uri", redirectURI)
+	params.Set("state", state)
+	if scope != "" {
+		params.Set("scope", scope)
+	}
+	return baseURL + "/open-apis/authen/v1/authorize?" + params.Encode()
+}
+
+// generateState 生成随机 state 参数
+func generateState() (string, error) {
+	b := make([]byte, 16)
+	if _, err := rand.Read(b); err != nil {
+		return "", err
+	}
+	return hex.EncodeToString(b), nil
+}
+
+// openBrowser 尝试打开系统默认浏览器
+func openBrowser(url string) {
+	var cmd *exec.Cmd
+	switch runtime.GOOS {
+	case "darwin":
+		cmd = exec.Command("open", url)
+	case "linux":
+		cmd = exec.Command("xdg-open", url)
+	case "windows":
+		cmd = exec.Command("rundll32", "url.dll,FileProtocolHandler", url)
+	default:
+		return
+	}
+	cmd.Start()
+}
+
+// htmlPage 生成简单的 HTML 页面
+func htmlPage(title, message string) string {
+	return fmt.Sprintf(`<!DOCTYPE html>
+<html><head><meta charset="utf-8"><title>%s - 飞书 CLI</title>
+<style>body{font-family:-apple-system,BlinkMacSystemFont,sans-serif;display:flex;justify-content:center;align-items:center;height:100vh;margin:0;background:#f5f6f7}
+.card{background:#fff;padding:40px;border-radius:12px;box-shadow:0 2px 12px rgba(0,0,0,.1);text-align:center;max-width:400px}
+h1{color:#1f2329;margin-bottom:16px}p{color:#646a73;font-size:16px}</style>
+</head><body><div class="card"><h1>%s</h1><p>%s</p></div></body></html>`, title, title, message)
+}

--- a/internal/auth/token.go
+++ b/internal/auth/token.go
@@ -1,0 +1,104 @@
+package auth
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"time"
+)
+
+// UserToken 存储 OAuth 用户令牌信息
+type UserToken struct {
+	AccessToken      string `json:"access_token"`
+	RefreshToken     string `json:"refresh_token"`
+	ExpiresAt        int64  `json:"expires_at"`
+	RefreshExpiresAt int64  `json:"refresh_expires_at"`
+	TokenType        string `json:"token_type"`
+	Scope            string `json:"scope"`
+}
+
+// IsValid 检查 access_token 是否有效（未过期且剩余 > 5 分钟）
+func (t *UserToken) IsValid() bool {
+	return t.AccessToken != "" && time.Now().Unix() < t.ExpiresAt-300
+}
+
+// IsRefreshable 检查 refresh_token 是否可用（未过期）
+func (t *UserToken) IsRefreshable() bool {
+	return t.RefreshToken != "" && time.Now().Unix() < t.RefreshExpiresAt
+}
+
+// tokenFilePath 返回 token 文件路径
+func tokenFilePath() (string, error) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", fmt.Errorf("获取用户目录失败: %w", err)
+	}
+	return filepath.Join(home, ".feishu-cli", "user_token.json"), nil
+}
+
+// LoadToken 从文件加载用户令牌
+func LoadToken() (*UserToken, error) {
+	path, err := tokenFilePath()
+	if err != nil {
+		return nil, err
+	}
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("读取 token 文件失败: %w", err)
+	}
+
+	var token UserToken
+	if err := json.Unmarshal(data, &token); err != nil {
+		return nil, fmt.Errorf("解析 token 文件失败: %w", err)
+	}
+
+	return &token, nil
+}
+
+// SaveToken 保存用户令牌到文件
+func SaveToken(token *UserToken) error {
+	path, err := tokenFilePath()
+	if err != nil {
+		return err
+	}
+
+	// 确保目录存在，使用 0700 权限保护敏感信息
+	dir := filepath.Dir(path)
+	if err := os.MkdirAll(dir, 0700); err != nil {
+		return fmt.Errorf("创建配置目录失败: %w", err)
+	}
+
+	data, err := json.MarshalIndent(token, "", "  ")
+	if err != nil {
+		return fmt.Errorf("序列化 token 失败: %w", err)
+	}
+
+	// 使用 0600 权限，仅所有者可读写
+	if err := os.WriteFile(path, data, 0600); err != nil {
+		return fmt.Errorf("写入 token 文件失败: %w", err)
+	}
+
+	return nil
+}
+
+// DeleteToken 删除本地缓存的用户令牌
+func DeleteToken() error {
+	path, err := tokenFilePath()
+	if err != nil {
+		return err
+	}
+
+	if err := os.Remove(path); err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+		return fmt.Errorf("删除 token 文件失败: %w", err)
+	}
+
+	return nil
+}

--- a/internal/auth/token_test.go
+++ b/internal/auth/token_test.go
@@ -1,0 +1,231 @@
+package auth
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func TestUserToken_IsValid(t *testing.T) {
+	tests := []struct {
+		name  string
+		token UserToken
+		want  bool
+	}{
+		{
+			name: "有效令牌（未过期且剩余 > 5 分钟）",
+			token: UserToken{
+				AccessToken: "u-test",
+				ExpiresAt:   time.Now().Unix() + 600, // 10 分钟后过期
+			},
+			want: true,
+		},
+		{
+			name: "即将过期（剩余 < 5 分钟）",
+			token: UserToken{
+				AccessToken: "u-test",
+				ExpiresAt:   time.Now().Unix() + 200, // 3 分钟后过期
+			},
+			want: false,
+		},
+		{
+			name: "已过期",
+			token: UserToken{
+				AccessToken: "u-test",
+				ExpiresAt:   time.Now().Unix() - 100,
+			},
+			want: false,
+		},
+		{
+			name: "空令牌",
+			token: UserToken{
+				AccessToken: "",
+				ExpiresAt:   time.Now().Unix() + 600,
+			},
+			want: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.token.IsValid(); got != tt.want {
+				t.Errorf("IsValid() = %v, 期望 %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestUserToken_IsRefreshable(t *testing.T) {
+	tests := []struct {
+		name  string
+		token UserToken
+		want  bool
+	}{
+		{
+			name: "可刷新",
+			token: UserToken{
+				RefreshToken:     "ur-test",
+				RefreshExpiresAt: time.Now().Unix() + 86400,
+			},
+			want: true,
+		},
+		{
+			name: "refresh_token 已过期",
+			token: UserToken{
+				RefreshToken:     "ur-test",
+				RefreshExpiresAt: time.Now().Unix() - 100,
+			},
+			want: false,
+		},
+		{
+			name: "无 refresh_token",
+			token: UserToken{
+				RefreshToken:     "",
+				RefreshExpiresAt: time.Now().Unix() + 86400,
+			},
+			want: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.token.IsRefreshable(); got != tt.want {
+				t.Errorf("IsRefreshable() = %v, 期望 %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestSaveAndLoadToken(t *testing.T) {
+	// 使用临时目录模拟 home
+	tmpDir := t.TempDir()
+	origHome := os.Getenv("HOME")
+	os.Setenv("HOME", tmpDir)
+	defer os.Setenv("HOME", origHome)
+
+	// 创建配置目录
+	configDir := filepath.Join(tmpDir, ".feishu-cli")
+	os.MkdirAll(configDir, 0700)
+
+	token := &UserToken{
+		AccessToken:      "u-test-token",
+		RefreshToken:     "ur-test-refresh",
+		ExpiresAt:        time.Now().Unix() + 7200,
+		RefreshExpiresAt: time.Now().Unix() + 2592000,
+		TokenType:        "Bearer",
+		Scope:            "docx:document wiki:wiki:readonly",
+	}
+
+	// 保存
+	if err := SaveToken(token); err != nil {
+		t.Fatalf("SaveToken() 失败: %v", err)
+	}
+
+	// 验证文件权限
+	tokenPath := filepath.Join(configDir, "user_token.json")
+	info, err := os.Stat(tokenPath)
+	if err != nil {
+		t.Fatalf("token 文件不存在: %v", err)
+	}
+	if info.Mode().Perm() != 0600 {
+		t.Errorf("文件权限 = %o, 期望 0600", info.Mode().Perm())
+	}
+
+	// 加载
+	loaded, err := LoadToken()
+	if err != nil {
+		t.Fatalf("LoadToken() 失败: %v", err)
+	}
+	if loaded == nil {
+		t.Fatal("LoadToken() 返回 nil")
+	}
+	if loaded.AccessToken != token.AccessToken {
+		t.Errorf("AccessToken = %q, 期望 %q", loaded.AccessToken, token.AccessToken)
+	}
+	if loaded.RefreshToken != token.RefreshToken {
+		t.Errorf("RefreshToken = %q, 期望 %q", loaded.RefreshToken, token.RefreshToken)
+	}
+	if loaded.Scope != token.Scope {
+		t.Errorf("Scope = %q, 期望 %q", loaded.Scope, token.Scope)
+	}
+}
+
+func TestLoadToken_NotExist(t *testing.T) {
+	tmpDir := t.TempDir()
+	origHome := os.Getenv("HOME")
+	os.Setenv("HOME", tmpDir)
+	defer os.Setenv("HOME", origHome)
+
+	token, err := LoadToken()
+	if err != nil {
+		t.Fatalf("LoadToken() 返回错误: %v", err)
+	}
+	if token != nil {
+		t.Error("期望返回 nil，但返回了 token")
+	}
+}
+
+func TestDeleteToken(t *testing.T) {
+	tmpDir := t.TempDir()
+	origHome := os.Getenv("HOME")
+	os.Setenv("HOME", tmpDir)
+	defer os.Setenv("HOME", origHome)
+
+	// 先保存
+	configDir := filepath.Join(tmpDir, ".feishu-cli")
+	os.MkdirAll(configDir, 0700)
+
+	token := &UserToken{
+		AccessToken: "u-test",
+		ExpiresAt:   time.Now().Unix() + 7200,
+	}
+	if err := SaveToken(token); err != nil {
+		t.Fatalf("SaveToken() 失败: %v", err)
+	}
+
+	// 删除
+	if err := DeleteToken(); err != nil {
+		t.Fatalf("DeleteToken() 失败: %v", err)
+	}
+
+	// 再次加载应返回 nil
+	loaded, err := LoadToken()
+	if err != nil {
+		t.Fatalf("LoadToken() 返回错误: %v", err)
+	}
+	if loaded != nil {
+		t.Error("删除后仍能加载到 token")
+	}
+
+	// 重复删除不应报错
+	if err := DeleteToken(); err != nil {
+		t.Errorf("重复删除返回错误: %v", err)
+	}
+}
+
+func TestParseTokenMode(t *testing.T) {
+	tests := []struct {
+		input string
+		want  TokenMode
+		err   bool
+	}{
+		{"", TokenModeAuto, false},
+		{"auto", TokenModeAuto, false},
+		{"user", TokenModeUser, false},
+		{"tenant", TokenModeTenant, false},
+		{"invalid", "", true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			got, err := ParseTokenMode(tt.input)
+			if (err != nil) != tt.err {
+				t.Errorf("ParseTokenMode(%q) error = %v, 期望 err = %v", tt.input, err, tt.err)
+			}
+			if got != tt.want {
+				t.Errorf("ParseTokenMode(%q) = %q, 期望 %q", tt.input, got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/client/user_token.go
+++ b/internal/client/user_token.go
@@ -1,0 +1,37 @@
+package client
+
+import (
+	larkcore "github.com/larksuite/oapi-sdk-go/v3/core"
+	"github.com/riba2534/feishu-cli/internal/auth"
+	"github.com/riba2534/feishu-cli/internal/config"
+)
+
+// GetUserTokenOption 根据当前配置的 token-mode 返回请求选项
+// 如果应该使用 user_access_token，返回 WithUserAccessToken 选项
+// 如果应该使用 tenant_access_token（默认），返回 nil
+//
+// 优先级：
+//   1. 如果配置文件/环境变量中设置了静态 user_access_token，且 token-mode 不是 tenant，直接使用
+//   2. 如果通过 OAuth 登录过，根据 token-mode 决定是否使用
+//   3. 否则使用默认的 tenant_access_token
+func GetUserTokenOption() (larkcore.RequestOptionFunc, error) {
+	cfg := config.Get()
+
+	mode, err := auth.ParseTokenMode(cfg.TokenMode)
+	if err != nil {
+		return nil, err
+	}
+
+	// 如果强制使用 tenant 模式，直接返回
+	if mode == auth.TokenModeTenant {
+		return nil, nil
+	}
+
+	// 优先使用配置中的静态 user_access_token（向后兼容）
+	if cfg.UserAccessToken != "" {
+		return larkcore.WithUserAccessToken(cfg.UserAccessToken), nil
+	}
+
+	// 使用 OAuth 管理的 user_access_token
+	return auth.UserTokenRequestOption(mode)
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -13,6 +13,7 @@ type Config struct {
 	AppID           string       `mapstructure:"app_id"`
 	AppSecret       string       `mapstructure:"app_secret"`
 	UserAccessToken string       `mapstructure:"user_access_token"`
+	TokenMode       string       `mapstructure:"token_mode"`
 	BaseURL         string       `mapstructure:"base_url"`
 	Debug           bool         `mapstructure:"debug"`
 	Export          ExportConfig `mapstructure:"export"`
@@ -66,6 +67,7 @@ func Init(cfgFile string) error {
 	_ = viper.BindEnv("app_id", "FEISHU_APP_ID")
 	_ = viper.BindEnv("app_secret", "FEISHU_APP_SECRET")
 	_ = viper.BindEnv("user_access_token", "FEISHU_USER_ACCESS_TOKEN")
+	_ = viper.BindEnv("token_mode", "FEISHU_TOKEN_MODE")
 	_ = viper.BindEnv("base_url", "FEISHU_BASE_URL")
 	_ = viper.BindEnv("debug", "FEISHU_DEBUG")
 


### PR DESCRIPTION
## Summary
This PR adds OAuth 2.0 authentication support to feishu-cli, enabling users to log in with their Feishu account and make API calls using user identity instead of application identity. This eliminates the need to add the application as a collaborator to every document.

## Key Changes

### New OAuth Login Flow
- **`internal/auth/oauth.go`**: Implements complete OAuth 2.0 authorization code flow
  - Starts local HTTP server to receive authorization callback
  - Automatically opens browser for user authorization
  - Exchanges authorization code for user access tokens
  - Supports token refresh using refresh_token
  - Includes CSRF protection via state parameter validation

### Token Management
- **`internal/auth/token.go`**: Manages user token persistence
  - `UserToken` struct stores access_token, refresh_token, and expiration times
  - `IsValid()` checks if token is usable (not expired, >5 min remaining)
  - `IsRefreshable()` checks if token can be refreshed
  - Secure file storage with 0600 permissions in `~/.feishu-cli/user_token.json`
  - Load, save, and delete operations for token lifecycle

### Token Mode System
- **`internal/auth/manager.go`**: Centralized token management
  - `TokenMode` enum: `auto` (prefer user token), `user` (require user token), `tenant` (use app token)
  - `Manager` handles automatic token refresh with double-checked locking
  - `GetUserAccessToken()` returns valid token, auto-refreshing if needed
  - `UserTokenRequestOption()` returns appropriate request option based on mode

### CLI Commands
- **`cmd/login.go`**: New `login` command
  - OAuth login with configurable port and scope
  - `--status` flag to check current login status
  - Displays token expiration times and authorized scopes
  
- **`cmd/logout.go`**: New `logout` command
  - Clears cached user token
  - Reverts to application identity for subsequent API calls

### Integration
- **`cmd/root.go`**: 
  - Adds global `--token-mode` flag (supports `FEISHU_TOKEN_MODE` env var)
  - Initializes token manager with app credentials
  - Updated help text with login/logout examples

- **`internal/client/user_token.go`**: New helper function
  - `GetUserTokenOption()` determines which token to use based on config and mode
  - Maintains backward compatibility with static `user_access_token` config

### Testing
- **`internal/auth/token_test.go`**: Comprehensive test coverage
  - Token validity and refreshability checks
  - Token persistence (save/load/delete)
  - Token mode parsing
  - File permission verification

## Implementation Details

- **Security**: Token files stored with restrictive 0600 permissions; state parameter prevents CSRF attacks
- **Auto-refresh**: Tokens automatically refreshed when expired but still refreshable
- **Graceful degradation**: `auto` mode falls back to tenant token if user token unavailable
- **Cross-platform**: Browser opening works on macOS, Linux, and Windows
- **Timeout handling**: 5-minute timeout for authorization flow with user-friendly error messages

https://claude.ai/code/session_01XwhRkaaNvUBiZJn1tWwq9C