### PR TITLE
fix: accept IM API style member type aliases in perm commands

### DIFF
--- a/cmd/add_permission.go
+++ b/cmd/add_permission.go
@@ -27,10 +27,10 @@ var addPermissionCmd = &cobra.Command{
 
 成员类型:
   email             邮箱
-  openid            Open ID
-  userid            用户 ID
-  unionid           Union ID
-  openchat          群组 ID
+  openid/open_id    Open ID
+  userid/user_id    用户 ID
+  unionid/union_id  Union ID
+  openchat/chat_id  群组 ID
   opendepartmentid  部门 ID
   groupid           群组 ID
   wikispaceid       知识空间 ID
@@ -63,6 +63,8 @@ var addPermissionCmd = &cobra.Command{
 		perm, _ := cmd.Flags().GetString("perm")
 		notification, _ := cmd.Flags().GetBool("notification")
 
+		memberType = normalizePermMemberType(memberType)
+
 		member := client.PermissionMember{
 			MemberType: memberType,
 			MemberID:   memberID,
@@ -84,7 +86,7 @@ var addPermissionCmd = &cobra.Command{
 func init() {
 	permCmd.AddCommand(addPermissionCmd)
 	addPermissionCmd.Flags().String("doc-type", "docx", "文档类型（docx/sheet/bitable 等）")
-	addPermissionCmd.Flags().String("member-type", "", "成员类型（email/openid/userid 等）")
+	addPermissionCmd.Flags().String("member-type", "", "成员类型（email/openid/open_id/userid/user_id 等）")
 	addPermissionCmd.Flags().String("member-id", "", "成员标识")
 	addPermissionCmd.Flags().String("perm", "", "权限级别（view/edit/full_access）")
 	addPermissionCmd.Flags().Bool("notification", false, "发送通知给成员")

--- a/cmd/batch_add_permission.go
+++ b/cmd/batch_add_permission.go
@@ -65,6 +65,7 @@ var batchAddPermissionCmd = &cobra.Command{
 		}
 
 		for i, m := range members {
+			m.MemberType = normalizePermMemberType(m.MemberType)
 			if m.MemberType == "" {
 				return fmt.Errorf("第 %d 个成员的 member_type 不能为空", i+1)
 			}

--- a/cmd/delete_permission.go
+++ b/cmd/delete_permission.go
@@ -21,10 +21,10 @@ var deletePermissionCmd = &cobra.Command{
 
 成员类型:
   email             邮箱
-  openid            Open ID
-  userid            用户 ID
-  unionid           Union ID
-  openchat          群组 ID
+  openid/open_id    Open ID
+  userid/user_id    用户 ID
+  unionid/union_id  Union ID
+  openchat/chat_id  群组 ID
   opendepartmentid  部门 ID
   groupid           群组 ID
   wikispaceid       知识空间 ID
@@ -51,6 +51,8 @@ var deletePermissionCmd = &cobra.Command{
 		memberType, _ := cmd.Flags().GetString("member-type")
 		memberID, _ := cmd.Flags().GetString("member-id")
 
+		memberType = normalizePermMemberType(memberType)
+
 		if err := client.DeletePermission(docToken, docType, memberType, memberID); err != nil {
 			return err
 		}
@@ -65,7 +67,7 @@ var deletePermissionCmd = &cobra.Command{
 func init() {
 	permCmd.AddCommand(deletePermissionCmd)
 	deletePermissionCmd.Flags().String("doc-type", "docx", "文档类型（docx/sheet/bitable 等）")
-	deletePermissionCmd.Flags().String("member-type", "", "成员类型（email/openid/userid 等）")
+	deletePermissionCmd.Flags().String("member-type", "", "成员类型（email/openid/open_id/userid/user_id 等）")
 	deletePermissionCmd.Flags().String("member-id", "", "成员标识")
 	mustMarkFlagRequired(deletePermissionCmd, "member-type", "member-id")
 }

--- a/cmd/perm.go
+++ b/cmd/perm.go
@@ -26,12 +26,12 @@ var permCmd = &cobra.Command{
   edit         编辑权限
   full_access  完全访问权限
 
-成员类型:
+成员类型（也接受 open_id/user_id/union_id/chat_id 等 IM API 风格的别名）:
   email             邮箱
-  openid            Open ID
-  userid            用户 ID
-  unionid           Union ID
-  openchat          群组 ID
+  openid/open_id    Open ID
+  userid/user_id    用户 ID
+  unionid/union_id  Union ID
+  openchat/chat_id  群组 ID
   opendepartmentid  部门 ID
 
 示例:

--- a/cmd/transfer_owner_permission.go
+++ b/cmd/transfer_owner_permission.go
@@ -24,9 +24,9 @@ var transferOwnerCmd = &cobra.Command{
   --old-owner-perm     原所有者保留权限（默认: full_access，仅 remove-old-owner=false 时生效）
 
 成员类型:
-  email     飞书邮箱
-  openid    开放平台 ID
-  userid    用户自定义 ID
+  email             飞书邮箱
+  openid/open_id    开放平台 ID
+  userid/user_id    用户自定义 ID
 
 文档类型:
   docx      新版文档（默认）
@@ -72,6 +72,8 @@ var transferOwnerCmd = &cobra.Command{
 		stayPut, _ := cmd.Flags().GetBool("stay-put")
 		oldOwnerPerm, _ := cmd.Flags().GetString("old-owner-perm")
 
+		memberType = normalizePermMemberType(memberType)
+
 		if err := client.TransferOwnership(docToken, docType, memberType, memberID, notification, removeOldOwner, stayPut, oldOwnerPerm); err != nil {
 			return err
 		}
@@ -91,7 +93,7 @@ var transferOwnerCmd = &cobra.Command{
 func init() {
 	permCmd.AddCommand(transferOwnerCmd)
 	transferOwnerCmd.Flags().String("doc-type", "docx", "文档类型（docx/sheet/bitable 等）")
-	transferOwnerCmd.Flags().String("member-type", "", "新所有者类型（email/openid/userid）")
+	transferOwnerCmd.Flags().String("member-type", "", "新所有者类型（email/openid/open_id/userid/user_id）")
 	transferOwnerCmd.Flags().String("member-id", "", "新所有者标识")
 	transferOwnerCmd.Flags().Bool("notification", true, "通知新所有者")
 	transferOwnerCmd.Flags().Bool("remove-old-owner", false, "移除原所有者权限")

--- a/cmd/update_permission.go
+++ b/cmd/update_permission.go
@@ -27,10 +27,10 @@ var updatePermissionCmd = &cobra.Command{
 
 成员类型:
   email             邮箱
-  openid            Open ID
-  userid            用户 ID
-  unionid           Union ID
-  openchat          群组 ID
+  openid/open_id    Open ID
+  userid/user_id    用户 ID
+  unionid/union_id  Union ID
+  openchat/chat_id  群组 ID
   opendepartmentid  部门 ID
   groupid           群组 ID
   wikispaceid       知识空间 ID
@@ -61,6 +61,8 @@ var updatePermissionCmd = &cobra.Command{
 		memberID, _ := cmd.Flags().GetString("member-id")
 		perm, _ := cmd.Flags().GetString("perm")
 
+		memberType = normalizePermMemberType(memberType)
+
 		if err := client.UpdatePermission(docToken, docType, memberID, memberType, perm); err != nil {
 			return err
 		}
@@ -76,7 +78,7 @@ var updatePermissionCmd = &cobra.Command{
 func init() {
 	permCmd.AddCommand(updatePermissionCmd)
 	updatePermissionCmd.Flags().String("doc-type", "docx", "文档类型（docx/sheet/bitable 等）")
-	updatePermissionCmd.Flags().String("member-type", "", "成员类型（email/openid/userid 等）")
+	updatePermissionCmd.Flags().String("member-type", "", "成员类型（email/openid/open_id/userid/user_id 等）")
 	updatePermissionCmd.Flags().String("member-id", "", "成员标识")
 	updatePermissionCmd.Flags().String("perm", "", "新权限级别（view/edit/full_access）")
 	mustMarkFlagRequired(updatePermissionCmd, "member-type", "member-id", "perm")

--- a/cmd/utils.go
+++ b/cmd/utils.go
@@ -153,6 +153,25 @@ func isValidToken(token string) bool {
 	return true
 }
 
+// normalizePermMemberType normalizes member type aliases for the Drive permission API.
+// The IM API uses underscore-separated identifiers (open_id, user_id, union_id, chat_id),
+// while the Drive permission API uses concatenated identifiers (openid, userid, unionid, openchat).
+// This function accepts both styles so users don't have to remember which API uses which format.
+func normalizePermMemberType(memberType string) string {
+	switch memberType {
+	case "open_id":
+		return "openid"
+	case "user_id":
+		return "userid"
+	case "union_id":
+		return "unionid"
+	case "chat_id":
+		return "openchat"
+	default:
+		return memberType
+	}
+}
+
 // splitAndTrim 按逗号分割字符串并去除空白
 func splitAndTrim(s string) []string {
 	parts := strings.Split(s, ",")

--- a/cmd/utils_test.go
+++ b/cmd/utils_test.go
@@ -319,6 +319,40 @@ func TestMustMarkFlagRequired_EmptyFlags(t *testing.T) {
 	mustMarkFlagRequired(cmd)
 }
 
+func TestNormalizePermMemberType(t *testing.T) {
+	tests := []struct {
+		input    string
+		expected string
+	}{
+		// Underscore aliases (IM API style) → Drive API style
+		{"open_id", "openid"},
+		{"user_id", "userid"},
+		{"union_id", "unionid"},
+		{"chat_id", "openchat"},
+		// Already correct Drive API values → unchanged
+		{"openid", "openid"},
+		{"userid", "userid"},
+		{"unionid", "unionid"},
+		{"openchat", "openchat"},
+		{"email", "email"},
+		{"opendepartmentid", "opendepartmentid"},
+		{"groupid", "groupid"},
+		{"wikispaceid", "wikispaceid"},
+		// Unknown values → pass through unchanged
+		{"something_else", "something_else"},
+		{"", ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			result := normalizePermMemberType(tt.input)
+			if result != tt.expected {
+				t.Errorf("normalizePermMemberType(%q) = %q, expected %q", tt.input, result, tt.expected)
+			}
+		})
+	}
+}
+
 // 测试 validateOutputPath 与允许目录的交互
 func TestValidateOutputPath_WithAllowedDir(t *testing.T) {
 	tmpDir := t.TempDir()

--- a/cmd/wiki_member.go
+++ b/cmd/wiki_member.go
@@ -19,11 +19,11 @@ var wikiMemberCmd = &cobra.Command{
   remove    移除成员
 
 成员类型 (--member-type):
-  openchat          群 ID
-  userid            用户 ID
-  email             邮箱
-  opendepartmentid  部门 ID
-  openid            Open ID
+  openchat/chat_id      群 ID
+  userid/user_id        用户 ID
+  email                 邮箱
+  opendepartmentid      部门 ID
+  openid/open_id        Open ID
 
 角色 (--role):
   admin    管理员
@@ -58,6 +58,8 @@ var wikiMemberAddCmd = &cobra.Command{
 		memberType, _ := cmd.Flags().GetString("member-type")
 		memberID, _ := cmd.Flags().GetString("member-id")
 		role, _ := cmd.Flags().GetString("role")
+
+		memberType = normalizePermMemberType(memberType)
 
 		if err := client.AddWikiSpaceMember(spaceID, memberType, memberID, role, resolveOptionalUserToken(cmd)); err != nil {
 			return err
@@ -147,6 +149,8 @@ var wikiMemberRemoveCmd = &cobra.Command{
 		memberType, _ := cmd.Flags().GetString("member-type")
 		memberID, _ := cmd.Flags().GetString("member-id")
 		role, _ := cmd.Flags().GetString("role")
+
+		memberType = normalizePermMemberType(memberType)
 
 		if err := client.RemoveWikiSpaceMember(spaceID, memberType, memberID, role, resolveOptionalUserToken(cmd)); err != nil {
 			return err


### PR DESCRIPTION
## Summary

- The Feishu IM API uses underscore-separated identifiers (`open_id`, `user_id`, `union_id`, `chat_id`), while the Drive permission API uses concatenated ones (`openid`, `userid`, `unionid`, `openchat`). Users who learn `--receive-id-type open_id` from `msg send` naturally try `--member-type open_id` in `perm add`, which fails with a confusing `code=99992402, msg=field validation failed` error.
- Added `normalizePermMemberType()` to accept both styles, automatically converting IM API aliases to Drive API format
- Applied to: `perm add/delete/update/transfer-owner/batch-add` and `wiki member add/remove`
- Updated help text to document both accepted formats
- Added unit tests covering all aliases and pass-through cases

## Test plan

- [x] `TestNormalizePermMemberType` passes all 14 cases (aliases, native values, unknown values, empty string)
- [x] Manual: `feishu-cli perm add <token> --member-type open_id --member-id ou_xxx --perm view` should succeed (previously failed)
- [x] Manual: `feishu-cli perm add <token> --member-type openid --member-id ou_xxx --perm view` still works as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)