### PR TITLE
feat: 支持 Task 块（type=35）导入导出

### DIFF
--- a/internal/converter/block_to_markdown.go
+++ b/internal/converter/block_to_markdown.go
@@ -438,6 +438,8 @@ func (c *BlockToMarkdown) convertBlockWithDepth(block *larkdocx.Block, indent in
 		return "[知识库目录 V2]\n", nil
 	case BlockTypeAITemplate:
 		return "<!-- AI 模板块 -->\n", nil
+	case BlockTypeTask:
+		return c.convertTask(block)
 	default:
 		typeName := BlockTypeName(blockType)
 		return fmt.Sprintf("<!-- 不支持的块类型: %s (type=%d) -->\n", typeName, int(blockType)), nil
@@ -722,6 +724,14 @@ func (c *BlockToMarkdown) convertTodo(block *larkdocx.Block) (string, error) {
 
 	text := c.convertTextElements(block.Todo.Elements)
 	return fmt.Sprintf("- %s %s\n", checkbox, text), nil
+}
+
+func (c *BlockToMarkdown) convertTask(block *larkdocx.Block) (string, error) {
+	taskID := ""
+	if block.Task != nil && block.Task.TaskId != nil {
+		taskID = *block.Task.TaskId
+	}
+	return fmt.Sprintf("<!-- task:%s -->\n", taskID), nil
 }
 
 func (c *BlockToMarkdown) convertImage(block *larkdocx.Block) (string, error) {

--- a/internal/converter/block_to_markdown_test.go
+++ b/internal/converter/block_to_markdown_test.go
@@ -1373,3 +1373,73 @@ func TestBlockTypeName(t *testing.T) {
 		})
 	}
 }
+
+func TestConvertTaskBlock(t *testing.T) {
+	tests := []struct {
+		name     string
+		taskID   string
+		expected string
+	}{
+		{
+			name:     "task block with ID",
+			taskID:   "463d80ff-6fe3-4646-83b1-5bc18d894872",
+			expected: "<!-- task:463d80ff-6fe3-4646-83b1-5bc18d894872 -->\n",
+		},
+		{
+			name:     "task block with empty ID",
+			taskID:   "",
+			expected: "<!-- task: -->\n",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			blockType := int(BlockTypeTask)
+			pageType := int(BlockTypePage)
+			taskBlock := &larkdocx.Block{
+				BlockId:   strPtr("task_block_1"),
+				BlockType: &blockType,
+				Task:      larkdocx.NewTaskBuilder().TaskId(tt.taskID).Build(),
+			}
+			pageBlock := &larkdocx.Block{
+				BlockId:   strPtr("page"),
+				BlockType: &pageType,
+				Children:  []string{"task_block_1"},
+			}
+			blocks := []*larkdocx.Block{pageBlock, taskBlock}
+			converter := NewBlockToMarkdown(blocks, ConvertOptions{})
+			result, err := converter.Convert()
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if !strings.Contains(result, tt.expected) {
+				t.Errorf("expected %q in result, got:\n%s", tt.expected, result)
+			}
+		})
+	}
+}
+
+func TestConvertTaskBlockNilTask(t *testing.T) {
+	blockType := int(BlockTypeTask)
+	pageType := int(BlockTypePage)
+	taskBlock := &larkdocx.Block{
+		BlockId:   strPtr("task_block_nil"),
+		BlockType: &blockType,
+		Task:      nil,
+	}
+	pageBlock := &larkdocx.Block{
+		BlockId:   strPtr("page"),
+		BlockType: &pageType,
+		Children:  []string{"task_block_nil"},
+	}
+	blocks := []*larkdocx.Block{pageBlock, taskBlock}
+	converter := NewBlockToMarkdown(blocks, ConvertOptions{})
+	result, err := converter.Convert()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	expected := "<!-- task: -->\n"
+	if !strings.Contains(result, expected) {
+		t.Errorf("expected %q in result, got:\n%s", expected, result)
+	}
+}

--- a/internal/converter/markdown_to_block.go
+++ b/internal/converter/markdown_to_block.go
@@ -33,6 +33,33 @@ const (
 	columnPadding    = 16  // 列内边距
 )
 
+// taskCommentRegex 匹配 <!-- task:TASK_ID --> 格式的 HTML 注释
+var taskCommentRegex = regexp.MustCompile(`<!--\s*task:([^\s]*)\s*-->`)
+
+// convertHTMLBlock 处理 HTML 块，识别特殊的 task 注释
+func (c *MarkdownToBlock) convertHTMLBlock(node *ast.HTMLBlock) *larkdocx.Block {
+	var buf bytes.Buffer
+	lines := node.Lines()
+	for i := 0; i < lines.Len(); i++ {
+		seg := lines.At(i)
+		buf.Write(c.source[seg.Start:seg.Stop])
+	}
+	raw := strings.TrimSpace(buf.String())
+
+	// 匹配 <!-- task:TASK_ID -->
+	if m := taskCommentRegex.FindStringSubmatch(raw); m != nil {
+		taskID := m[1]
+		blockType := int(BlockTypeTask)
+		block := &larkdocx.Block{
+			BlockType: &blockType,
+			Task: larkdocx.NewTaskBuilder().TaskId(taskID).Build(),
+		}
+		return block
+	}
+
+	return nil
+}
+
 // calculateColumnWidths 根据单元格内容计算每列的宽度
 func calculateColumnWidths(headerContents []string, dataRows [][]string, cols int) []int {
 	if cols == 0 {
@@ -222,6 +249,13 @@ func (c *MarkdownToBlock) ConvertWithTableData() (*ConvertResult, error) {
 		case *ast.ThematicBreak:
 			result.BlockNodes = append(result.BlockNodes, &BlockNode{Block: c.createDividerBlock()})
 			return ast.WalkContinue, nil
+
+		case *ast.HTMLBlock:
+			block := c.convertHTMLBlock(node)
+			if block != nil {
+				result.BlockNodes = append(result.BlockNodes, &BlockNode{Block: block})
+			}
+			return ast.WalkSkipChildren, nil
 		}
 
 		return ast.WalkContinue, nil

--- a/internal/converter/markdown_to_block_test.go
+++ b/internal/converter/markdown_to_block_test.go
@@ -829,3 +829,71 @@ func TestConvert_AnchorLink(t *testing.T) {
 		}
 	}
 }
+
+func TestConvertTaskComment(t *testing.T) {
+	tests := []struct {
+		name       string
+		markdown   string
+		expectTask bool
+		taskID     string
+	}{
+		{
+			name:       "task comment with ID",
+			markdown:   "<!-- task:463d80ff-6fe3-4646-83b1-5bc18d894872 -->",
+			expectTask: true,
+			taskID:     "463d80ff-6fe3-4646-83b1-5bc18d894872",
+		},
+		{
+			name:       "task comment with empty ID",
+			markdown:   "<!-- task: -->",
+			expectTask: true,
+			taskID:     "",
+		},
+		{
+			name:       "task comment with spaces",
+			markdown:   "<!--  task:abc-123  -->",
+			expectTask: true,
+			taskID:     "abc-123",
+		},
+		{
+			name:       "non-task HTML comment",
+			markdown:   "<!-- some other comment -->",
+			expectTask: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			converter := NewMarkdownToBlock([]byte(tt.markdown), ConvertOptions{}, "")
+			result, err := converter.ConvertWithTableData()
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+
+			if tt.expectTask {
+				found := false
+				for _, node := range result.BlockNodes {
+					if node.Block.BlockType != nil && *node.Block.BlockType == int(BlockTypeTask) {
+						found = true
+						if node.Block.Task != nil && node.Block.Task.TaskId != nil {
+							if *node.Block.Task.TaskId != tt.taskID {
+								t.Errorf("task_id = %q, want %q", *node.Block.Task.TaskId, tt.taskID)
+							}
+						} else if tt.taskID != "" {
+							t.Errorf("expected task_id %q, got nil", tt.taskID)
+						}
+					}
+				}
+				if !found {
+					t.Error("expected Task block but not found")
+				}
+			} else {
+				for _, node := range result.BlockNodes {
+					if node.Block.BlockType != nil && *node.Block.BlockType == int(BlockTypeTask) {
+						t.Error("unexpected Task block found")
+					}
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

- **导出**：Task 块（type=35）从 `<!-- 不支持的块类型: Task (type=35) -->` 改为导出为 `<!-- task:TASK_ID -->` 格式，保留任务 ID 信息
- **导入**：新增识别 `<!-- task:TASK_ID -->` HTML 注释，自动创建对应的飞书 Task 块
- 新增完整的单元测试覆盖导入导出两个方向

## 背景

飞书文档中的 Task 块（type=35）此前在导出时被标记为"不支持的块类型"，导致内容丢失。此 PR 通过 HTML 注释格式实现 Task 块的无损往返转换。

## 改动文件

| 文件 | 改动 |
|------|------|
| `block_to_markdown.go` | 新增 `convertTask` 方法，Task 块导出为 `<!-- task:TASK_ID -->` |
| `markdown_to_block.go` | 新增 `convertHTMLBlock` 方法，识别 task 注释并创建 Task 块 |
| `block_to_markdown_test.go` | Task 块导出测试（含 ID / 空 ID / nil Task） |
| `markdown_to_block_test.go` | Task 块导入测试（含 ID / 空 ID / 空格 / 非 task 注释） |

## Test plan

- [x] `go test ./internal/converter/... -v -run TestConvertTask` — 全部通过
- [x] `go test ./...` — 全量测试无回归
- [x] 实际飞书文档验证：Task 块可通过 API 创建和读取