### PR TITLE
feat: User Token passthrough for doc/wiki export and media download

### DIFF
--- a/cmd/export_file.go
+++ b/cmd/export_file.go
@@ -55,9 +55,12 @@ var exportFileCmd = &cobra.Command{
 			outputPath = fmt.Sprintf("%s.%s", docToken, fileType)
 		}
 
+		// 获取可选的 User Access Token
+		userAccessToken := resolveOptionalUserTokenWithFallback(cmd)
+
 		// 创建导出任务
 		fmt.Printf("正在创建导出任务...\n")
-		ticket, err := client.CreateExportTask(docToken, docType, fileType)
+		ticket, err := client.CreateExportTask(docToken, docType, fileType, userAccessToken)
 		if err != nil {
 			return err
 		}
@@ -65,7 +68,7 @@ var exportFileCmd = &cobra.Command{
 
 		// 轮询等待任务完成
 		fmt.Printf("正在等待导出完成...\n")
-		fileToken, err := client.WaitExportTask(ticket, docToken, 60)
+		fileToken, err := client.WaitExportTask(ticket, docToken, userAccessToken, 60)
 		if err != nil {
 			return err
 		}
@@ -73,7 +76,7 @@ var exportFileCmd = &cobra.Command{
 
 		// 下载导出文件
 		fmt.Printf("正在下载文件...\n")
-		if err := client.DownloadExportFile(fileToken, outputPath); err != nil {
+		if err := client.DownloadExportFile(fileToken, outputPath, userAccessToken); err != nil {
 			return err
 		}
 
@@ -89,5 +92,6 @@ func init() {
 	exportFileCmd.Flags().String("type", "", "导出格式（pdf/docx/xlsx，必填）")
 	exportFileCmd.Flags().String("doc-type", "docx", "文档类型")
 	exportFileCmd.Flags().StringP("output", "o", "", "输出文件路径")
+	exportFileCmd.Flags().String("user-access-token", "", "User Access Token（用于导出无 App 权限的文档）")
 	mustMarkFlagRequired(exportFileCmd, "type")
 }

--- a/cmd/export_markdown.go
+++ b/cmd/export_markdown.go
@@ -58,13 +58,16 @@ var exportMarkdownCmd = &cobra.Command{
 		expandMentions, _ := cmd.Flags().GetBool("expand-mentions")
 
 		// Convert to Markdown
+		cfg := config.Get()
 		options := converter.ConvertOptions{
-			DownloadImages: downloadImages,
-			AssetsDir:      assetsDir,
-			DocumentID:     documentID,
-			FrontMatter:    frontMatter,
-			Highlight:      highlight,
-			ExpandMentions: expandMentions,
+			DownloadImages:  downloadImages,
+			AssetsDir:       assetsDir,
+			DocumentID:      documentID,
+			UserAccessToken: userAccessToken,
+			Debug:           cfg.Debug,
+			FrontMatter:     frontMatter,
+			Highlight:       highlight,
+			ExpandMentions:  expandMentions,
 		}
 
 		var conv *converter.BlockToMarkdown

--- a/cmd/export_wiki.go
+++ b/cmd/export_wiki.go
@@ -56,9 +56,12 @@ var exportWikiCmd = &cobra.Command{
 			return err
 		}
 
+		// 获取可选的 User Access Token（用于访问无 App 权限的文档）
+		userAccessToken := resolveOptionalUserTokenWithFallback(cmd)
+
 		// 1. 获取节点信息
 		fmt.Printf("正在获取节点信息: %s\n", nodeToken)
-		node, err := client.GetWikiNode(nodeToken, resolveOptionalUserToken(cmd))
+		node, err := client.GetWikiNode(nodeToken, userAccessToken)
 		if err != nil {
 			return err
 		}
@@ -72,9 +75,9 @@ var exportWikiCmd = &cobra.Command{
 			return fmt.Errorf("暂不支持导出 %s 类型的文档，目前仅支持 docx", node.ObjType)
 		}
 
-		// 3. 获取文档块
+		// 3. 获取文档块（使用 User Token，与获取节点信息保持一致）
 		fmt.Println("正在获取文档内容...")
-		blocks, err := client.GetAllBlocks(node.ObjToken)
+		blocks, err := client.GetAllBlocksWithToken(node.ObjToken, userAccessToken)
 		if err != nil {
 			return fmt.Errorf("获取块失败: %w", err)
 		}
@@ -83,10 +86,13 @@ var exportWikiCmd = &cobra.Command{
 		downloadImages, _ := cmd.Flags().GetBool("download-images")
 		assetsDir, _ := cmd.Flags().GetString("assets-dir")
 
+		cfg := config.Get()
 		options := converter.ConvertOptions{
-			DocumentID:     node.ObjToken,
-			DownloadImages: downloadImages,
-			AssetsDir:      assetsDir,
+			DocumentID:      node.ObjToken,
+			DownloadImages:  downloadImages,
+			AssetsDir:       assetsDir,
+			UserAccessToken: userAccessToken,
+			Debug:           cfg.Debug,
 		}
 
 		conv := converter.NewBlockToMarkdown(blocks, options)

--- a/cmd/utils.go
+++ b/cmd/utils.go
@@ -33,7 +33,22 @@ func resolveOptionalUserToken(cmd *cobra.Command) string {
 func resolveOptionalUserTokenWithFallback(cmd *cobra.Command) string {
 	flagToken, _ := cmd.Flags().GetString("user-access-token")
 	cfg := config.Get()
-	token, _ := auth.ResolveUserAccessToken(flagToken, cfg.UserAccessToken, cfg.AppID, cfg.AppSecret, cfg.BaseURL)
+	token, err := auth.ResolveUserAccessToken(flagToken, cfg.UserAccessToken, cfg.AppID, cfg.AppSecret, cfg.BaseURL)
+	if err != nil {
+		if cfg.Debug {
+			fmt.Fprintf(os.Stderr, "[Debug] User Token 解析失败，回退到 App Token: %v\n", err)
+		}
+		return ""
+	}
+	if cfg.Debug {
+		source := "token.json/config"
+		if flagToken != "" {
+			source = "--user-access-token 参数"
+		} else if os.Getenv("FEISHU_USER_ACCESS_TOKEN") != "" {
+			source = "FEISHU_USER_ACCESS_TOKEN 环境变量"
+		}
+		fmt.Fprintf(os.Stderr, "[Debug] 使用 User Access Token (来源: %s)\n", source)
+	}
 	return token
 }
 

--- a/internal/client/board.go
+++ b/internal/client/board.go
@@ -13,7 +13,7 @@ import (
 )
 
 // GetBoardImage downloads whiteboard image and saves to file
-func GetBoardImage(whiteboardID string, outputPath string) error {
+func GetBoardImage(whiteboardID string, outputPath string, userAccessToken ...string) error {
 	client, err := GetClient()
 	if err != nil {
 		return err
@@ -22,7 +22,14 @@ func GetBoardImage(whiteboardID string, outputPath string) error {
 	// 使用通用 HTTP 请求方式
 	apiPath := fmt.Sprintf("/open-apis/board/v1/whiteboards/%s/download_as_image", whiteboardID)
 
-	resp, err := client.Get(Context(), apiPath, nil, larkcore.AccessTokenTypeTenant)
+	tokenType := larkcore.AccessTokenTypeTenant
+	var opts []larkcore.RequestOptionFunc
+	if len(userAccessToken) > 0 && userAccessToken[0] != "" {
+		tokenType = larkcore.AccessTokenTypeUser
+		opts = UserTokenOption(userAccessToken[0])
+	}
+
+	resp, err := client.Get(Context(), apiPath, nil, tokenType, opts...)
 	if err != nil {
 		return fmt.Errorf("获取画板图片失败: %w", err)
 	}

--- a/internal/client/drive.go
+++ b/internal/client/drive.go
@@ -1,6 +1,7 @@
 package client
 
 import (
+	"encoding/json"
 	"fmt"
 	"io"
 	"net/http"
@@ -9,6 +10,7 @@ import (
 	"strings"
 	"time"
 
+	larkcore "github.com/larksuite/oapi-sdk-go/v3/core"
 	larkdrive "github.com/larksuite/oapi-sdk-go/v3/service/drive/v1"
 )
 
@@ -78,8 +80,14 @@ func UploadMediaWithExtra(filePath, parentType, parentNode, fileName, extra stri
 	return *resp.Data.FileToken, nil
 }
 
+// DownloadMediaOptions holds optional parameters for DownloadMedia
+type DownloadMediaOptions struct {
+	UserAccessToken string // User Access Token（可选）
+	DocToken        string // 文档 Token（文档内嵌图片下载时需要）
+}
+
 // DownloadMedia downloads a file from Feishu drive
-func DownloadMedia(fileToken string, outputPath string) error {
+func DownloadMedia(fileToken string, outputPath string, opts ...DownloadMediaOptions) error {
 	if err := validatePath(outputPath); err != nil {
 		return err
 	}
@@ -89,11 +97,19 @@ func DownloadMedia(fileToken string, outputPath string) error {
 		return err
 	}
 
-	req := larkdrive.NewDownloadMediaReqBuilder().
-		FileToken(fileToken).
-		Build()
+	reqBuilder := larkdrive.NewDownloadMediaReqBuilder().
+		FileToken(fileToken)
 
-	resp, err := client.Drive.Media.Download(ContextWithTimeout(downloadTimeout), req)
+	var reqOpts []larkcore.RequestOptionFunc
+	if len(opts) > 0 {
+		reqOpts = UserTokenOption(opts[0].UserAccessToken)
+		if opts[0].DocToken != "" {
+			extraJSON, _ := json.Marshal(map[string]string{"doc_token": opts[0].DocToken, "obj_type": "docx"})
+			reqBuilder = reqBuilder.Extra(string(extraJSON))
+		}
+	}
+
+	resp, err := client.Drive.Media.Download(ContextWithTimeout(downloadTimeout), reqBuilder.Build(), reqOpts...)
 	if err != nil {
 		return fmt.Errorf("下载素材失败: %w", err)
 	}
@@ -106,17 +122,25 @@ func DownloadMedia(fileToken string, outputPath string) error {
 }
 
 // GetMediaTempURL gets a temporary download URL for a media file
-func GetMediaTempURL(fileToken string) (string, error) {
+func GetMediaTempURL(fileToken string, opts ...DownloadMediaOptions) (string, error) {
 	client, err := GetClient()
 	if err != nil {
 		return "", err
 	}
 
-	req := larkdrive.NewBatchGetTmpDownloadUrlMediaReqBuilder().
-		FileTokens([]string{fileToken}).
-		Build()
+	reqBuilder := larkdrive.NewBatchGetTmpDownloadUrlMediaReqBuilder().
+		FileTokens([]string{fileToken})
 
-	resp, err := client.Drive.Media.BatchGetTmpDownloadUrl(Context(), req)
+	var reqOpts []larkcore.RequestOptionFunc
+	if len(opts) > 0 {
+		reqOpts = UserTokenOption(opts[0].UserAccessToken)
+		if opts[0].DocToken != "" {
+			extraJSON, _ := json.Marshal(map[string]string{"doc_token": opts[0].DocToken, "obj_type": "docx"})
+			reqBuilder = reqBuilder.Extra(string(extraJSON))
+		}
+	}
+
+	resp, err := client.Drive.Media.BatchGetTmpDownloadUrl(Context(), reqBuilder.Build(), reqOpts...)
 	if err != nil {
 		return "", fmt.Errorf("获取临时下载链接失败: %w", err)
 	}

--- a/internal/client/export.go
+++ b/internal/client/export.go
@@ -8,7 +8,7 @@ import (
 )
 
 // CreateExportTask 创建导出任务，返回任务 ticket
-func CreateExportTask(docToken, docType, fileExtension string) (string, error) {
+func CreateExportTask(docToken, docType, fileExtension, userAccessToken string) (string, error) {
 	client, err := GetClient()
 	if err != nil {
 		return "", err
@@ -24,7 +24,7 @@ func CreateExportTask(docToken, docType, fileExtension string) (string, error) {
 		ExportTask(exportTask).
 		Build()
 
-	resp, err := client.Drive.ExportTask.Create(Context(), req)
+	resp, err := client.Drive.ExportTask.Create(Context(), req, UserTokenOption(userAccessToken)...)
 	if err != nil {
 		return "", fmt.Errorf("创建导出任务失败: %w", err)
 	}
@@ -42,7 +42,7 @@ func CreateExportTask(docToken, docType, fileExtension string) (string, error) {
 
 // GetExportTask 查询导出任务状态，返回 jobStatus、fileToken、error
 // jobStatus: 0=成功, 1=初始化, 2=处理中
-func GetExportTask(ticket, docToken string) (int, string, error) {
+func GetExportTask(ticket, docToken, userAccessToken string) (int, string, error) {
 	client, err := GetClient()
 	if err != nil {
 		return -1, "", err
@@ -53,7 +53,7 @@ func GetExportTask(ticket, docToken string) (int, string, error) {
 		Token(docToken).
 		Build()
 
-	resp, err := client.Drive.ExportTask.Get(Context(), req)
+	resp, err := client.Drive.ExportTask.Get(Context(), req, UserTokenOption(userAccessToken)...)
 	if err != nil {
 		return -1, "", fmt.Errorf("查询导出任务失败: %w", err)
 	}
@@ -83,7 +83,7 @@ func GetExportTask(ticket, docToken string) (int, string, error) {
 }
 
 // DownloadExportFile 下载导出任务生成的文件
-func DownloadExportFile(fileToken, outputPath string) error {
+func DownloadExportFile(fileToken, outputPath, userAccessToken string) error {
 	if err := validatePath(outputPath); err != nil {
 		return err
 	}
@@ -97,7 +97,7 @@ func DownloadExportFile(fileToken, outputPath string) error {
 		FileToken(fileToken).
 		Build()
 
-	resp, err := client.Drive.ExportTask.Download(ContextWithTimeout(downloadTimeout), req)
+	resp, err := client.Drive.ExportTask.Download(ContextWithTimeout(downloadTimeout), req, UserTokenOption(userAccessToken)...)
 	if err != nil {
 		return fmt.Errorf("下载导出文件失败: %w", err)
 	}
@@ -110,9 +110,9 @@ func DownloadExportFile(fileToken, outputPath string) error {
 }
 
 // WaitExportTask 轮询等待导出任务完成，返回导出文件的 fileToken
-func WaitExportTask(ticket, docToken string, maxRetries int) (string, error) {
+func WaitExportTask(ticket, docToken, userAccessToken string, maxRetries int) (string, error) {
 	for i := 0; i < maxRetries; i++ {
-		jobStatus, fileToken, err := GetExportTask(ticket, docToken)
+		jobStatus, fileToken, err := GetExportTask(ticket, docToken, userAccessToken)
 		if err != nil {
 			return "", err
 		}

--- a/internal/converter/block_to_markdown.go
+++ b/internal/converter/block_to_markdown.go
@@ -764,17 +764,28 @@ func (c *BlockToMarkdown) convertImage(block *larkdocx.Block) (string, error) {
 
 		localPath := filepath.Join(c.options.AssetsDir, filename)
 
+		dlOpts := client.DownloadMediaOptions{
+			UserAccessToken: c.options.UserAccessToken,
+			DocToken:        c.options.DocumentID,
+		}
+
 		// 方式一：获取临时 URL 后下载
-		tmpURL, urlErr := client.GetMediaTempURL(token)
+		tmpURL, urlErr := client.GetMediaTempURL(token, dlOpts)
 		if urlErr == nil {
 			if dlErr := client.DownloadFromURL(tmpURL, localPath); dlErr == nil {
 				return fmt.Sprintf("![%s](%s)\n", alt, localPath), nil
+			} else if c.options.Debug {
+				fmt.Fprintf(os.Stderr, "[Debug] 图片下载失败 (URL方式): %v\n", dlErr)
 			}
+		} else if c.options.Debug {
+			fmt.Fprintf(os.Stderr, "[Debug] 获取图片临时URL失败: %v\n", urlErr)
 		}
 
 		// 方式二：SDK 直接下载
-		if sdkErr := client.DownloadMedia(token, localPath); sdkErr == nil {
+		if sdkErr := client.DownloadMedia(token, localPath, dlOpts); sdkErr == nil {
 			return fmt.Sprintf("![%s](%s)\n", alt, localPath), nil
+		} else if c.options.Debug {
+			fmt.Fprintf(os.Stderr, "[Debug] 图片SDK下载失败: %v\n", sdkErr)
 		}
 
 		// 全部失败，保留 token 引用（可能因权限不足）
@@ -1061,8 +1072,10 @@ func (c *BlockToMarkdown) convertBoard(block *larkdocx.Block) (string, error) {
 
 		localPath := filepath.Join(c.options.AssetsDir, filename)
 
-		if err := client.GetBoardImage(token, localPath); err == nil {
+		if err := client.GetBoardImage(token, localPath, c.options.UserAccessToken); err == nil {
 			return fmt.Sprintf("![画板](%s)\n", localPath), nil
+		} else if c.options.Debug {
+			fmt.Fprintf(os.Stderr, "[Debug] 画板下载失败: %v\n", err)
 		}
 	}
 

--- a/internal/converter/types.go
+++ b/internal/converter/types.go
@@ -97,10 +97,12 @@ type ConvertOptions struct {
 	AssetsDir           string
 	UploadImages        bool
 	DocumentID          string
-	DegradeDeepHeadings bool // 为 true 时，Heading 7-9 输出为粗体段落而非 ######
-	FrontMatter         bool // 为 true 时，导出时添加 YAML front matter
-	Highlight           bool // 为 true 时，导出文本颜色和背景色为 HTML span
-	ExpandMentions      bool // 导出时展开 @用户为友好格式（默认 false，CLI 默认 true）
+	UserAccessToken     string // User Access Token，用于下载图片和画板等需要权限的资源
+	Debug               bool   // 为 true 时，输出下载失败等调试信息到 stderr
+	DegradeDeepHeadings bool   // 为 true 时，Heading 7-9 输出为粗体段落而非 ######
+	FrontMatter         bool   // 为 true 时，导出时添加 YAML front matter
+	Highlight           bool   // 为 true 时，导出文本颜色和背景色为 HTML span
+	ExpandMentions      bool   // 导出时展开 @用户为友好格式（默认 false，CLI 默认 true）
 }
 
 // ConvertResult contains converted blocks and table data


### PR DESCRIPTION
## Summary

- **User Token 全链路透传**：doc export、wiki export、export-file、图片/画板下载全部支持 User Access Token，使用户可以导出无 App 权限但有个人权限的文档
- **API 一致性修复**：`export_wiki.go` 中 Token 解析统一为命令开头一次 `resolveOptionalUserTokenWithFallback`，消除同一命令中两个 API 调用使用不同身份的风险
- **安全性改进**：`drive.go` 中 JSON 拼接从 `fmt.Sprintf` 改为 `json.Marshal`，防止 DocToken 含特殊字符时的 JSON 格式错误
- 新增 debug 日志，下载失败时输出调试信息到 stderr

## Changes

| 文件 | 改动 |
|------|------|
| `cmd/export_wiki.go` | Token 解析统一为一次，传给 GetWikiNode 和 GetAllBlocksWithToken |
| `cmd/export_markdown.go` | 传递 UserAccessToken 和 Debug 到 ConvertOptions |
| `cmd/export_file.go` | 新增 `--user-access-token` flag，透传到导出任务全流程 |
| `cmd/utils.go` | `resolveOptionalUserTokenWithFallback` 增加错误处理和 debug 日志 |
| `internal/client/drive.go` | DownloadMedia/GetMediaTempURL 支持 User Token 和 DocToken；JSON 构建改用 json.Marshal |
| `internal/client/board.go` | GetBoardImage 支持可选 User Token |
| `internal/client/export.go` | CreateExportTask/GetExportTask/DownloadExportFile/WaitExportTask 支持 User Token |
| `internal/converter/block_to_markdown.go` | 图片和画板下载传递 User Token；增加 debug 日志 |
| `internal/converter/types.go` | ConvertOptions 新增 UserAccessToken 和 Debug 字段 |

## Test plan

- [x] `go build` 编译通过
- [x] `go vet ./...` 静态检查通过
- [ ] 使用 App Token 导出文档（回归测试，行为不变）
- [ ] 使用 User Token（`--user-access-token` 或 `auth login`）导出个人知识库文档
- [ ] 使用 `--download-images` 验证图片下载透传 User Token
- [ ] 使用 `export-file --type pdf --user-access-token` 导出 PDF

🤖 Generated with [Claude Code](https://claude.com/claude-code)