### PR TITLE
fix: 修复 install.sh 临时目录未清理的问题

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -4,6 +4,7 @@ set -euo pipefail
 REPO="riba2534/feishu-cli"
 BINARY_NAME="feishu-cli"
 DEFAULT_INSTALL_DIR="/usr/local/bin"
+tmpdir=""
 
 # 颜色输出
 info()  { printf "\033[34m[INFO]\033[0m  %s\n" "$*"; }
@@ -85,7 +86,7 @@ detect_install_dir() {
 
 # 下载并安装
 install() {
-    local os arch version install_dir asset_name download_url tmpdir
+    local os arch version install_dir asset_name download_url
 
     os=$(detect_os)
     arch=$(detect_arch)


### PR DESCRIPTION
## 问题

`install.sh` 中 `tmpdir` 被声明为 `install()` 函数内的 `local` 变量，但 `EXIT` trap 在函数返回后才执行，此时 local 变量已超出作用域。

配合 `set -u`，会导致：
1. `unbound variable` 报错
2. `rm -rf` 未执行，临时目录（约 9MB）从未被清理

## 修复

将 `tmpdir` 改为全局变量，使 trap 在退出时能正确访问并清理。