### PR TITLE
docs: add board image node guide and clone workflow

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -351,6 +351,8 @@ feishu-cli search docs "产品需求" --user-access-token <token>
 - **表格列宽**：通过 `TableProperty.ColumnWidth` 设置，单位像素，数组长度需与列数一致
 - **画板 API**：路径 `/open-apis/board/v1/whiteboards/{id}/nodes/plantuml`，`syntax_type=1` PlantUML / `2` Mermaid
 - **diagram_type 映射**：0=auto, 1=mindmap, 2=sequence, 3=activity, 4=class, 5=er, 6=flowchart, 7=state, 8=component
+- **画板图片节点**：上传必须用 `parent_type=whiteboard` + `parent_node=画板ID`；节点格式 `{"image":{"token":"xxx"}}`（嵌套，非顶层）；每个节点需独立 token（不可复用）；API 不支持裁切/遮罩，需预处理图片
+- **画板克隆 GET→POST 清洗**：必须移除 `id`、`locked`、`children`、`parent_id` 字段；`composite_shape` 必须保留完整子结构（`composite_shape.type` + `text`）；批量创建建议每批 10 个、间隔 3s
 
 ### 电子表格
 

--- a/skills/feishu-cli-toolkit/references/board-commands.md
+++ b/skills/feishu-cli-toolkit/references/board-commands.md
@@ -117,6 +117,30 @@ feishu-cli board create-notes <whiteboard_id> nodes.json -o json
 
 详细的节点格式和高级用法请参考 `references/board-node-api.md`。
 
+## 画板图片节点
+
+画板中插入图片需要特殊的上传和创建流程：
+
+```bash
+# 1. 上传图片（必须用 whiteboard 类型 + 画板 ID）
+feishu-cli media upload image.png --parent-type whiteboard --parent-node <whiteboard_id> -o json
+# 返回 {"file_token": "xxx"}
+
+# 2. 创建图片节点（token 必须嵌套在 image 对象内）
+feishu-cli board create-notes <whiteboard_id> \
+  '[{"type":"image","x":100,"y":100,"width":86,"height":86,"image":{"token":"<file_token>"},"z_index":100}]' \
+  --source-type content
+```
+
+**关键注意事项**：
+- `parent_type` 必须是 `whiteboard`（不是 `docx_image`），否则图片在画板中显示为棋盘格
+- `parent_node` 必须是画板 ID（不是文档 ID）
+- token 格式：`{"image":{"token":"xxx"}}`（嵌套），不能放顶层
+- 每个图片节点需要独立的 token，同一张图片用于多个节点时必须分别上传
+- 圆形头像：API 不支持 `clip`/`mask`/`border_radius`，需预处理图片为圆形后上传
+
+详见 `references/board-node-api.md` 的 image 节点章节。
+
 ## 已知限制
 
 | 限制 | 说明 |
@@ -125,3 +149,5 @@ feishu-cli board create-notes <whiteboard_id> nodes.json -o json
 | Mermaid 花括号 | `{text}` 被识别为菱形节点，需避免 |
 | Mermaid par 语法 | `par...and...end` 飞书不支持 |
 | 画板无 PATCH/DELETE API | 修改节点需重建画板（redraw 模式） |
+| 画板图片裁切 | API 不支持 `clip`/`mask`/`crop_rect`/`border_radius` 等属性，需预处理图片 |
+| 画板图片 token | 每个节点必须独占 token，不可多节点复用同一 token |

--- a/skills/feishu-cli-toolkit/references/board-node-api.md
+++ b/skills/feishu-cli-toolkit/references/board-node-api.md
@@ -174,19 +174,90 @@ feishu-cli board create-notes <new_whiteboard_id> remapped_connectors.json -o js
 
 | 层级 | 需移除的字段 | 原因 |
 |------|------------|------|
-| 顶层 | `id`, `locked`, `children` | 只读/系统生成 |
+| 顶层 | `id`, `locked`, `children`, `parent_id` | 只读/系统生成。**`parent_id` 必须移除**，否则 2890002 |
 | `text.*` | `text_color_type` | 未公开的内部字段 |
 | `style.*` | `fill_color_type`, `border_color_type` | 未公开的内部字段 |
 | `connector.*` | `start_object`, `end_object` | 只读，改用 `start`/`end` |
+
+### image（图片节点）
+
+画板图片节点需要特殊处理，有多个关键注意事项：
+
+**创建格式**（token 必须嵌套在 `image` 对象内）：
+
+```json
+{
+  "type": "image",
+  "x": 100, "y": 100, "width": 86, "height": 86,
+  "z_index": 110,
+  "image": {"token": "<file_token>"}
+}
+```
+
+**图片上传**：画板图片必须使用 `parent_type=whiteboard`，`parent_node=画板ID`：
+
+```bash
+feishu-cli media upload image.png --parent-type whiteboard --parent-node <whiteboard_id> -o json
+# 返回 {"file_token": "xxx"}
+```
+
+**⚠️ 关键规则**：
+
+| 规则 | 说明 |
+|------|------|
+| **上传 parent_type** | 必须是 `whiteboard`，用 `docx_image` 上传的 token 在画板中无法渲染（显示棋盘格） |
+| **上传 parent_node** | 必须是目标画板 ID（whiteboard_id），不是文档 ID |
+| **token 嵌套格式** | 必须 `{"image":{"token":"xxx"}}`，不能放顶层 `{"token":"xxx"}`（顶层会被忽略） |
+| **每个节点独占 token** | 同一张图片用于多个节点时，**必须分别上传获得不同 token**，不可复用 |
+| **圆形裁切** | API 不支持 `clip`/`mask`/`border_radius`/`crop_rect` 等裁切属性。需**预处理图片**为圆形后上传 |
+
+**圆形图片预处理**（Python PIL）：
+
+```python
+from PIL import Image, ImageDraw
+
+img = Image.open("avatar.png").convert("RGBA")
+mask = Image.new("L", img.size, 0)
+ImageDraw.Draw(mask).ellipse((0, 0, img.size[0]-1, img.size[1]-1), fill=255)
+output = Image.new("RGBA", img.size, (0, 0, 0, 0))
+output.paste(img, (0, 0), mask)
+output.save("avatar_circle.png")
+```
+
+**完整克隆图片流程**：
+
+```bash
+# 1. 从原始画板获取节点，提取 image 节点的 token 列表
+feishu-cli board nodes <original_board_id> > original.json
+
+# 2. 下载原始图片
+feishu-cli media download <old_token> -o /tmp/images/<old_token>.png
+
+# 3. 预处理为圆形（如果原图是圆形头像）
+
+# 4. 逐个上传到新画板（每个节点一个独立 token）
+feishu-cli media upload image.png --parent-type whiteboard --parent-node <new_board_id> -o json
+
+# 5. 创建图片节点（注意限频，建议每个节点间隔 2s）
+feishu-cli board create-notes <new_board_id> '[{"type":"image",...,"image":{"token":"<new_token>"}}]' --source-type content
+```
+
+## 批量创建的限频与重试
+
+画板节点创建 API 有频率限制（实测约 10-20 req/5s），批量创建时需注意：
+
+- **批量模式**：每批 10 个节点，批间间隔 3 秒
+- **失败重试**：批量失败时改为逐个创建，每个间隔 2 秒
+- **新建画板后**：需等待 5-10 秒画板初始化完成后再创建节点
 
 ## 错误码
 
 | 错误码 | 含义 | 常见原因 |
 |--------|------|---------|
 | 2890001 | invalid format | JSON 格式错误 |
-| 2890002 | invalid arg | 包含未公开字段、连接线格式错误 |
+| 2890002 | invalid arg | 包含 `parent_id` 等未公开字段、连接线格式错误、节点缺少必需子结构（如 composite_shape 缺少 `composite_shape.type` 和 `text` 字段） |
 | 2890003 | record missing | whiteboard_id 不存在 |
-| 2890006 | rate limited | 超过 50 req/s 频率限制 |
+| 2890006 | rate limited | 超过频率限制 |
 
 ## 常用配色参考
 


### PR DESCRIPTION
## Summary
- 补充画板图片节点的完整使用指南：上传规则（`parent_type=whiteboard`）、token 嵌套格式、token 独占约束
- 新增画板克隆流程文档：GET→POST 字段清洗（`parent_id` 必须移除）、圆形图片预处理（PIL）、限频与重试策略
- 更新 CLAUDE.md 和错误码说明，反映实战踩坑经验

## Changes
- `CLAUDE.md`: 新增画板图片节点和画板克隆清洗的速查条目
- `board-commands.md`: 新增"画板图片节点"章节 + 已知限制补充
- `board-node-api.md`: 新增 image 节点详细文档、批量限频指南、更新错误码说明

## Context
这些文档来自实际画板克隆操作中的踩坑总结，涉及 9 张图片节点的完整克隆流程（上传、圆形裁切预处理、token 映射、批量创建）。关键发现包括：
- `docx_image` 类型上传的 token 在画板中显示为棋盘格
- token 放顶层会被静默忽略，必须嵌套在 `image` 对象内
- 同一 token 不可复用于多个节点（第二个节点起报 2890002）
- API 不支持任何裁切属性，圆形头像需客户端预处理

🤖 Generated with [Claude Code](https://claude.com/claude-code)