### PR TITLE
feat(auth): add auth auto command for non-interactive token refresh

### DIFF
--- a/cmd/auth_auto.go
+++ b/cmd/auth_auto.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"fmt"
+	"os"
 	"time"
 
 	"github.com/riba2534/feishu-cli/internal/auth"
@@ -37,6 +38,7 @@ var authAutoCmd = &cobra.Command{
   # 自定义缓冲时间（默认 300 秒）
   feishu-cli auth auto --buffer 600`,
 	SilenceErrors: true,
+	SilenceUsage:  true,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		output, _ := cmd.Flags().GetString("output")
 		buffer, _ := cmd.Flags().GetInt("buffer")
@@ -89,8 +91,8 @@ var authAutoCmd = &cobra.Command{
 }
 
 // wrapAutoResult 统一处理 auth auto 的输出
-// JSON 模式下先输出 JSON 到 stdout，再返回 error（非零退出码）；
-// SilenceErrors 防止 cobra 重复打印 error 到 stderr。
+// JSON 模式下输出 JSON 到 stdout，失败时直接 os.Exit(1) 确保退出码正确，
+// 避免 root.go Execute() 重复打印 error 到 stderr。
 func wrapAutoResult(output string, ok bool, msg string, err error) error {
 	if output == "json" {
 		result := map[string]any{"ok": ok}
@@ -101,7 +103,10 @@ func wrapAutoResult(output string, ok bool, msg string, err error) error {
 			result["error"] = err.Error()
 		}
 		_ = printJSON(result)
-		return err // nil on success, non-nil on failure → correct exit code
+		if err != nil {
+			os.Exit(1)
+		}
+		return nil
 	}
 
 	if err != nil {

--- a/cmd/auth_auto.go
+++ b/cmd/auth_auto.go
@@ -21,17 +21,22 @@ var authAutoCmd = &cobra.Command{
 如果两级均失败（无 refresh_token 或已过期），返回非零退出码，
 提示调用方执行 auth login 重新授权。
 
+缓冲时间说明:
+  --buffer 默认 300 秒（5 分钟），用于预防性刷新，避免 token 在使用过程中过期。
+  这与 SDK 内部的 60 秒缓冲（IsAccessTokenValid）不同，auth auto 更保守。
+
 适用于 AI Agent、定时任务等需要无人值守保持 Token 有效的场景。
 
 示例:
   # 检查并自动刷新
   feishu-cli auth auto
 
-  # JSON 输出（AI Agent 推荐）
+  # JSON 输出（AI Agent 推荐，成败通过退出码和 ok 字段双重判断）
   feishu-cli auth auto -o json
 
   # 自定义缓冲时间（默认 300 秒）
   feishu-cli auth auto --buffer 600`,
+	SilenceErrors: true,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		output, _ := cmd.Flags().GetString("output")
 		buffer, _ := cmd.Flags().GetInt("buffer")
@@ -44,9 +49,9 @@ var authAutoCmd = &cobra.Command{
 			return wrapAutoResult(output, false, "", fmt.Errorf("未登录，请先执行: feishu-cli auth login"))
 		}
 
-		// Level 1: access_token 有效性检查
+		// Level 1: access_token 有效性检查（含空 token 校验，与 IsAccessTokenValid 一致）
 		remaining := time.Until(token.ExpiresAt)
-		if remaining > time.Duration(buffer)*time.Second {
+		if token.AccessToken != "" && remaining > time.Duration(buffer)*time.Second {
 			msg := fmt.Sprintf("Token 有效（剩余 %s）", formatDuration(remaining))
 			return wrapAutoResult(output, true, msg, nil)
 		}
@@ -84,6 +89,8 @@ var authAutoCmd = &cobra.Command{
 }
 
 // wrapAutoResult 统一处理 auth auto 的输出
+// JSON 模式下先输出 JSON 到 stdout，再返回 error（非零退出码）；
+// SilenceErrors 防止 cobra 重复打印 error 到 stderr。
 func wrapAutoResult(output string, ok bool, msg string, err error) error {
 	if output == "json" {
 		result := map[string]any{"ok": ok}
@@ -93,7 +100,8 @@ func wrapAutoResult(output string, ok bool, msg string, err error) error {
 		if err != nil {
 			result["error"] = err.Error()
 		}
-		return printJSON(result)
+		_ = printJSON(result)
+		return err // nil on success, non-nil on failure → correct exit code
 	}
 
 	if err != nil {

--- a/cmd/auth_auto.go
+++ b/cmd/auth_auto.go
@@ -1,0 +1,110 @@
+package cmd
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/riba2534/feishu-cli/internal/auth"
+	"github.com/riba2534/feishu-cli/internal/config"
+	"github.com/spf13/cobra"
+)
+
+var authAutoCmd = &cobra.Command{
+	Use:   "auto",
+	Short: "自动检查并刷新 Token",
+	Long: `自动检查当前 Token 状态，必要时通过 refresh_token 刷新。
+
+两级降级策略:
+  1. 检查 access_token 是否仍然有效（默认预留 5 分钟缓冲）
+  2. 若过期，尝试用 refresh_token 刷新
+
+如果两级均失败（无 refresh_token 或已过期），返回非零退出码，
+提示调用方执行 auth login 重新授权。
+
+适用于 AI Agent、定时任务等需要无人值守保持 Token 有效的场景。
+
+示例:
+  # 检查并自动刷新
+  feishu-cli auth auto
+
+  # JSON 输出（AI Agent 推荐）
+  feishu-cli auth auto -o json
+
+  # 自定义缓冲时间（默认 300 秒）
+  feishu-cli auth auto --buffer 600`,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		output, _ := cmd.Flags().GetString("output")
+		buffer, _ := cmd.Flags().GetInt("buffer")
+
+		token, err := auth.LoadToken()
+		if err != nil {
+			return wrapAutoResult(output, false, "", fmt.Errorf("读取 token 失败: %w", err))
+		}
+		if token == nil {
+			return wrapAutoResult(output, false, "", fmt.Errorf("未登录，请先执行: feishu-cli auth login"))
+		}
+
+		// Level 1: access_token 有效性检查
+		remaining := time.Until(token.ExpiresAt)
+		if remaining > time.Duration(buffer)*time.Second {
+			msg := fmt.Sprintf("Token 有效（剩余 %s）", formatDuration(remaining))
+			return wrapAutoResult(output, true, msg, nil)
+		}
+
+		// Level 2: refresh_token 刷新
+		if !token.IsRefreshTokenValid() {
+			return wrapAutoResult(output, false, "",
+				fmt.Errorf("Token 已过期且无有效的 refresh_token，请重新登录: feishu-cli auth login"))
+		}
+
+		if err := config.Validate(); err != nil {
+			return wrapAutoResult(output, false, "", err)
+		}
+		cfg := config.Get()
+
+		baseURL := cfg.BaseURL
+		if baseURL == "" {
+			baseURL = "https://open.feishu.cn"
+		}
+
+		newToken, err := auth.RefreshAccessToken(token.RefreshToken, cfg.AppID, cfg.AppSecret, baseURL)
+		if err != nil {
+			return wrapAutoResult(output, false, "",
+				fmt.Errorf("刷新失败: %w\n请重新登录: feishu-cli auth login", err))
+		}
+
+		if err := auth.SaveToken(newToken); err != nil {
+			return wrapAutoResult(output, false, "",
+				fmt.Errorf("Token 已刷新但保存失败: %w", err))
+		}
+
+		msg := fmt.Sprintf("Token 已刷新，有效期至 %s", newToken.ExpiresAt.Format("2006-01-02 15:04:05"))
+		return wrapAutoResult(output, true, msg, nil)
+	},
+}
+
+// wrapAutoResult 统一处理 auth auto 的输出
+func wrapAutoResult(output string, ok bool, msg string, err error) error {
+	if output == "json" {
+		result := map[string]any{"ok": ok}
+		if msg != "" {
+			result["message"] = msg
+		}
+		if err != nil {
+			result["error"] = err.Error()
+		}
+		return printJSON(result)
+	}
+
+	if err != nil {
+		return err
+	}
+	fmt.Println(msg)
+	return nil
+}
+
+func init() {
+	authCmd.AddCommand(authAutoCmd)
+	authAutoCmd.Flags().StringP("output", "o", "", "输出格式（json）")
+	authAutoCmd.Flags().Int("buffer", 300, "Token 有效期缓冲时间（秒），剩余时间低于此值时触发刷新")
+}


### PR DESCRIPTION
## Summary

- Add `feishu-cli auth auto` subcommand that automatically checks and refreshes User Access Token
- Two-level strategy: check access_token validity → refresh via refresh_token
- Returns non-zero exit code when both fail, prompting `auth login`
- Supports `-o json` for AI agent integration and `--buffer` for custom validity threshold (default 300s)

## Motivation

AI agents, cron jobs, and automation scripts need a single command to ensure a valid token exists without interactive browser flows. Currently they must manually parse `auth status` output or implement custom refresh logic.

`auth auto` provides a clean, non-interactive entry point:

```bash
# In a script or AI agent
feishu-cli auth auto || feishu-cli auth login

# JSON output for programmatic use
feishu-cli auth auto -o json
# {"ok": true, "message": "Token 有效（剩余 1 小时 30 分）"}
```

## Test plan

- [x] `go vet ./...` passes
- [x] `go test ./...` passes (all existing tests)
- [x] `feishu-cli auth auto` returns success when token is valid
- [x] `feishu-cli auth auto -o json` returns correct JSON
- [x] `feishu-cli auth auto` refreshes when access_token expired but refresh_token valid
- [x] `feishu-cli auth auto` returns error when both tokens expired
- [x] `feishu-cli auth auto --buffer 7200` triggers refresh for tokens expiring within 2h