### PR TITLE
fix: 拆分 Feishu/Lark 的 API、OAuth 与文档域名配置

### DIFF
--- a/cmd/auth_callback.go
+++ b/cmd/auth_callback.go
@@ -43,10 +43,7 @@ var authCallbackCmd = &cobra.Command{
 		// 构造 redirectURI（需与 --print-url 时一致）
 		redirectURI := fmt.Sprintf("http://127.0.0.1:%d%s", port, auth.CallbackPath)
 
-		baseURL := cfg.BaseURL
-		if baseURL == "" {
-			baseURL = "https://open.feishu.cn"
-		}
+		baseURL := config.ResolveAPIBaseURL(cfg)
 
 		// 用 code 换 token
 		token, err := auth.ExchangeToken(code, cfg.AppID, cfg.AppSecret, redirectURI, baseURL)

--- a/cmd/auth_login.go
+++ b/cmd/auth_login.go
@@ -58,13 +58,14 @@ Token 保存位置: ~/.feishu-cli/token.json
 		printURL, _ := cmd.Flags().GetBool("print-url")
 
 		opts := auth.LoginOptions{
-			Port:      port,
-			Manual:    manual,
-			NoManual:  noManual,
-			AppID:     cfg.AppID,
-			AppSecret: cfg.AppSecret,
-			BaseURL:   cfg.BaseURL,
-			Scopes:    scopes,
+			Port:        port,
+			Manual:      manual,
+			NoManual:    noManual,
+			AppID:       cfg.AppID,
+			AppSecret:   cfg.AppSecret,
+			BaseURL:     config.ResolveAPIBaseURL(cfg),
+			AuthBaseURL: config.ResolveAuthBaseURL(cfg),
+			Scopes:      scopes,
 		}
 
 		// 非交互模式：仅输出授权 URL 和 state

--- a/cmd/config.go
+++ b/cmd/config.go
@@ -18,11 +18,14 @@ var configCmd = &cobra.Command{
 配置优先级:
   环境变量 > 配置文件 > 默认值
 
-环境变量:
-  FEISHU_APP_ID      应用 ID
-  FEISHU_APP_SECRET  应用密钥
-  FEISHU_BASE_URL    API 地址（可选）
-  FEISHU_DEBUG       调试模式（可选）
+	环境变量:
+    FEISHU_APP_ID      应用 ID
+    FEISHU_APP_SECRET  应用密钥
+    FEISHU_PLATFORM    平台（feishu/lark）
+    FEISHU_BASE_URL    API 地址（可选，仅 API）
+    FEISHU_AUTH_BASE_URL  OAuth 地址（可选）
+    FEISHU_WEB_BASE_URL   文档链接地址（可选）
+    FEISHU_DEBUG       调试模式（可选）
 
 示例:
   # 初始化配置文件

--- a/cmd/create_document.go
+++ b/cmd/create_document.go
@@ -63,11 +63,12 @@ var createDocumentCmd = &cobra.Command{
 				return err
 			}
 		} else {
+			documentWebURL := fmt.Sprintf("%s/docx/%s", config.ResolveWebBaseURL(config.Get()), documentID)
 			fmt.Printf("文档创建成功！\n")
 			fmt.Printf("  文档 ID: %s\n", documentID)
 			fmt.Printf("  标题: %s\n", docTitle)
 			fmt.Printf("  版本: %d\n", revisionID)
-			fmt.Printf("  链接: https://feishu.cn/docx/%s\n", documentID)
+			fmt.Printf("  链接: %s\n", documentWebURL)
 		}
 
 		return nil

--- a/cmd/get_document.go
+++ b/cmd/get_document.go
@@ -47,11 +47,12 @@ var getDocumentCmd = &cobra.Command{
 				return err
 			}
 		} else {
+			docWebURL := fmt.Sprintf("%s/docx/%s", config.ResolveWebBaseURL(config.Get()), documentID)
 			fmt.Printf("文档信息:\n")
 			fmt.Printf("  文档ID: %s\n", documentID)
 			fmt.Printf("  标题: %s\n", docTitle)
 			fmt.Printf("  版本: %d\n", revisionID)
-			fmt.Printf("  链接: https://feishu.cn/docx/%s\n", documentID)
+			fmt.Printf("  链接: %s\n", docWebURL)
 		}
 
 		return nil

--- a/cmd/import_markdown.go
+++ b/cmd/import_markdown.go
@@ -380,7 +380,7 @@ var importMarkdownCmd = &cobra.Command{
 			}
 			documentID = *doc.DocumentId
 			fmt.Printf("已创建文档: %s\n", documentID)
-			fmt.Printf("链接: https://feishu.cn/docx/%s\n\n", documentID)
+			fmt.Printf("链接: %s/docx/%s\n\n", config.ResolveWebBaseURL(config.Get()), documentID)
 		}
 
 		// 解析 Markdown 为片段
@@ -518,7 +518,7 @@ var importMarkdownCmd = &cobra.Command{
 				}
 			}
 			fmt.Printf("  总耗时: %.1fs\n", totalDuration.Seconds())
-			fmt.Printf("  链接: https://feishu.cn/docx/%s\n", documentID)
+			fmt.Printf("  链接: %s/docx/%s\n", config.ResolveWebBaseURL(config.Get()), documentID)
 		}
 
 		return nil

--- a/cmd/utils.go
+++ b/cmd/utils.go
@@ -31,7 +31,7 @@ func resolveOptionalUserToken(cmd *cobra.Command) string {
 func resolveRequiredUserToken(cmd *cobra.Command) (string, error) {
 	flagToken, _ := cmd.Flags().GetString("user-access-token")
 	cfg := config.Get()
-	return auth.ResolveUserAccessToken(flagToken, cfg.UserAccessToken, cfg.AppID, cfg.AppSecret, cfg.BaseURL)
+	return auth.ResolveUserAccessToken(flagToken, cfg.UserAccessToken, cfg.AppID, cfg.AppSecret, config.ResolveAPIBaseURL(cfg))
 }
 
 // mustMarkFlagRequired 标记 flag 为必填，如果失败则 panic

--- a/internal/auth/oauth.go
+++ b/internal/auth/oauth.go
@@ -16,23 +16,25 @@ import (
 	"os"
 	"strings"
 	"time"
+
+	"github.com/riba2534/feishu-cli/internal/config"
 )
 
 const (
-	DefaultPort   = 9768
-	CallbackPath  = "/callback"
-	FeishuAuthURL = "https://accounts.feishu.cn/open-apis/authen/v1/authorize"
+	DefaultPort  = 9768
+	CallbackPath = "/callback"
 )
 
 // LoginOptions 登录选项
 type LoginOptions struct {
-	Port      int
-	Manual    bool   // 强制手动粘贴模式
-	NoManual  bool   // 强制本地回调模式
-	AppID     string
-	AppSecret string
-	BaseURL   string
-	Scopes    string // OAuth scope，空格分隔
+	Port        int
+	Manual      bool // 强制手动粘贴模式
+	NoManual    bool // 强制本地回调模式
+	AppID       string
+	AppSecret   string
+	BaseURL     string // API 地址
+	AuthBaseURL string
+	Scopes      string // OAuth scope，空格分隔
 }
 
 // tokenResponse 飞书 token 端点响应
@@ -88,9 +90,14 @@ func buildAuthURL(opts LoginOptions) (state, redirectURI, authURL string, err er
 	state = hex.EncodeToString(stateBytes)
 
 	redirectURI = fmt.Sprintf("http://127.0.0.1:%d%s", opts.Port, CallbackPath)
+	authBaseURL := opts.AuthBaseURL
+	if authBaseURL == "" {
+		authBaseURL = config.ResolveAuthBaseURL(nil)
+	}
+	authAuthorizeURL := config.ResolveOAuthAuthorizeURL(&config.Config{AuthBaseURL: authBaseURL})
 
 	authURL = fmt.Sprintf("%s?client_id=%s&redirect_uri=%s&response_type=code&state=%s",
-		FeishuAuthURL,
+		authAuthorizeURL,
 		url.QueryEscape(opts.AppID),
 		url.QueryEscape(redirectURI),
 		url.QueryEscape(state),
@@ -111,7 +118,10 @@ func Login(opts LoginOptions) (*TokenStore, error) {
 	}
 
 	if opts.BaseURL == "" {
-		opts.BaseURL = "https://open.feishu.cn"
+		opts.BaseURL = config.ResolveAPIBaseURL(nil)
+	}
+	if opts.AuthBaseURL == "" {
+		opts.AuthBaseURL = config.ResolveAuthBaseURL(nil)
 	}
 
 	state, redirectURI, authURL, err := buildAuthURL(opts)
@@ -311,11 +321,11 @@ func ExchangeToken(code, appID, appSecret, redirectURI, baseURL string) (*TokenS
 	tokenURL := baseURL + "/open-apis/authen/v2/oauth/token"
 
 	body := map[string]string{
-		"grant_type":   "authorization_code",
-		"code":         code,
-		"client_id":    appID,
+		"grant_type":    "authorization_code",
+		"code":          code,
+		"client_id":     appID,
 		"client_secret": appSecret,
-		"redirect_uri": redirectURI,
+		"redirect_uri":  redirectURI,
 	}
 
 	return doTokenRequest(tokenURL, body)

--- a/internal/auth/resolve.go
+++ b/internal/auth/resolve.go
@@ -2,6 +2,9 @@ package auth
 
 import (
 	"fmt"
+	"strings"
+
+	"github.com/riba2534/feishu-cli/internal/config"
 	"os"
 )
 
@@ -39,8 +42,8 @@ func ResolveUserAccessToken(flagValue, configValue, appID, appSecret, baseURL st
 
 		// access_token 过期，尝试刷新
 		if token.IsRefreshTokenValid() {
-			if baseURL == "" {
-				baseURL = "https://open.feishu.cn"
+			if strings.TrimSpace(baseURL) == "" {
+				baseURL = config.ResolveAPIBaseURL(nil)
 			}
 			logf("[自动刷新] Access Token 已过期，正在刷新...")
 			newToken, refreshErr := RefreshAccessToken(token.RefreshToken, appID, appSecret, baseURL)

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -39,17 +39,18 @@ func GetClient() (*lark.Client, error) {
 
 	// 使用简单的配置指纹来检测变更，避免存储敏感信息
 	currentHash := fmt.Sprintf("%s:%d", cfg.AppID, len(cfg.AppSecret))
+	apiBaseURL := config.ResolveAPIBaseURL(cfg)
 
 	// Check if config changed or instance is nil
 	configChanged := instance == nil ||
 		lastCfg.appID != cfg.AppID ||
 		lastCfg.cfgHash != currentHash ||
-		lastCfg.baseURL != cfg.BaseURL ||
+		lastCfg.baseURL != apiBaseURL ||
 		lastCfg.debug != cfg.Debug
 
 	if configChanged {
 		opts := []lark.ClientOptionFunc{
-			lark.WithOpenBaseUrl(cfg.BaseURL),
+			lark.WithOpenBaseUrl(apiBaseURL),
 		}
 		if cfg.Debug {
 			opts = append(opts, lark.WithLogLevel(larkcore.LogLevelDebug))
@@ -59,7 +60,7 @@ func GetClient() (*lark.Client, error) {
 		// Save current config (不存储 secret 明文)
 		lastCfg.appID = cfg.AppID
 		lastCfg.cfgHash = currentHash
-		lastCfg.baseURL = cfg.BaseURL
+		lastCfg.baseURL = apiBaseURL
 		lastCfg.debug = cfg.Debug
 	}
 

--- a/internal/client/search.go
+++ b/internal/client/search.go
@@ -7,6 +7,7 @@ import (
 
 	larkcore "github.com/larksuite/oapi-sdk-go/v3/core"
 	larksearch "github.com/larksuite/oapi-sdk-go/v3/service/search/v2"
+	"github.com/riba2534/feishu-cli/internal/config"
 )
 
 // SearchMessagesOptions 搜索消息的选项
@@ -204,7 +205,7 @@ func buildDocsURL(docsType, docsToken string) string {
 	if !ok {
 		path = docsType
 	}
-	return fmt.Sprintf("https://feishu.cn/%s/%s", path, docsToken)
+	return fmt.Sprintf("%s/%s/%s", config.ResolveWebBaseURL(config.Get()), path, docsToken)
 }
 
 // SearchDocWiki 搜索云文档

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -2,18 +2,38 @@ package config
 
 import (
 	"fmt"
+	"net/url"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"github.com/spf13/viper"
 )
+
+const (
+	PlatformFeishu = "feishu"
+	PlatformLark   = "lark"
+)
+
+const defaultFeishuAPIBaseURL = "https://open.feishu.cn"
+const defaultFeishuAuthBaseURL = "https://accounts.feishu.cn"
+const defaultFeishuWebBaseURL = "https://feishu.cn"
+
+const defaultLarkAPIBaseURL = "https://open.larksuite.com"
+const defaultLarkAuthBaseURL = "https://accounts.larksuite.com"
+const defaultLarkWebBaseURL = "https://larksuite.com"
+
+const defaultAuthPath = "/open-apis/authen/v1/authorize"
 
 // Config holds the application configuration
 type Config struct {
 	AppID           string       `mapstructure:"app_id"`
 	AppSecret       string       `mapstructure:"app_secret"`
 	UserAccessToken string       `mapstructure:"user_access_token"`
-	BaseURL         string       `mapstructure:"base_url"`
+	Platform        string       `mapstructure:"platform"`
+	BaseURL         string       `mapstructure:"base_url"`      // API 地址
+	AuthBaseURL     string       `mapstructure:"auth_base_url"` // OAuth 地址
+	WebBaseURL      string       `mapstructure:"web_base_url"`  // 文档链接地址
 	Debug           bool         `mapstructure:"debug"`
 	Export          ExportConfig `mapstructure:"export"`
 	Import          ImportConfig `mapstructure:"import"`
@@ -52,7 +72,10 @@ func Init(cfgFile string) error {
 	}
 
 	// 2. 设置默认值
-	viper.SetDefault("base_url", "https://open.feishu.cn")
+	viper.SetDefault("platform", PlatformFeishu)
+	viper.SetDefault("base_url", "")
+	viper.SetDefault("auth_base_url", "")
+	viper.SetDefault("web_base_url", "")
 	viper.SetDefault("debug", false)
 	viper.SetDefault("export.download_images", false)
 	viper.SetDefault("export.assets_dir", "./assets")
@@ -66,7 +89,10 @@ func Init(cfgFile string) error {
 	_ = viper.BindEnv("app_id", "FEISHU_APP_ID")
 	_ = viper.BindEnv("app_secret", "FEISHU_APP_SECRET")
 	_ = viper.BindEnv("user_access_token", "FEISHU_USER_ACCESS_TOKEN")
+	_ = viper.BindEnv("platform", "FEISHU_PLATFORM")
 	_ = viper.BindEnv("base_url", "FEISHU_BASE_URL")
+	_ = viper.BindEnv("auth_base_url", "FEISHU_AUTH_BASE_URL")
+	_ = viper.BindEnv("web_base_url", "FEISHU_WEB_BASE_URL")
 	_ = viper.BindEnv("debug", "FEISHU_DEBUG")
 
 	// 4. 读取配置文件
@@ -80,6 +106,9 @@ func Init(cfgFile string) error {
 	if err := viper.Unmarshal(cfg); err != nil {
 		return fmt.Errorf("解析配置失败: %w", err)
 	}
+	if err := normalizeConfig(cfg); err != nil {
+		return err
+	}
 
 	return nil
 }
@@ -88,7 +117,7 @@ func Init(cfgFile string) error {
 func Get() *Config {
 	if cfg == nil {
 		return &Config{
-			BaseURL: "https://open.feishu.cn",
+			Platform: PlatformFeishu,
 			Export: ExportConfig{
 				AssetsDir: "./assets",
 			},
@@ -98,6 +127,113 @@ func Get() *Config {
 		}
 	}
 	return cfg
+}
+
+func normalizeConfig(c *Config) error {
+	if c == nil {
+		return nil
+	}
+
+	platform, err := normalizePlatform(c.Platform)
+	if err != nil {
+		return err
+	}
+	c.Platform = platform
+
+	c.BaseURL, err = normalizeBaseURLField("base_url", c.BaseURL)
+	if err != nil {
+		return err
+	}
+	c.AuthBaseURL, err = normalizeBaseURLField("auth_base_url", c.AuthBaseURL)
+	if err != nil {
+		return err
+	}
+	c.WebBaseURL, err = normalizeBaseURLField("web_base_url", c.WebBaseURL)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func normalizePlatform(platform string) (string, error) {
+	platform = strings.ToLower(strings.TrimSpace(platform))
+	if platform == "" {
+		return PlatformFeishu, nil
+	}
+	switch platform {
+	case PlatformFeishu, PlatformLark:
+		return platform, nil
+	default:
+		return "", fmt.Errorf("配置项 platform 无效: %s（仅支持 feishu 或 lark）", platform)
+	}
+}
+
+func normalizeBaseURLField(name, raw string) (string, error) {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return "", nil
+	}
+
+	u, err := url.Parse(raw)
+	if err != nil || u.Scheme == "" || u.Host == "" {
+		return "", fmt.Errorf("配置项 %s 无效: %s", name, raw)
+	}
+	return u.Scheme + "://" + u.Host, nil
+}
+
+func effectivePlatform(cfg *Config) string {
+	if cfg == nil {
+		return PlatformFeishu
+	}
+	if cfg.Platform == "" {
+		return PlatformFeishu
+	}
+	return cfg.Platform
+}
+
+// ResolveAPIBaseURL 返回 API 入口地址。
+func ResolveAPIBaseURL(cfg *Config) string {
+	if cfg != nil && cfg.BaseURL != "" {
+		return cfg.BaseURL
+	}
+	switch effectivePlatform(cfg) {
+	case PlatformLark:
+		return defaultLarkAPIBaseURL
+	default:
+		return defaultFeishuAPIBaseURL
+	}
+}
+
+// ResolveAuthBaseURL 返回 OAuth 主机地址。
+func ResolveAuthBaseURL(cfg *Config) string {
+	if cfg != nil && cfg.AuthBaseURL != "" {
+		return cfg.AuthBaseURL
+	}
+	switch effectivePlatform(cfg) {
+	case PlatformLark:
+		return defaultLarkAuthBaseURL
+	default:
+		return defaultFeishuAuthBaseURL
+	}
+}
+
+// ResolveOAuthAuthorizeURL 返回完整 OAuth authorize 地址。
+func ResolveOAuthAuthorizeURL(cfg *Config) string {
+	return ResolveAuthBaseURL(cfg) + defaultAuthPath
+}
+
+// ResolveWebBaseURL 返回文档/知识库链接域名。
+func ResolveWebBaseURL(cfg *Config) string {
+	if cfg != nil && cfg.WebBaseURL != "" {
+		return cfg.WebBaseURL
+	}
+	switch effectivePlatform(cfg) {
+	case PlatformLark:
+		return defaultLarkWebBaseURL
+	default:
+		return defaultFeishuWebBaseURL
+	}
 }
 
 // Validate validates the configuration
@@ -143,7 +279,10 @@ func CreateDefaultConfig() error {
 
 app_id: ""
 app_secret: ""
-base_url: "https://open.feishu.cn"
+platform: "feishu"  # 可选: feishu, lark
+base_url: ""        # API 地址，留空时按 platform 使用官方默认值
+auth_base_url: ""   # OAuth 地址，留空时按 platform 使用官方默认值
+web_base_url: ""    # 文档链接地址，留空时按 platform 使用官方默认值
 debug: false
 
 # 导出配置

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -45,7 +45,10 @@ func TestInit_DefaultValues(t *testing.T) {
 	// 清除可能存在的环境变量
 	os.Unsetenv("FEISHU_APP_ID")
 	os.Unsetenv("FEISHU_APP_SECRET")
+	os.Unsetenv("FEISHU_PLATFORM")
 	os.Unsetenv("FEISHU_BASE_URL")
+	os.Unsetenv("FEISHU_AUTH_BASE_URL")
+	os.Unsetenv("FEISHU_WEB_BASE_URL")
 	os.Unsetenv("FEISHU_DEBUG")
 	os.Unsetenv("FEISHU_USER_ACCESS_TOKEN")
 
@@ -55,8 +58,11 @@ func TestInit_DefaultValues(t *testing.T) {
 	}
 
 	c := Get()
-	if c.BaseURL != "https://open.feishu.cn" {
-		t.Errorf("BaseURL = %q, 期望 %q", c.BaseURL, "https://open.feishu.cn")
+	if c.Platform != PlatformFeishu {
+		t.Errorf("Platform = %q, 期望 %q", c.Platform, PlatformFeishu)
+	}
+	if c.BaseURL != "" {
+		t.Errorf("BaseURL = %q, 期望空字符串", c.BaseURL)
 	}
 	if c.Debug != false {
 		t.Errorf("Debug = %v, 期望 %v", c.Debug, false)
@@ -165,8 +171,11 @@ func TestGet_WithoutInit(t *testing.T) {
 		t.Fatal("Get() 返回 nil")
 	}
 	// 应返回默认配置
-	if c.BaseURL != "https://open.feishu.cn" {
-		t.Errorf("BaseURL = %q, 期望 %q", c.BaseURL, "https://open.feishu.cn")
+	if c.Platform != PlatformFeishu {
+		t.Errorf("Platform = %q, 期望 %q", c.Platform, PlatformFeishu)
+	}
+	if c.BaseURL != "" {
+		t.Errorf("BaseURL = %q, 期望空字符串", c.BaseURL)
 	}
 	if c.Export.AssetsDir != "./assets" {
 		t.Errorf("Export.AssetsDir = %q, 期望 %q", c.Export.AssetsDir, "./assets")
@@ -363,6 +372,53 @@ func TestInit_BaseURLFromEnv(t *testing.T) {
 	c := Get()
 	if c.BaseURL != "https://custom.lark.com" {
 		t.Errorf("BaseURL = %q, 期望 %q", c.BaseURL, "https://custom.lark.com")
+	}
+}
+
+func TestResolveURLs_DefaultFeishu(t *testing.T) {
+	cfg := &Config{Platform: PlatformFeishu}
+
+	if got := ResolveAPIBaseURL(cfg); got != defaultFeishuAPIBaseURL {
+		t.Errorf("ResolveAPIBaseURL() = %q, 期望 %q", got, defaultFeishuAPIBaseURL)
+	}
+	if got := ResolveAuthBaseURL(cfg); got != defaultFeishuAuthBaseURL {
+		t.Errorf("ResolveAuthBaseURL() = %q, 期望 %q", got, defaultFeishuAuthBaseURL)
+	}
+	if got := ResolveWebBaseURL(cfg); got != defaultFeishuWebBaseURL {
+		t.Errorf("ResolveWebBaseURL() = %q, 期望 %q", got, defaultFeishuWebBaseURL)
+	}
+}
+
+func TestResolveURLs_DefaultLark(t *testing.T) {
+	cfg := &Config{Platform: PlatformLark}
+
+	if got := ResolveAPIBaseURL(cfg); got != defaultLarkAPIBaseURL {
+		t.Errorf("ResolveAPIBaseURL() = %q, 期望 %q", got, defaultLarkAPIBaseURL)
+	}
+	if got := ResolveAuthBaseURL(cfg); got != defaultLarkAuthBaseURL {
+		t.Errorf("ResolveAuthBaseURL() = %q, 期望 %q", got, defaultLarkAuthBaseURL)
+	}
+	if got := ResolveWebBaseURL(cfg); got != defaultLarkWebBaseURL {
+		t.Errorf("ResolveWebBaseURL() = %q, 期望 %q", got, defaultLarkWebBaseURL)
+	}
+}
+
+func TestResolveURLs_ExplicitOverrides(t *testing.T) {
+	cfg := &Config{
+		Platform:    PlatformLark,
+		BaseURL:     "https://proxy.example.com",
+		AuthBaseURL: "https://auth.example.com",
+		WebBaseURL:  "https://docs.example.com",
+	}
+
+	if got := ResolveAPIBaseURL(cfg); got != "https://proxy.example.com" {
+		t.Errorf("ResolveAPIBaseURL() = %q, 期望 %q", got, "https://proxy.example.com")
+	}
+	if got := ResolveAuthBaseURL(cfg); got != "https://auth.example.com" {
+		t.Errorf("ResolveAuthBaseURL() = %q, 期望 %q", got, "https://auth.example.com")
+	}
+	if got := ResolveWebBaseURL(cfg); got != "https://docs.example.com" {
+		t.Errorf("ResolveWebBaseURL() = %q, 期望 %q", got, "https://docs.example.com")
 	}
 }
 

--- a/internal/converter/block_to_markdown.go
+++ b/internal/converter/block_to_markdown.go
@@ -988,7 +988,8 @@ func (c *BlockToMarkdown) convertBitable(block *larkdocx.Block) (string, error) 
 		token = *block.Bitable.Token
 	}
 
-	return fmt.Sprintf("[Bitable: %s](https://feishu.cn/base/%s)\n", token, token), nil
+	baseURL := docBaseURL()
+	return fmt.Sprintf("[Bitable: %s](%s/base/%s)\n", token, baseURL, token), nil
 }
 
 func (c *BlockToMarkdown) convertSheet(block *larkdocx.Block) (string, error) {
@@ -1001,7 +1002,8 @@ func (c *BlockToMarkdown) convertSheet(block *larkdocx.Block) (string, error) {
 		token = *block.Sheet.Token
 	}
 
-	return fmt.Sprintf("[Sheet: %s](https://feishu.cn/sheets/%s)\n", token, token), nil
+	baseURL := docBaseURL()
+	return fmt.Sprintf("[Sheet: %s](%s/sheets/%s)\n", token, baseURL, token), nil
 }
 
 func (c *BlockToMarkdown) convertChatCard(block *larkdocx.Block) (string, error) {

--- a/internal/converter/markdown_to_block.go
+++ b/internal/converter/markdown_to_block.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 
 	larkdocx "github.com/larksuite/oapi-sdk-go/v3/service/docx/v1"
+	"github.com/riba2534/feishu-cli/internal/config"
 	"github.com/yuin/goldmark"
 	"github.com/yuin/goldmark/ast"
 	"github.com/yuin/goldmark/extension"
@@ -1703,16 +1704,18 @@ func applyTextStyle(elem *larkdocx.TextElement, bold, italic, strikethrough bool
 // 1. 将 feishu:// 内部协议转换为 https:// 链接（API 不接受 feishu:// 协议）
 // 2. 解码 URL 编码的链接，例如 "https%3A%2F%2Fexample.com" → "https://example.com"
 func normalizeURL(rawURL string) string {
+	baseURL := docBaseURL()
+
 	// feishu:// 内部协议转换为 HTTPS 链接
 	if strings.HasPrefix(rawURL, "feishu://doc/") {
-		return "https://feishu.cn/docx/" + strings.TrimPrefix(rawURL, "feishu://doc/")
+		return baseURL + "/docx/" + strings.TrimPrefix(rawURL, "feishu://doc/")
 	}
 	if strings.HasPrefix(rawURL, "feishu://wiki/") {
-		return "https://feishu.cn/wiki/" + strings.TrimPrefix(rawURL, "feishu://wiki/")
+		return baseURL + "/wiki/" + strings.TrimPrefix(rawURL, "feishu://wiki/")
 	}
 	if strings.HasPrefix(rawURL, "feishu://") {
 		// 其他 feishu:// 链接，尝试通用转换
-		return "https://feishu.cn/" + strings.TrimPrefix(rawURL, "feishu://")
+		return baseURL + "/" + strings.TrimPrefix(rawURL, "feishu://")
 	}
 
 	// URL 解码
@@ -1720,6 +1723,10 @@ func normalizeURL(rawURL string) string {
 		return decoded
 	}
 	return rawURL
+}
+
+func docBaseURL() string {
+	return config.ResolveWebBaseURL(config.Get())
 }
 
 // hasValidURLPrefix 检查 URL 是否以支持的协议开头


### PR DESCRIPTION
## 变更说明
- 为配置新增 `platform`、`auth_base_url`、`web_base_url`，将 API、OAuth、文档链接域名拆分解析
- `base_url` 仅用于 API Client 和 token 刷新，不再推导授权地址和文档链接
- OAuth 登录、搜索结果 URL、文档导入导出相关链接统一改为走独立 resolver
- 补充配置解析与 URL resolver 测试，默认支持 `feishu` 和 `lark`
