### PR TITLE
fix: 修复 config 测试因读取本机配置文件导致断言失败

### DIFF
--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -42,6 +42,12 @@ func TestInit_WithEnvVariables(t *testing.T) {
 func TestInit_DefaultValues(t *testing.T) {
 	resetConfig()
 
+	// 隔离本地配置文件：临时替换 HOME，避免读到 ~/.feishu-cli/config.yaml
+	tmpDir := t.TempDir()
+	originalHome := os.Getenv("HOME")
+	os.Setenv("HOME", tmpDir)
+	defer os.Setenv("HOME", originalHome)
+
 	// 清除可能存在的环境变量
 	os.Unsetenv("FEISHU_APP_ID")
 	os.Unsetenv("FEISHU_APP_SECRET")


### PR DESCRIPTION
## Summary
  - 修复 `TestInit_DefaultValues` 因读取本机配置文件导致断言失败

  ## Background
本地环境有配置文件，运行测试用例时，会读取到配置文件的值，干扰用例结果。
  `TestInit_DefaultValues` 测试默认配置值，但未隔离 HOME 目录。当开发者本机存在 `~/.feishu-cli/config.yaml` 时，viper 会加载真实配置覆盖默认值，导致 `BaseURL` 等字段断言失败。测试结果取决于运行环境，不可复现。

  ## Changes
  | 文件 | 改动说明 |
  |------|---------|
  | `internal/config/config_test.go` | 将 HOME 环境变量临时替换为 `t.TempDir()`，测试结束后恢复 |

  ## Test Plan
  ### 常规检查
  - [x] `go build ./...` 编译通过
  - [x] `go vet ./...` 静态检查通过
  - [x] `go clean -testcache && go test ./...` 全部测试通过（含此前失败的 `TestInit_DefaultValues`）

  ### 变更用例
  | 用例 | 变更说明 |
  |------|---------|
  | `TestInit_DefaultValues` | 新增 HOME 隔离逻辑（+6 行），确保不读取真实配置文件，测试结果不依赖运行环境 |