### PR TITLE
refactor: extract DocxClient struct for user token handling

### DIFF
--- a/cmd/add_content.go
+++ b/cmd/add_content.go
@@ -62,6 +62,7 @@ var addContentCmd = &cobra.Command{
 		index, _ := cmd.Flags().GetInt("index")
 		uploadImages, _ := cmd.Flags().GetBool("upload-images")
 		output, _ := cmd.Flags().GetString("output")
+		dc := client.NewDocxClient(resolveOptionalUserToken(cmd))
 
 		// Get source from args or flags
 		var source string
@@ -103,7 +104,7 @@ var addContentCmd = &cobra.Command{
 		}
 
 		if contentType == "markdown" {
-			return addContentMarkdown(documentID, blockID, contentData, basePath, uploadImages, index, output)
+			return addContentMarkdown(documentID, blockID, contentData, basePath, uploadImages, index, output, dc)
 		}
 
 		// JSON 模式
@@ -115,7 +116,7 @@ var addContentCmd = &cobra.Command{
 			return fmt.Errorf("没有内容可添加")
 		}
 
-		createdBlocks, err := client.CreateBlock(documentID, blockID, blocks, index)
+		createdBlocks, err := dc.CreateBlock(documentID, blockID, blocks, index)
 		if err != nil {
 			return err
 		}
@@ -134,7 +135,7 @@ var addContentCmd = &cobra.Command{
 }
 
 // addContentMarkdown 处理 Markdown 模式的内容添加，支持嵌套结构、分批创建、表格 429 重试
-func addContentMarkdown(documentID, blockID, contentData, basePath string, uploadImages bool, index int, output string) error {
+func addContentMarkdown(documentID, blockID, contentData, basePath string, uploadImages bool, index int, output string, dc *client.DocxClient) error {
 	opts := converter.ConvertOptions{
 		DocumentID:   documentID,
 		UploadImages: uploadImages,
@@ -181,7 +182,7 @@ func addContentMarkdown(documentID, blockID, contentData, basePath string, uploa
 		}
 		batch := topLevelBlocks[i:end]
 
-		createdBlocks, err := client.CreateBlock(documentID, blockID, batch, currentIndex)
+		createdBlocks, err := dc.CreateBlock(documentID, blockID, batch, currentIndex)
 		if err != nil {
 			return fmt.Errorf("添加内容失败: %w", err)
 		}
@@ -203,7 +204,7 @@ func addContentMarkdown(documentID, blockID, contentData, basePath string, uploa
 	for idx, children := range nodeChildrenMap {
 		if idx < len(createdBlockIDs) {
 			parentID := createdBlockIDs[idx]
-			nestedCount, nestedErr := createNestedChildren(documentID, parentID, children)
+			nestedCount, nestedErr := createNestedChildren(documentID, parentID, children, dc)
 			if nestedErr != nil {
 				fmt.Fprintf(os.Stderr, "[Warning] 嵌套子块创建失败: %v\n", nestedErr)
 			}
@@ -229,7 +230,7 @@ func addContentMarkdown(documentID, blockID, contentData, basePath string, uploa
 			td := result.TableDatas[tableDataIdx]
 			tableDataIdx++
 
-			if fillTableWithRetry(documentID, tableBlockID, td) {
+			if fillTableWithRetry(documentID, tableBlockID, td, dc) {
 				tableSuccess++
 			} else {
 				tableFailed++
@@ -257,20 +258,20 @@ func addContentMarkdown(documentID, blockID, contentData, basePath string, uploa
 }
 
 // fillTableWithRetry 填充单个表格内容，带重试（最多 5 次，full jitter 退避）
-func fillTableWithRetry(documentID, tableBlockID string, td *converter.TableData) bool {
+func fillTableWithRetry(documentID, tableBlockID string, td *converter.TableData, dc *client.DocxClient) bool {
 	result := client.DoVoidWithRetry(func() (http.Header, error) {
-		cellIDs, err := client.GetTableCellIDs(documentID, tableBlockID)
+		cellIDs, err := dc.GetTableCellIDs(documentID, tableBlockID)
 		if err != nil {
 			return nil, fmt.Errorf("获取单元格失败: %w", err)
 		}
 
 		if len(td.CellElements) > 0 {
-			if err := client.FillTableCellsRich(documentID, cellIDs, td.CellElements, td.CellContents); err != nil {
+			if err := dc.FillTableCellsRich(documentID, cellIDs, td.CellElements, td.CellContents); err != nil {
 				return nil, fmt.Errorf("填充内容失败: %w", err)
 			}
 			return nil, nil
 		}
-		if err := client.FillTableCells(documentID, cellIDs, td.CellContents); err != nil {
+		if err := dc.FillTableCells(documentID, cellIDs, td.CellContents); err != nil {
 			return nil, fmt.Errorf("填充内容失败: %w", err)
 		}
 		return nil, nil
@@ -296,4 +297,5 @@ func init() {
 	addContentCmd.Flags().IntP("index", "i", -1, "插入位置索引 (-1 表示末尾)")
 	addContentCmd.Flags().Bool("upload-images", false, "上传 Markdown 中的本地图片")
 	addContentCmd.Flags().StringP("output", "o", "", "输出格式 (json)")
+	addContentCmd.Flags().String("user-access-token", "", "User Access Token（可选，用于访问个人知识库等需要用户身份的文档）")
 }

--- a/cmd/batch_update_blocks.go
+++ b/cmd/batch_update_blocks.go
@@ -55,6 +55,7 @@ var batchUpdateBlocksCmd = &cobra.Command{
 		clientToken, _ := cmd.Flags().GetString("client-token")
 		userIDType, _ := cmd.Flags().GetString("user-id-type")
 		output, _ := cmd.Flags().GetString("output")
+		dc := client.NewDocxClient(resolveOptionalUserToken(cmd))
 
 		// Get requests JSON
 		var requestsJSON string
@@ -75,7 +76,7 @@ var batchUpdateBlocksCmd = &cobra.Command{
 			UserIDType:         userIDType,
 		}
 
-		result, err := client.BatchUpdateBlocks(documentID, requestsJSON, opts)
+		result, err := dc.BatchUpdateBlocks(documentID, requestsJSON, opts)
 		if err != nil {
 			return err
 		}
@@ -104,4 +105,5 @@ func init() {
 	batchUpdateBlocksCmd.Flags().String("client-token", "", "操作唯一标识（幂等）")
 	batchUpdateBlocksCmd.Flags().String("user-id-type", "open_id", "用户 ID 类型")
 	batchUpdateBlocksCmd.Flags().StringP("output", "o", "", "输出格式 (json)")
+	batchUpdateBlocksCmd.Flags().String("user-access-token", "", "User Access Token（可选，用于访问个人知识库等需要用户身份的文档）")
 }

--- a/cmd/delete_blocks.go
+++ b/cmd/delete_blocks.go
@@ -31,10 +31,11 @@ var deleteBlocksCmd = &cobra.Command{
 		endIndex, _ := cmd.Flags().GetInt("end")
 		deleteAll, _ := cmd.Flags().GetBool("all")
 		force, _ := cmd.Flags().GetBool("force")
+		dc := client.NewDocxClient(resolveOptionalUserToken(cmd))
 
 		if deleteAll {
 			// Get block children count first
-			children, err := client.GetBlockChildren(documentID, blockID)
+			children, err := dc.GetBlockChildren(documentID, blockID)
 			if err != nil {
 				return fmt.Errorf("获取子块失败: %w", err)
 			}
@@ -66,7 +67,7 @@ var deleteBlocksCmd = &cobra.Command{
 			}
 		}
 
-		if err := client.DeleteBlocks(documentID, blockID, startIndex, endIndex); err != nil {
+		if err := dc.DeleteBlocks(documentID, blockID, startIndex, endIndex); err != nil {
 			return err
 		}
 
@@ -81,4 +82,5 @@ func init() {
 	deleteBlocksCmd.Flags().Int("end", 0, "结束索引 (不包含)")
 	deleteBlocksCmd.Flags().Bool("all", false, "删除所有子块")
 	deleteBlocksCmd.Flags().BoolP("force", "f", false, "跳过确认直接删除")
+	deleteBlocksCmd.Flags().String("user-access-token", "", "User Access Token（可选，用于访问个人知识库等需要用户身份的文档）")
 }

--- a/cmd/get_blocks.go
+++ b/cmd/get_blocks.go
@@ -41,6 +41,7 @@ var getBlocksCmd = &cobra.Command{
 		pageSize, _ := cmd.Flags().GetInt("page-size")
 		pageToken, _ := cmd.Flags().GetString("page-token")
 		output, _ := cmd.Flags().GetString("output")
+		dc := client.NewDocxClient(resolveOptionalUserToken(cmd))
 
 		if raw {
 			content, err := client.GetRawContent(documentID)
@@ -57,7 +58,7 @@ var getBlocksCmd = &cobra.Command{
 
 		if all {
 			// Get all blocks with automatic pagination
-			allBlocks, err := client.GetAllBlocks(documentID)
+			allBlocks, err := dc.GetAllBlocks(documentID)
 			if err != nil {
 				return err
 			}
@@ -83,7 +84,7 @@ var getBlocksCmd = &cobra.Command{
 			}
 		} else {
 			// Get blocks with pagination
-			blockList, nextToken, err := client.ListBlocks(documentID, pageToken, pageSize)
+			blockList, nextToken, err := dc.ListBlocks(documentID, pageToken, pageSize)
 			if err != nil {
 				return err
 			}
@@ -131,4 +132,5 @@ func init() {
 	getBlocksCmd.Flags().Int("document-revision-id", -1, "文档版本 ID（-1 表示最新）")
 	getBlocksCmd.Flags().String("user-id-type", "open_id", "用户 ID 类型")
 	getBlocksCmd.Flags().StringP("output", "o", "", "输出格式 (json)")
+	getBlocksCmd.Flags().String("user-access-token", "", "User Access Token（可选，用于访问个人知识库等需要用户身份的文档）")
 }

--- a/cmd/import_markdown.go
+++ b/cmd/import_markdown.go
@@ -555,7 +555,7 @@ func phase1CreateBlocks(
 			for idx, children := range nodeChildrenMap {
 				if idx < len(createdBlockIDs) {
 					parentID := createdBlockIDs[idx]
-					nestedCount, nestedErr := createNestedChildren(documentID, parentID, children)
+					nestedCount, nestedErr := createNestedChildren(documentID, parentID, children, client.NewDocxClient())
 					if nestedErr != nil {
 						if verbose {
 							syncPrintf("  ⚠ 段落 %d 嵌套子块创建失败: %v\n", segIdx+1, nestedErr)
@@ -821,7 +821,7 @@ func processTableTask(documentID string, task tableTask, verbose bool) tableResu
 
 // createNestedChildren 递归创建嵌套子块（如嵌套列表的父子关系）
 // 返回创建的块总数和可能的错误
-func createNestedChildren(documentID string, parentBlockID string, children []*converter.BlockNode) (int, error) {
+func createNestedChildren(documentID string, parentBlockID string, children []*converter.BlockNode, dc *client.DocxClient) (int, error) {
 	if len(children) == 0 {
 		return 0, nil
 	}
@@ -843,7 +843,7 @@ func createNestedChildren(documentID string, parentBlockID string, children []*c
 		batch := childBlocks[i:end]
 
 		result := client.DoWithRetry(func() ([]*larkdocx.Block, http.Header, error) {
-			blocks, err := client.CreateBlock(documentID, parentBlockID, batch, -1)
+			blocks, err := dc.CreateBlock(documentID, parentBlockID, batch, -1)
 			return blocks, nil, err
 		}, client.RetryConfig{
 			MaxRetries:       5,
@@ -864,7 +864,7 @@ func createNestedChildren(documentID string, parentBlockID string, children []*c
 	// 递归创建更深层的子块
 	for i, child := range children {
 		if len(child.Children) > 0 && i < len(createdBlockIDs) {
-			nestedCount, err := createNestedChildren(documentID, createdBlockIDs[i], child.Children)
+			nestedCount, err := createNestedChildren(documentID, createdBlockIDs[i], child.Children, dc)
 			totalCreated += nestedCount
 			if err != nil {
 				return totalCreated, err

--- a/cmd/utils.go
+++ b/cmd/utils.go
@@ -8,6 +8,7 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/riba2534/feishu-cli/internal/config"
 	"github.com/spf13/cobra"
 )
 
@@ -117,6 +118,21 @@ func isValidToken(token string) bool {
 		}
 	}
 	return true
+}
+
+// resolveOptionalUserToken 从命令行 flag、配置文件、环境变量中解析可选的 User Access Token。
+// 优先级：--user-access-token flag > config.UserAccessToken > FEISHU_USER_ACCESS_TOKEN 环境变量。
+// 返回空字符串表示未提供（此时 API 调用将使用 Tenant Access Token）。
+func resolveOptionalUserToken(cmd *cobra.Command) string {
+	token, _ := cmd.Flags().GetString("user-access-token")
+	if token != "" {
+		return token
+	}
+	token = config.Get().UserAccessToken
+	if token != "" {
+		return token
+	}
+	return os.Getenv("FEISHU_USER_ACCESS_TOKEN")
 }
 
 // splitAndTrim 按逗号分割字符串并去除空白

--- a/internal/client/docx.go
+++ b/internal/client/docx.go
@@ -7,8 +7,33 @@ import (
 	"strings"
 	"time"
 
+	larkcore "github.com/larksuite/oapi-sdk-go/v3/core"
 	larkdocx "github.com/larksuite/oapi-sdk-go/v3/service/docx/v1"
 )
+
+// DocxClient 封装了文档操作的客户端，支持可选的 User Access Token。
+// 使用 User Access Token 时，API 调用将以用户身份执行（用于访问个人知识库等文档）；
+// 不设置时，使用 Tenant Access Token（应用身份）。
+type DocxClient struct {
+	userAccessToken string
+}
+
+// NewDocxClient 创建文档操作客户端。可选传入 userAccessToken 以用户身份访问文档。
+func NewDocxClient(userAccessToken ...string) *DocxClient {
+	token := ""
+	if len(userAccessToken) > 0 {
+		token = userAccessToken[0]
+	}
+	return &DocxClient{userAccessToken: token}
+}
+
+// requestOpts 将 userAccessToken 转换为 larkcore.RequestOptionFunc 切片。
+func (c *DocxClient) requestOpts() []larkcore.RequestOptionFunc {
+	if c.userAccessToken != "" {
+		return []larkcore.RequestOptionFunc{larkcore.WithUserAccessToken(c.userAccessToken)}
+	}
+	return nil
+}
 
 // 块类型常量（避免魔术数字）
 const (
@@ -93,8 +118,8 @@ func GetRawContent(documentID string) (string, error) {
 	return *resp.Data.Content, nil
 }
 
-// ListBlocks retrieves all blocks in a document
-func ListBlocks(documentID string, pageToken string, pageSize int) ([]*larkdocx.Block, string, error) {
+// ListBlocks retrieves all blocks in a document.
+func (c *DocxClient) ListBlocks(documentID string, pageToken string, pageSize int) ([]*larkdocx.Block, string, error) {
 	client, err := GetClient()
 	if err != nil {
 		return nil, "", err
@@ -108,7 +133,7 @@ func ListBlocks(documentID string, pageToken string, pageSize int) ([]*larkdocx.
 		reqBuilder.PageToken(pageToken)
 	}
 
-	resp, err := client.Docx.DocumentBlock.List(Context(), reqBuilder.Build())
+	resp, err := client.Docx.DocumentBlock.List(Context(), reqBuilder.Build(), c.requestOpts()...)
 	if err != nil {
 		return nil, "", fmt.Errorf("获取块列表失败: %w", err)
 	}
@@ -122,8 +147,8 @@ func ListBlocks(documentID string, pageToken string, pageSize int) ([]*larkdocx.
 	return resp.Data.Items, nextPageToken, nil
 }
 
-// GetAllBlocks retrieves all blocks in a document with pagination
-func GetAllBlocks(documentID string) ([]*larkdocx.Block, error) {
+// GetAllBlocks retrieves all blocks in a document with pagination.
+func (c *DocxClient) GetAllBlocks(documentID string) ([]*larkdocx.Block, error) {
 	var allBlocks []*larkdocx.Block
 	pageToken := ""
 	pageSize := 500
@@ -134,7 +159,7 @@ func GetAllBlocks(documentID string) ([]*larkdocx.Block, error) {
 		if pageCount >= maxPages {
 			return nil, fmt.Errorf("超过最大分页限制 %d，文档可能有异常", maxPages)
 		}
-		blocks, nextToken, err := ListBlocks(documentID, pageToken, pageSize)
+		blocks, nextToken, err := c.ListBlocks(documentID, pageToken, pageSize)
 		if err != nil {
 			return nil, err
 		}
@@ -151,8 +176,8 @@ func GetAllBlocks(documentID string) ([]*larkdocx.Block, error) {
 	return allBlocks, nil
 }
 
-// GetBlock retrieves a specific block
-func GetBlock(documentID string, blockID string) (*larkdocx.Block, error) {
+// GetBlock retrieves a specific block.
+func (c *DocxClient) GetBlock(documentID string, blockID string) (*larkdocx.Block, error) {
 	client, err := GetClient()
 	if err != nil {
 		return nil, err
@@ -163,7 +188,7 @@ func GetBlock(documentID string, blockID string) (*larkdocx.Block, error) {
 		BlockId(blockID).
 		Build()
 
-	resp, err := client.Docx.DocumentBlock.Get(Context(), req)
+	resp, err := client.Docx.DocumentBlock.Get(Context(), req, c.requestOpts()...)
 	if err != nil {
 		return nil, fmt.Errorf("获取块失败: %w", err)
 	}
@@ -175,8 +200,8 @@ func GetBlock(documentID string, blockID string) (*larkdocx.Block, error) {
 	return resp.Data.Block, nil
 }
 
-// CreateBlock creates a new block under a parent block
-func CreateBlock(documentID string, blockID string, children []*larkdocx.Block, index int) ([]*larkdocx.Block, error) {
+// CreateBlock creates a new block under a parent block.
+func (c *DocxClient) CreateBlock(documentID string, blockID string, children []*larkdocx.Block, index int) ([]*larkdocx.Block, error) {
 	client, err := GetClient()
 	if err != nil {
 		return nil, err
@@ -192,7 +217,7 @@ func CreateBlock(documentID string, blockID string, children []*larkdocx.Block, 
 			Build()).
 		Build()
 
-	resp, err := client.Docx.DocumentBlockChildren.Create(Context(), req)
+	resp, err := client.Docx.DocumentBlockChildren.Create(Context(), req, c.requestOpts()...)
 	if err != nil {
 		return nil, fmt.Errorf("创建块失败: %w", err)
 	}
@@ -204,8 +229,8 @@ func CreateBlock(documentID string, blockID string, children []*larkdocx.Block, 
 	return resp.Data.Children, nil
 }
 
-// UpdateBlock updates an existing block
-func UpdateBlock(documentID string, blockID string, updateContent any) error {
+// UpdateBlock updates an existing block.
+func (c *DocxClient) UpdateBlock(documentID string, blockID string, updateContent any) error {
 	client, err := GetClient()
 	if err != nil {
 		return err
@@ -229,7 +254,7 @@ func UpdateBlock(documentID string, blockID string, updateContent any) error {
 		UpdateBlockRequest(&updateBody).
 		Build()
 
-	resp, err := client.Docx.DocumentBlock.Patch(Context(), req)
+	resp, err := client.Docx.DocumentBlock.Patch(Context(), req, c.requestOpts()...)
 	if err != nil {
 		return fmt.Errorf("更新块失败: %w", err)
 	}
@@ -241,9 +266,9 @@ func UpdateBlock(documentID string, blockID string, updateContent any) error {
 	return nil
 }
 
-// DeleteBlocks deletes child blocks from a parent block by index range
-// startIndex is the starting index (0-based), endIndex is exclusive
-func DeleteBlocks(documentID string, blockID string, startIndex int, endIndex int) error {
+// DeleteBlocks deletes child blocks from a parent block by index range.
+// startIndex is the starting index (0-based), endIndex is exclusive.
+func (c *DocxClient) DeleteBlocks(documentID string, blockID string, startIndex int, endIndex int) error {
 	client, err := GetClient()
 	if err != nil {
 		return err
@@ -259,7 +284,7 @@ func DeleteBlocks(documentID string, blockID string, startIndex int, endIndex in
 			Build()).
 		Build()
 
-	resp, err := client.Docx.DocumentBlockChildren.BatchDelete(Context(), req)
+	resp, err := client.Docx.DocumentBlockChildren.BatchDelete(Context(), req, c.requestOpts()...)
 	if err != nil {
 		return fmt.Errorf("删除块失败: %w", err)
 	}
@@ -285,7 +310,7 @@ type BatchUpdateBlocksResult struct {
 }
 
 // BatchUpdateBlocks batch updates blocks in a document
-func BatchUpdateBlocks(documentID string, requestsJSON string, opts BatchUpdateBlocksOptions) (*BatchUpdateBlocksResult, error) {
+func (c *DocxClient) BatchUpdateBlocks(documentID string, requestsJSON string, opts BatchUpdateBlocksOptions) (*BatchUpdateBlocksResult, error) {
 	client, err := GetClient()
 	if err != nil {
 		return nil, err
@@ -317,7 +342,7 @@ func BatchUpdateBlocks(documentID string, requestsJSON string, opts BatchUpdateB
 		reqBuilder.ClientToken(opts.ClientToken)
 	}
 
-	resp, err := client.Docx.DocumentBlock.BatchUpdate(Context(), reqBuilder.Build())
+	resp, err := client.Docx.DocumentBlock.BatchUpdate(Context(), reqBuilder.Build(), c.requestOpts()...)
 	if err != nil {
 		return nil, fmt.Errorf("批量更新块失败: %w", err)
 	}
@@ -337,8 +362,8 @@ func BatchUpdateBlocks(documentID string, requestsJSON string, opts BatchUpdateB
 	return result, nil
 }
 
-// GetBlockChildren retrieves children of a block (first page only)
-func GetBlockChildren(documentID string, blockID string) ([]*larkdocx.Block, error) {
+// GetBlockChildren retrieves children of a block (first page only).
+func (c *DocxClient) GetBlockChildren(documentID string, blockID string) ([]*larkdocx.Block, error) {
 	client, err := GetClient()
 	if err != nil {
 		return nil, err
@@ -349,7 +374,7 @@ func GetBlockChildren(documentID string, blockID string) ([]*larkdocx.Block, err
 		BlockId(blockID).
 		Build()
 
-	resp, err := client.Docx.DocumentBlockChildren.Get(Context(), req)
+	resp, err := client.Docx.DocumentBlockChildren.Get(Context(), req, c.requestOpts()...)
 	if err != nil {
 		return nil, fmt.Errorf("获取子块失败: %w", err)
 	}
@@ -361,8 +386,8 @@ func GetBlockChildren(documentID string, blockID string) ([]*larkdocx.Block, err
 	return resp.Data.Items, nil
 }
 
-// GetAllBlockChildren retrieves all direct children of a block with pagination
-func GetAllBlockChildren(documentID string, blockID string) ([]*larkdocx.Block, error) {
+// GetAllBlockChildren retrieves all direct children of a block with pagination.
+func (c *DocxClient) GetAllBlockChildren(documentID string, blockID string) ([]*larkdocx.Block, error) {
 	client, err := GetClient()
 	if err != nil {
 		return nil, err
@@ -384,7 +409,7 @@ func GetAllBlockChildren(documentID string, blockID string) ([]*larkdocx.Block, 
 			reqBuilder.PageToken(pageToken)
 		}
 
-		resp, err := client.Docx.DocumentBlockChildren.Get(Context(), reqBuilder.Build())
+		resp, err := client.Docx.DocumentBlockChildren.Get(Context(), reqBuilder.Build(), c.requestOpts()...)
 		if err != nil {
 			return nil, fmt.Errorf("获取子块失败: %w", err)
 		}
@@ -428,7 +453,7 @@ func AddBoard(documentID string, parentID string, index int) (*AddBoardResult, e
 	}
 
 	// 创建画板块
-	createdBlocks, err := CreateBlock(documentID, parentID, []*larkdocx.Block{boardBlock}, index)
+	createdBlocks, err := NewDocxClient().CreateBlock(documentID, parentID, []*larkdocx.Block{boardBlock}, index)
 	if err != nil {
 		return nil, fmt.Errorf("创建画板块失败: %w", err)
 	}
@@ -452,7 +477,7 @@ func AddBoard(documentID string, parentID string, index int) (*AddBoardResult, e
 // contents: cell content strings (in row-major order)
 // Note: Feishu API automatically creates an empty text block in each cell when creating a table,
 // so we need to update the existing block instead of creating a new one to avoid duplicate rows.
-func FillTableCells(documentID string, cellIDs []string, contents []string) error {
+func (c *DocxClient) FillTableCells(documentID string, cellIDs []string, contents []string) error {
 	if len(cellIDs) == 0 || len(contents) == 0 {
 		return nil
 	}
@@ -470,14 +495,14 @@ func FillTableCells(documentID string, cellIDs []string, contents []string) erro
 		}
 	}
 
-	return fillTableCellsInternal(documentID, cellIDs[:cellCount], cellElements)
+	return c.fillTableCellsInternal(documentID, cellIDs[:cellCount], cellElements)
 }
 
 // FillTableCellsRich fills table cells with rich text elements (preserving links, styles, etc.)
 // cellIDs: cell block IDs from the created table
 // cellElements: each cell's text elements (in row-major order)
 // fallbackContents: plain text fallback for cells without elements
-func FillTableCellsRich(documentID string, cellIDs []string, cellElements [][]*larkdocx.TextElement, fallbackContents []string) error {
+func (c *DocxClient) FillTableCellsRich(documentID string, cellIDs []string, cellElements [][]*larkdocx.TextElement, fallbackContents []string) error {
 	if len(cellIDs) == 0 {
 		return nil
 	}
@@ -495,11 +520,11 @@ func FillTableCellsRich(documentID string, cellIDs []string, cellElements [][]*l
 		}
 	}
 
-	return fillTableCellsInternal(documentID, cellIDs, merged)
+	return c.fillTableCellsInternal(documentID, cellIDs, merged)
 }
 
 // fillTableCellsInternal 是 FillTableCells 和 FillTableCellsRich 的统一实现
-func fillTableCellsInternal(documentID string, cellIDs []string, cellElements [][]*larkdocx.TextElement) error {
+func (c *DocxClient) fillTableCellsInternal(documentID string, cellIDs []string, cellElements [][]*larkdocx.TextElement) error {
 	const maxRetries = 5
 
 	for i, cellID := range cellIDs {
@@ -515,11 +540,9 @@ func fillTableCellsInternal(documentID string, cellIDs []string, cellElements []
 
 		var err error
 		if len(groups) > 1 {
-			// 多块：删除已有空块后创建多个正确类型的块（支持标题、列表等）
-			err = fillCellMultiBlocks(documentID, cellID, groups, maxRetries)
+			err = c.fillCellMultiBlocks(documentID, cellID, groups, maxRetries)
 		} else {
-			// 单块：更新已有空块（飞书创建表格时自动生成）
-			err = fillCellSingleBlock(documentID, cellID, elements, maxRetries)
+			err = c.fillCellSingleBlock(documentID, cellID, elements, maxRetries)
 		}
 		if err != nil {
 			return fmt.Errorf("填充单元格 %d 失败: %w", i, err)
@@ -532,7 +555,7 @@ func fillTableCellsInternal(documentID string, cellIDs []string, cellElements []
 }
 
 // fillCellSingleBlock 用单个文本块填充单元格（优先更新已有空块）
-func fillCellSingleBlock(documentID, cellID string, elements []*larkdocx.TextElement, maxRetries int) error {
+func (c *DocxClient) fillCellSingleBlock(documentID, cellID string, elements []*larkdocx.TextElement, maxRetries int) error {
 	retryCfg := RetryConfig{
 		MaxRetries:       maxRetries,
 		MaxTotalAttempts: maxRetries + 5,
@@ -540,13 +563,13 @@ func fillCellSingleBlock(documentID, cellID string, elements []*larkdocx.TextEle
 	}
 
 	// 尝试更新已有子块（飞书创建表格时自动生成空文本块）
-	children, childErr := GetBlockChildren(documentID, cellID)
+	children, childErr := c.GetBlockChildren(documentID, cellID)
 	if childErr == nil && len(children) > 0 {
 		existingBlockID := StringVal(children[0].BlockId)
 		if existingBlockID != "" {
 			updateContent := buildCellUpdateContent(elements)
 			result := DoVoidWithRetry(func() (http.Header, error) {
-				return nil, UpdateBlock(documentID, existingBlockID, updateContent)
+				return nil, c.UpdateBlock(documentID, existingBlockID, updateContent)
 			}, retryCfg)
 			if result.Err == nil {
 				return nil
@@ -561,14 +584,14 @@ func fillCellSingleBlock(documentID, cellID string, elements []*larkdocx.TextEle
 		Text:      &larkdocx.Text{Elements: elements},
 	}
 	result := DoVoidWithRetry(func() (http.Header, error) {
-		_, err := CreateBlock(documentID, cellID, []*larkdocx.Block{textBlock}, 0)
+		_, err := c.CreateBlock(documentID, cellID, []*larkdocx.Block{textBlock}, 0)
 		return nil, err
 	}, retryCfg)
 	return result.Err
 }
 
 // fillCellMultiBlocks 用多个块填充单元格（支持 bullet/heading/text 混合）
-func fillCellMultiBlocks(documentID, cellID string, groups []cellBlockGroup, maxRetries int) error {
+func (c *DocxClient) fillCellMultiBlocks(documentID, cellID string, groups []cellBlockGroup, maxRetries int) error {
 	retryCfg := RetryConfig{
 		MaxRetries:       maxRetries,
 		MaxTotalAttempts: maxRetries + 5,
@@ -577,13 +600,13 @@ func fillCellMultiBlocks(documentID, cellID string, groups []cellBlockGroup, max
 
 	// 获取飞书自动创建的空文本块，更新其内容以避免留下空块
 	startIdx := 0
-	children, childErr := GetBlockChildren(documentID, cellID)
+	children, childErr := c.GetBlockChildren(documentID, cellID)
 	if childErr == nil && len(children) > 0 && len(groups) > 0 && len(groups[0].elements) > 0 {
 		existingBlockID := StringVal(children[0].BlockId)
 		if existingBlockID != "" {
 			updateContent := buildCellUpdateContent(groups[0].elements)
 			result := DoVoidWithRetry(func() (http.Header, error) {
-				return nil, UpdateBlock(documentID, existingBlockID, updateContent)
+				return nil, c.UpdateBlock(documentID, existingBlockID, updateContent)
 			}, retryCfg)
 			if result.Err == nil {
 				startIdx = 1 // 第一组已通过更新处理
@@ -599,7 +622,7 @@ func fillCellMultiBlocks(documentID, cellID string, groups []cellBlockGroup, max
 		}
 		block := buildCellBlock(group)
 		result := DoVoidWithRetry(func() (http.Header, error) {
-			_, err := CreateBlock(documentID, cellID, []*larkdocx.Block{block}, -1)
+			_, err := c.CreateBlock(documentID, cellID, []*larkdocx.Block{block}, -1)
 			return nil, err
 		}, retryCfg)
 		if result.Err != nil {
@@ -803,8 +826,8 @@ func buildElementsJSON(elements []*larkdocx.TextElement) []map[string]any {
 }
 
 // GetTableCellIDs retrieves cell block IDs from a table block
-func GetTableCellIDs(documentID string, tableBlockID string) ([]string, error) {
-	block, err := GetBlock(documentID, tableBlockID)
+func (c *DocxClient) GetTableCellIDs(documentID string, tableBlockID string) ([]string, error) {
+	block, err := c.GetBlock(documentID, tableBlockID)
 	if err != nil {
 		return nil, err
 	}
@@ -814,4 +837,56 @@ func GetTableCellIDs(documentID string, tableBlockID string) ([]string, error) {
 	}
 
 	return block.Table.Cells, nil
+}
+
+// ---------------------------------------------------------------------------
+// 向后兼容的包级函数（委托给 DocxClient，不传 token 时使用 Tenant Access Token）
+// ---------------------------------------------------------------------------
+
+func ListBlocks(documentID, pageToken string, pageSize int) ([]*larkdocx.Block, string, error) {
+	return NewDocxClient().ListBlocks(documentID, pageToken, pageSize)
+}
+
+func GetAllBlocks(documentID string) ([]*larkdocx.Block, error) {
+	return NewDocxClient().GetAllBlocks(documentID)
+}
+
+func GetBlock(documentID, blockID string) (*larkdocx.Block, error) {
+	return NewDocxClient().GetBlock(documentID, blockID)
+}
+
+func CreateBlock(documentID, blockID string, children []*larkdocx.Block, index int) ([]*larkdocx.Block, error) {
+	return NewDocxClient().CreateBlock(documentID, blockID, children, index)
+}
+
+func UpdateBlock(documentID, blockID string, updateContent any) error {
+	return NewDocxClient().UpdateBlock(documentID, blockID, updateContent)
+}
+
+func DeleteBlocks(documentID, blockID string, startIndex, endIndex int) error {
+	return NewDocxClient().DeleteBlocks(documentID, blockID, startIndex, endIndex)
+}
+
+func BatchUpdateBlocks(documentID, requestsJSON string, opts BatchUpdateBlocksOptions) (*BatchUpdateBlocksResult, error) {
+	return NewDocxClient().BatchUpdateBlocks(documentID, requestsJSON, opts)
+}
+
+func GetBlockChildren(documentID, blockID string) ([]*larkdocx.Block, error) {
+	return NewDocxClient().GetBlockChildren(documentID, blockID)
+}
+
+func GetAllBlockChildren(documentID, blockID string) ([]*larkdocx.Block, error) {
+	return NewDocxClient().GetAllBlockChildren(documentID, blockID)
+}
+
+func FillTableCells(documentID string, cellIDs, contents []string) error {
+	return NewDocxClient().FillTableCells(documentID, cellIDs, contents)
+}
+
+func FillTableCellsRich(documentID string, cellIDs []string, cellElements [][]*larkdocx.TextElement, fallbackContents []string) error {
+	return NewDocxClient().FillTableCellsRich(documentID, cellIDs, cellElements, fallbackContents)
+}
+
+func GetTableCellIDs(documentID, tableBlockID string) ([]string, error) {
+	return NewDocxClient().GetTableCellIDs(documentID, tableBlockID)
 }


### PR DESCRIPTION
## Summary
- Replace per-function `userAccessToken ...string` variadic parameter with `DocxClient` struct across 15 docx functions
- Token set once at construction via `client.NewDocxClient(token)`, all methods inherit automatically
- Backward-compatible package-level wrapper functions preserved — callers without token need no changes

## Changed files
- `internal/client/docx.go` — Define `DocxClient` struct, convert 15 functions to methods, add wrapper functions
- `cmd/add_content.go` / `get_blocks.go` / `delete_blocks.go` / `batch_update_blocks.go` — Use `dc := client.NewDocxClient(token)`
- `cmd/import_markdown.go` — Update `createNestedChildren` to accept `*client.DocxClient`

## Test plan
- [x] `doc blocks` read personal wiki with `--user-access-token`
- [x] `doc add` JSON and Markdown (including tables with token passthrough)
- [x] `doc delete` range and `--all`
- [x] `doc batch-update`
- [x] Regression: all commands without token on regular docs
- [x] `go build ./...` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)