### PR TITLE
feat: add --file and --image flags to msg send

### DIFF
--- a/cmd/msg.go
+++ b/cmd/msg.go
@@ -44,6 +44,18 @@ var msgCmd = &cobra.Command{
     --receive-id user@example.com \
     --text "你好，这是一条测试消息"
 
+  # 直接发送本地文件（自动上传）
+  feishu-cli msg send \
+    --receive-id-type chat_id \
+    --receive-id oc_xxx \
+    --file /path/to/report.pdf
+
+  # 直接发送本地图片（自动上传）
+  feishu-cli msg send \
+    --receive-id-type chat_id \
+    --receive-id oc_xxx \
+    --image /path/to/screenshot.png
+
   # 回复消息
   feishu-cli msg reply om_xxx --text "收到！"
 

--- a/cmd/send_message.go
+++ b/cmd/send_message.go
@@ -1,8 +1,10 @@
 package cmd
 
 import (
+	"encoding/json"
 	"fmt"
 	"os"
+	"path/filepath"
 
 	"github.com/riba2534/feishu-cli/internal/client"
 	"github.com/riba2534/feishu-cli/internal/config"
@@ -21,6 +23,8 @@ var sendMessageCmd = &cobra.Command{
   --content, -c       消息内容 JSON
   --content-file      消息内容 JSON 文件
   --text, -t          简单文本消息（快捷方式）
+  --file, -f          发送本地文件（自动上传并发送，快捷方式）
+  --image             发送本地图片（自动上传并发送，快捷方式）
   --output, -o        输出格式（json）
 
 接收者类型:
@@ -55,6 +59,18 @@ var sendMessageCmd = &cobra.Command{
     --receive-id oc_xxx \
     --text "群消息"
 
+  # 直接发送本地文件（自动上传）
+  feishu-cli msg send \
+    --receive-id-type chat_id \
+    --receive-id oc_xxx \
+    --file /path/to/report.pdf
+
+  # 直接发送本地图片（自动上传）
+  feishu-cli msg send \
+    --receive-id-type chat_id \
+    --receive-id oc_xxx \
+    --image /path/to/screenshot.png
+
   # 发送卡片消息
   feishu-cli msg send \
     --receive-id-type email \
@@ -74,21 +90,49 @@ var sendMessageCmd = &cobra.Command{
 		content, _ := cmd.Flags().GetString("content")
 		contentFile, _ := cmd.Flags().GetString("content-file")
 		text, _ := cmd.Flags().GetString("text")
+		filePath, _ := cmd.Flags().GetString("file")
+		imagePath, _ := cmd.Flags().GetString("image")
 
 		var msgContent string
-		if contentFile != "" {
+		switch {
+		case filePath != "":
+			// Upload file via IM API, then send as file message
+			fmt.Printf("正在上传文件: %s\n", filepath.Base(filePath))
+			fileKey, err := client.UploadIMFile(filePath, "")
+			if err != nil {
+				return err
+			}
+			msgType = "file"
+			contentJSON, _ := json.Marshal(map[string]string{"file_key": fileKey})
+			msgContent = string(contentJSON)
+
+		case imagePath != "":
+			// Upload image via IM API, then send as image message
+			fmt.Printf("正在上传图片: %s\n", filepath.Base(imagePath))
+			imageKey, err := client.UploadIMImage(imagePath)
+			if err != nil {
+				return err
+			}
+			msgType = "image"
+			contentJSON, _ := json.Marshal(map[string]string{"image_key": imageKey})
+			msgContent = string(contentJSON)
+
+		case contentFile != "":
 			data, err := os.ReadFile(contentFile)
 			if err != nil {
 				return fmt.Errorf("读取内容文件失败: %w", err)
 			}
 			msgContent = string(data)
-		} else if content != "" {
+
+		case content != "":
 			msgContent = content
-		} else if text != "" {
+
+		case text != "":
 			msgType = "text"
 			msgContent = client.CreateTextMessageContent(text)
-		} else {
-			return fmt.Errorf("必须指定 --content、--content-file 或 --text")
+
+		default:
+			return fmt.Errorf("必须指定 --content、--content-file、--text、--file 或 --image")
 		}
 
 		messageID, err := client.SendMessage(receiveIDType, receiveID, msgType, msgContent, token)
@@ -120,6 +164,8 @@ func init() {
 	sendMessageCmd.Flags().StringP("content", "c", "", "消息内容 JSON")
 	sendMessageCmd.Flags().String("content-file", "", "消息内容 JSON 文件")
 	sendMessageCmd.Flags().StringP("text", "t", "", "简单文本消息")
+	sendMessageCmd.Flags().StringP("file", "f", "", "发送本地文件（自动上传并发送）")
+	sendMessageCmd.Flags().String("image", "", "发送本地图片（自动上传并发送）")
 	sendMessageCmd.Flags().StringP("output", "o", "", "输出格式（json）")
 	sendMessageCmd.Flags().String("user-access-token", "", "User Access Token（用户授权令牌）")
 	mustMarkFlagRequired(sendMessageCmd, "receive-id-type", "receive-id")

--- a/internal/client/im_upload.go
+++ b/internal/client/im_upload.go
@@ -1,0 +1,113 @@
+package client
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	larkim "github.com/larksuite/oapi-sdk-go/v3/service/im/v1"
+)
+
+// fileExtToIMType maps common file extensions to Feishu IM file_type values.
+// Falls back to "stream" for unknown extensions.
+func fileExtToIMType(filename string) string {
+	ext := strings.ToLower(filepath.Ext(filename))
+	switch ext {
+	case ".opus":
+		return "opus"
+	case ".mp4":
+		return "mp4"
+	case ".pdf":
+		return "pdf"
+	case ".doc", ".docx":
+		return "doc"
+	case ".xls", ".xlsx":
+		return "xls"
+	case ".ppt", ".pptx":
+		return "ppt"
+	default:
+		return "stream"
+	}
+}
+
+// UploadIMFile uploads a local file via the IM API (/open-apis/im/v1/files)
+// and returns the file_key that can be used directly in msg send --msg-type file.
+func UploadIMFile(filePath string, fileName string) (string, error) {
+	client, err := GetClient()
+	if err != nil {
+		return "", err
+	}
+
+	f, err := os.Open(filePath)
+	if err != nil {
+		return "", fmt.Errorf("打开文件失败: %w", err)
+	}
+	defer f.Close()
+
+	if fileName == "" {
+		fileName = filepath.Base(filePath)
+	}
+
+	fileType := fileExtToIMType(fileName)
+
+	req := larkim.NewCreateFileReqBuilder().
+		Body(larkim.NewCreateFileReqBodyBuilder().
+			FileType(fileType).
+			FileName(fileName).
+			File(f).
+			Build()).
+		Build()
+
+	resp, err := client.Im.File.Create(Context(), req)
+	if err != nil {
+		return "", fmt.Errorf("上传文件失败: %w", err)
+	}
+
+	if !resp.Success() {
+		return "", fmt.Errorf("上传文件失败: code=%d, msg=%s", resp.Code, resp.Msg)
+	}
+
+	if resp.Data == nil || resp.Data.FileKey == nil {
+		return "", fmt.Errorf("上传文件成功但未返回 file_key")
+	}
+
+	return *resp.Data.FileKey, nil
+}
+
+// UploadIMImage uploads a local image via the IM API (/open-apis/im/v1/images)
+// and returns the image_key that can be used directly in msg send --msg-type image.
+func UploadIMImage(filePath string) (string, error) {
+	client, err := GetClient()
+	if err != nil {
+		return "", err
+	}
+
+	f, err := os.Open(filePath)
+	if err != nil {
+		return "", fmt.Errorf("打开图片失败: %w", err)
+	}
+	defer f.Close()
+
+	req := larkim.NewCreateImageReqBuilder().
+		Body(larkim.NewCreateImageReqBodyBuilder().
+			ImageType("message").
+			Image(f).
+			Build()).
+		Build()
+
+	resp, err := client.Im.Image.Create(Context(), req)
+	if err != nil {
+		return "", fmt.Errorf("上传图片失败: %w", err)
+	}
+
+	if !resp.Success() {
+		return "", fmt.Errorf("上传图片失败: code=%d, msg=%s", resp.Code, resp.Msg)
+	}
+
+	if resp.Data == nil || resp.Data.ImageKey == nil {
+		return "", fmt.Errorf("上传图片成功但未返回 image_key")
+	}
+
+	return *resp.Data.ImageKey, nil
+}


### PR DESCRIPTION
## Summary

- Add `--file` / `-f` flag to `msg send` that uploads a local file via the IM API (`/open-apis/im/v1/files`) and sends it as a file message in one command
- Add `--image` flag to `msg send` that uploads a local image via the IM API (`/open-apis/im/v1/images`) and sends it as an image message in one command
- Previously sending files required `file upload` (Drive API) + manual JSON construction, which failed with `code=230017 Bot is NOT the owner of the resource` because Drive uploads and IM messages use different APIs with different ownership models

## Usage

```bash
# Send a file (one command instead of two)
feishu-cli msg send \
  --receive-id-type chat_id \
  --receive-id oc_xxx \
  --file /path/to/report.pdf

# Send an image
feishu-cli msg send \
  --receive-id-type open_id \
  --receive-id ou_xxx \
  --image /path/to/screenshot.png
```

## Changes

- `internal/client/im_upload.go` — new `UploadIMFile()` and `UploadIMImage()` functions using the IM API
- `cmd/send_message.go` — added `--file` and `--image` flags with auto-upload logic
- `cmd/msg.go` — updated help text with new examples
- Common file types (pdf, doc, xls, ppt, mp4, opus) are auto-detected by extension; unknown types fall back to `stream`

## Test plan

- [x] `go build` compiles cleanly
- [x] All existing tests pass
- [x] Manual: `feishu-cli msg send --receive-id-type open_id --receive-id ou_xxx --file test.pdf` uploads and sends successfully
- [x] Manual: `feishu-cli msg send --receive-id-type chat_id --receive-id oc_xxx --image test.png` uploads and sends successfully
- [x] Manual: existing `--text`, `--content`, `--content-file` flags still work as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)