### PR TITLE
fix(cli): printJSON 输出 URL 时 & 被转义为 \u0026

### DIFF
--- a/cmd/utils.go
+++ b/cmd/utils.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"bufio"
+	"bytes"
 	"encoding/json"
 	"fmt"
 	"os"
@@ -94,11 +95,14 @@ func loadJSONInput(inlineValue, filePath, inlineFlag, fileFlag, label string) (s
 // printJSON 安全地打印 JSON 格式的数据
 // 如果序列化失败，会返回错误而不是静默忽略
 func printJSON(v any) error {
-	data, err := json.MarshalIndent(v, "", "  ")
-	if err != nil {
+	var buf bytes.Buffer
+	enc := json.NewEncoder(&buf)
+	enc.SetEscapeHTML(false)
+	enc.SetIndent("", "  ")
+	if err := enc.Encode(v); err != nil {
 		return fmt.Errorf("JSON 序列化失败: %w", err)
 	}
-	fmt.Println(string(data))
+	fmt.Print(buf.String())
 	return nil
 }
 


### PR DESCRIPTION
## Summary
- `printJSON` 使用 `json.MarshalIndent` 序列化时，Go 默认对 `&` 做 HTML 安全转义为 `\u0026`，导致 `auth login --print-url` 输出的 auth_url 不可直接使用
- 改用 `json.NewEncoder` + `SetEscapeHTML(false)` 禁用 HTML 转义
## Test plan
- [x] `go build ./...` 编译通过
- [x] `go vet ./...` 静态检查通过
- [x] `go test ./...` 全部测试通过
- [x] `feishu-cli auth login --print-url` 验证 URL 中 `&` 不再被转义