### PR TITLE
feat: user search 支持按姓名模糊搜索 (--name)

### DIFF
--- a/cmd/user_search.go
+++ b/cmd/user_search.go
@@ -10,14 +10,16 @@ import (
 
 var userSearchCmd = &cobra.Command{
 	Use:   "search",
-	Short: "通过邮箱或手机号查询用户 ID",
-	Long: `通过邮箱或手机号批量查询用户 ID。至少需要指定一个查询条件。
+	Short: "通过姓名、邮箱或手机号查询用户",
+	Long: `通过姓名、邮箱或手机号查询用户。至少需要指定一个查询条件。
 
 参数:
+  --name      姓名（模糊匹配，递归搜索所有部门）
   --email     邮箱列表，逗号分隔
   --mobile    手机号列表，逗号分隔
 
 示例:
+  feishu-cli user search --name "张三"
   feishu-cli user search --email user@example.com
   feishu-cli user search --mobile +8613800138000
   feishu-cli user search --email a@example.com,b@example.com -o json`,
@@ -26,14 +28,56 @@ var userSearchCmd = &cobra.Command{
 			return err
 		}
 
+		nameStr, _ := cmd.Flags().GetString("name")
 		emailStr, _ := cmd.Flags().GetString("email")
 		mobileStr, _ := cmd.Flags().GetString("mobile")
 		output, _ := cmd.Flags().GetString("output")
 
-		if emailStr == "" && mobileStr == "" {
-			return fmt.Errorf("至少需要指定 --email 或 --mobile")
+		if nameStr == "" && emailStr == "" && mobileStr == "" {
+			return fmt.Errorf("至少需要指定 --name、--email 或 --mobile")
 		}
 
+		// 按姓名搜索（递归遍历部门）
+		if nameStr != "" {
+			users, err := client.SearchUsersByName(nameStr)
+			if err != nil {
+				return err
+			}
+
+			if output == "json" {
+				return printJSON(users)
+			}
+
+			if len(users) == 0 {
+				fmt.Printf("未找到姓名包含 \"%s\" 的用户\n", nameStr)
+				return nil
+			}
+
+			fmt.Printf("查询结果（共 %d 条，姓名匹配 \"%s\"）:\n\n", len(users), nameStr)
+			for i, u := range users {
+				fmt.Printf("[%d] %s", i+1, u.Name)
+				if u.EnName != "" {
+					fmt.Printf(" (%s)", u.EnName)
+				}
+				fmt.Println()
+				if u.OpenID != "" {
+					fmt.Printf("    Open ID: %s\n", u.OpenID)
+				}
+				if u.Email != "" {
+					fmt.Printf("    邮箱: %s\n", u.Email)
+				}
+				if u.JobTitle != "" {
+					fmt.Printf("    职位: %s\n", u.JobTitle)
+				}
+				if u.Status != "" {
+					fmt.Printf("    状态: %s\n", u.Status)
+				}
+				fmt.Println()
+			}
+			return nil
+		}
+
+		// 按邮箱/手机号搜索（原有逻辑）
 		var emails, mobiles []string
 		if emailStr != "" {
 			emails = splitAndTrim(emailStr)
@@ -74,6 +118,7 @@ var userSearchCmd = &cobra.Command{
 
 func init() {
 	userCmd.AddCommand(userSearchCmd)
+	userSearchCmd.Flags().String("name", "", "姓名（模糊匹配，递归搜索所有部门）")
 	userSearchCmd.Flags().String("email", "", "邮箱列表，逗号分隔")
 	userSearchCmd.Flags().String("mobile", "", "手机号列表，逗号分隔")
 	userSearchCmd.Flags().StringP("output", "o", "", "输出格式（json）")

--- a/internal/client/contact.go
+++ b/internal/client/contact.go
@@ -2,6 +2,7 @@ package client
 
 import (
 	"fmt"
+	"strings"
 
 	larkcontact "github.com/larksuite/oapi-sdk-go/v3/service/contact/v3"
 )
@@ -227,6 +228,61 @@ func ListDepartments(parentDepartmentID, userIDType, departmentIDType string, pa
 	}
 
 	return depts, nextPageToken, hasMore, nil
+}
+
+// SearchUsersByName 递归遍历所有部门，按姓名模糊搜索用户
+func SearchUsersByName(name string) ([]*UserInfo, error) {
+	var matched []*UserInfo
+	nameLower := strings.ToLower(name)
+
+	var searchDept func(deptID string) error
+	searchDept = func(deptID string) error {
+		// 列出当前部门的所有用户（自动分页）
+		pageToken := ""
+		for {
+			users, nextToken, hasMore, err := ListUsers(deptID, "open_id", 50, pageToken)
+			if err != nil {
+				return err
+			}
+			for _, u := range users {
+				if strings.Contains(strings.ToLower(u.Name), nameLower) ||
+					strings.Contains(strings.ToLower(u.EnName), nameLower) ||
+					strings.Contains(strings.ToLower(u.Nickname), nameLower) {
+					matched = append(matched, u)
+				}
+			}
+			if !hasMore {
+				break
+			}
+			pageToken = nextToken
+		}
+
+		// 递归子部门（自动分页）
+		pageToken = ""
+		for {
+			depts, nextToken, hasMore, err := ListDepartments(deptID, "open_id", "open_department_id", 50, pageToken)
+			if err != nil {
+				return err
+			}
+			for _, d := range depts {
+				if err := searchDept(d.OpenDepartmentID); err != nil {
+					return err
+				}
+			}
+			if !hasMore {
+				break
+			}
+			pageToken = nextToken
+		}
+
+		return nil
+	}
+
+	if err := searchDept("0"); err != nil {
+		return nil, err
+	}
+
+	return matched, nil
 }
 
 // convertDepartment 转换 SDK Department 为 DepartmentInfo


### PR DESCRIPTION
## Summary

- 新增 `--name` 参数，支持按姓名模糊搜索用户
- 递归遍历所有部门，客户端匹配 Name/EnName/Nickname
- 由于飞书 Contact v3 API 没有按姓名搜索的接口，采用递归遍历部门树 + 客户端过滤的方式实现
- 支持自动分页，适用于中小规模组织
- 原有 `--email` / `--mobile` 搜索功能不受影响

## 使用示例

```bash
feishu-cli user search --name "张三"        # 精确匹配
feishu-cli user search --name "张"          # 模糊匹配
feishu-cli user search --name "zhang" -o json  # 英文名 + JSON 输出
```

## 变更文件

- `cmd/user_search.go` — 新增 `--name` flag 和按姓名搜索的输出逻辑
- `internal/client/contact.go` — 新增 `SearchUsersByName()` 递归搜索函数

## Test plan

- [x] `--name "精确姓名"` 精确匹配测试通过
- [x] `--name "单字"` 模糊匹配测试通过
- [x] `--name "不存在"` 无结果时优雅提示
- [x] `--email` / `--mobile` 原有功能无回归
- [x] 跨多层部门递归搜索验证通过（7 个子部门、50+ 用户的组织）