### PR TITLE
fix(converter): 修复引用块导入导出多个问题

### DIFF
--- a/internal/converter/block_to_markdown.go
+++ b/internal/converter/block_to_markdown.go
@@ -1220,16 +1220,22 @@ func (c *BlockToMarkdown) convertQuoteContainerWithDepth(block *larkdocx.Block, 
 
 	var sb strings.Builder
 
-	// Process child blocks（跳过空文本子块，与 convertCallout 保持一致）
+	// Process child blocks（保留空行，确保引用块内空行正确导出）
 	if block.Children != nil {
+		hasContent := false
 		for _, childID := range block.Children {
 			childBlock := c.blockMap[childID]
 			if childBlock != nil {
 				text, _ := c.convertBlockWithDepth(childBlock, 0, depth+1)
 				text = strings.TrimRight(text, "\n")
 				if text == "" {
+					// 跳过开头的空行；已有内容后保留空行
+					if hasContent {
+						sb.WriteString(">\n")
+					}
 					continue
 				}
+				hasContent = true
 				for _, line := range strings.Split(text, "\n") {
 					sb.WriteString("> " + line + "\n")
 				}

--- a/internal/converter/markdown_to_block.go
+++ b/internal/converter/markdown_to_block.go
@@ -143,8 +143,63 @@ func FlattenBlockNodes(nodes []*BlockNode) []*larkdocx.Block {
 	return result
 }
 
+// normalizeBlockquoteEnding 确保引用块后有空行分隔
+// goldmark 的 lazy continuation 会将引用块后紧跟的非引用行视为引用块的一部分，
+// 通过在引用块最后一行和非引用行之间插入空行来终止引用块
+func normalizeBlockquoteEnding(source []byte) []byte {
+	lines := strings.Split(string(source), "\n")
+	var result []string
+	inFence := false
+	fenceLen := 0
+
+	for i, line := range lines {
+		result = append(result, line)
+		trimmed := strings.TrimSpace(line)
+
+		// 代码围栏检测（跳过围栏内的内容）
+		backticks := 0
+		for _, ch := range trimmed {
+			if ch == '`' {
+				backticks++
+			} else {
+				break
+			}
+		}
+		if !inFence && backticks >= 3 {
+			inFence = true
+			fenceLen = backticks
+			continue
+		}
+		if inFence && backticks >= fenceLen {
+			rest := strings.TrimLeft(trimmed, "`")
+			if strings.TrimSpace(rest) == "" {
+				inFence = false
+				fenceLen = 0
+			}
+			continue
+		}
+		if inFence {
+			continue
+		}
+
+		// 当前行是引用行，下一行非空且不是引用行 → 插入空行终止引用块
+		if i+1 < len(lines) {
+			nextTrimmed := strings.TrimSpace(lines[i+1])
+			if strings.HasPrefix(trimmed, ">") &&
+				nextTrimmed != "" &&
+				!strings.HasPrefix(nextTrimmed, ">") {
+				result = append(result, "")
+			}
+		}
+	}
+	return []byte(strings.Join(result, "\n"))
+}
+
 // ConvertWithTableData converts Markdown to Feishu blocks and returns table data for content filling
 func (c *MarkdownToBlock) ConvertWithTableData() (*ConvertResult, error) {
+	// 预处理：确保引用块后有空行分隔，避免 goldmark 的 lazy continuation
+	c.source = normalizeBlockquoteEnding(c.source)
+
 	md := goldmark.New(
 		goldmark.WithExtensions(extension.GFM),
 		goldmark.WithParserOptions(
@@ -631,9 +686,25 @@ func (c *MarkdownToBlock) convertBlockquote(node *ast.Blockquote) ([]*BlockNode,
 	}
 
 	var children []*BlockNode
+	paragraphCount := 0 // 跟踪已处理的段落数，用于插入段落间空行
 	for child := node.FirstChild(); child != nil; child = child.NextSibling() {
 		switch n := child.(type) {
 		case *ast.Paragraph:
+			// 段落间插入空 Text 块，对应引用块内的 > 空行
+			if paragraphCount > 0 {
+				emptyBlockType := int(BlockTypeText)
+				emptyContent := ""
+				children = append(children, &BlockNode{
+					Block: &larkdocx.Block{
+						BlockType: &emptyBlockType,
+						Text: &larkdocx.Text{Elements: []*larkdocx.TextElement{
+							{TextRun: &larkdocx.TextRun{Content: &emptyContent}},
+						}},
+					},
+				})
+			}
+			paragraphCount++
+
 			// 按行拆分段落内容
 			lines := c.extractQuoteLines(n)
 			textBlockType := int(BlockTypeText)
@@ -680,13 +751,16 @@ func (c *MarkdownToBlock) convertBlockquote(node *ast.Blockquote) ([]*BlockNode,
 		}
 	}
 
-	// 如果没有子块，创建一个空文本子块
+	// 如果没有子块，创建一个含空内容的文本子块
 	if len(children) == 0 {
 		textBlockType := int(BlockTypeText)
+		emptyContent := ""
 		children = append(children, &BlockNode{
 			Block: &larkdocx.Block{
 				BlockType: &textBlockType,
-				Text:      &larkdocx.Text{Elements: []*larkdocx.TextElement{}},
+				Text: &larkdocx.Text{Elements: []*larkdocx.TextElement{
+					{TextRun: &larkdocx.TextRun{Content: &emptyContent}},
+				}},
 			},
 		})
 	}

--- a/internal/converter/markdown_to_block_test.go
+++ b/internal/converter/markdown_to_block_test.go
@@ -233,6 +233,103 @@ func TestConvert_BlockquoteNested(t *testing.T) {
 	}
 }
 
+// TestConvert_BlockquoteMultiParagraphWithSurrounding 测试引用块：段落间空行 + 引用块前后文本
+func TestConvert_BlockquoteMultiParagraphWithSurrounding(t *testing.T) {
+	markdown := "123\n> 12312323213\n>\n> 213213\n>\n>\n> 1\n321"
+
+	conv := NewMarkdownToBlock([]byte(markdown), ConvertOptions{}, "")
+	result, err := conv.ConvertWithTableData()
+	if err != nil {
+		t.Fatalf("ConvertWithTableData() 返回错误: %v", err)
+	}
+
+	// 应该有 3 个顶层块: Text("123"), QuoteContainer, Text("321")
+	if len(result.BlockNodes) != 3 {
+		t.Fatalf("期望 3 个顶层块, 实际 %d 个", len(result.BlockNodes))
+	}
+
+	// 第一个块: Text "123"
+	first := result.BlockNodes[0]
+	if first.Block.BlockType == nil || *first.Block.BlockType != int(BlockTypeText) {
+		t.Errorf("第一个块类型 = %v, 期望 %d (Text)", first.Block.BlockType, int(BlockTypeText))
+	}
+
+	// 第二个块: QuoteContainer
+	quote := result.BlockNodes[1]
+	if quote.Block.BlockType == nil || *quote.Block.BlockType != int(BlockTypeQuoteContainer) {
+		t.Errorf("第二个块类型 = %v, 期望 %d (QuoteContainer)", quote.Block.BlockType, int(BlockTypeQuoteContainer))
+	}
+
+	// QuoteContainer 子块应该有段落间的空行分隔:
+	// "12312323213", empty, "213213", empty, "1"
+	if len(quote.Children) != 5 {
+		t.Fatalf("QuoteContainer 子块数 = %d, 期望 5 (含段落间空行)", len(quote.Children))
+	}
+
+	// 检查内容: [0]=12312323213, [1]=empty, [2]=213213, [3]=empty, [4]=1
+	getTextContent := func(node *BlockNode) string {
+		if node.Block.Text == nil || len(node.Block.Text.Elements) == 0 {
+			return ""
+		}
+		elem := node.Block.Text.Elements[0]
+		if elem.TextRun != nil && elem.TextRun.Content != nil {
+			return *elem.TextRun.Content
+		}
+		return ""
+	}
+	expected := []string{"12312323213", "", "213213", "", "1"}
+	for i, exp := range expected {
+		got := getTextContent(quote.Children[i])
+		if got != exp {
+			t.Errorf("QuoteContainer 子块[%d] 内容 = %q, 期望 %q", i, got, exp)
+		}
+	}
+
+	// 第三个块: Text "321"
+	last := result.BlockNodes[2]
+	if last.Block.BlockType == nil || *last.Block.BlockType != int(BlockTypeText) {
+		t.Errorf("第三个块类型 = %v, 期望 %d (Text)", last.Block.BlockType, int(BlockTypeText))
+	}
+}
+
+// TestNormalizeBlockquoteEnding 测试引用块结束标准化
+func TestNormalizeBlockquoteEnding(t *testing.T) {
+	tests := []struct {
+		name   string
+		input  string
+		expect string
+	}{
+		{
+			name:   "引用块后紧跟非引用行",
+			input:  "> line1\nnext",
+			expect: "> line1\n\nnext",
+		},
+		{
+			name:   "引用块后已有空行",
+			input:  "> line1\n\nnext",
+			expect: "> line1\n\nnext",
+		},
+		{
+			name:   "代码块内的 > 不处理",
+			input:  "```\n> not quote\nnext\n```",
+			expect: "```\n> not quote\nnext\n```",
+		},
+		{
+			name:   "引用块后是空行不插入",
+			input:  "> line1\n",
+			expect: "> line1\n",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := string(normalizeBlockquoteEnding([]byte(tt.input)))
+			if got != tt.expect {
+				t.Errorf("normalizeBlockquoteEnding(%q) = %q, 期望 %q", tt.input, got, tt.expect)
+			}
+		})
+	}
+}
+
 func TestConvert_ThematicBreak(t *testing.T) {
 	markdown := "段落一\n\n---\n\n段落二"
 


### PR DESCRIPTION
# Summary
  - 修复 goldmark lazy continuation 导致引用块后紧跟的文本被错误吞入引用块
  - 修复多段落引用块导入时段落间空行丢失
  - 修复引用块导出时段落间距消失
  - 修复空引用块使用空 Elements 数组导致 API 异常

  ## Background
  三个独立 bug，均与 QuoteContainer 相关：

  1. **lazy continuation 吞文本**：goldmark 将引用块后紧跟的非引用行视为引用块的一部分（如 `> 引用\n这行被吞掉`）
  2. **多段落空行丢失**：`> 段落1\n>\n> 段落2` 中间的空行在导入时丢失，两个段落合并为一个
  3. **导出空行未还原**：导出时跳过了所有空文本子块，多段落引用块的段落间空行消失

  ## Usage
  导入导出行为修复，无新增 API 或命令。修复前后对比：

  ```
  输入 Markdown：
    123
    > 第一段
    >
    > 第二段
    321

  修复前：
    - "321" 被吞入引用块
    - 引用块内两段落间无空行
    - 导出后空行丢失

  修复后：
    - "123" 和 "321" 作为独立段落
    - 引用块内段落间正确保留空行
    - 导入 → 导出 roundtrip 保持一致
  ```

  ## Changes
  | 文件 | 改动说明 |
  |------|---------|
  | `internal/converter/markdown_to_block.go` | 新增 `normalizeBlockquoteEnding` 预处理函数；`convertBlockquote` 段落间插入空 Text 块；空引用块 fallback  改为含空内容 TextRun |
  | `internal/converter/block_to_markdown.go` | `convertQuoteContainerWithDepth` 跳过开头空行，保留中间空行输出 `>` |
  | `internal/converter/markdown_to_block_test.go` | 新增 2 个测试函数 |

  ## Test Plan
  ### 常规检查
  - [x] `go build ./...` 编译通过
  - [x] `go vet ./...` 静态检查通过
  - [x] `go clean -testcache && go test ./...` 全部测试通过（除上游已有的 `TestInit_DefaultValues`）

  ### 新增用例
  | 用例 | 覆盖场景 |
  |------|---------|
  | `TestConvert_BlockquoteMultiParagraphWithSurrounding` | 引用块前后文本不被吞入 + 多段落空行保留 + QuoteContainer 子块数量和内容验证 |
  | `TestNormalizeBlockquoteEnding`（4 个子用例） | 引用块后紧跟非引用行、已有空行不重复插入、代码块内 `>` 不处理、末尾空行不插入 |