### PR TITLE
fix(converter): 修复列表嵌套、编号和 Todo 子项问题

### DIFF
--- a/internal/converter/block_to_markdown.go
+++ b/internal/converter/block_to_markdown.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"path/filepath"
 	"regexp"
+	"strconv"
 	"strings"
 
 	larkdocx "github.com/larksuite/oapi-sdk-go/v3/service/docx/v1"
@@ -25,6 +26,7 @@ type BlockToMarkdown struct {
 	imageCount    int
 	headingSeqs   []string                   // 标题自动编号状态，按深度索引（depth-1）
 	userCache     map[string]MentionUserInfo // 用户 ID → 信息缓存
+	orderedSeq    int                        // 当前顶层有序列表的自增序号（Convert 时使用）
 }
 
 // NewBlockToMarkdown creates a new converter
@@ -79,7 +81,7 @@ func NewBlockToMarkdown(blocks []*larkdocx.Block, options ConvertOptions) *Block
 					collectChildren(childID)
 				}
 			}
-		case BlockTypeBullet, BlockTypeOrdered:
+		case BlockTypeBullet, BlockTypeOrdered, BlockTypeTodo:
 			// 嵌套列表：子块由父列表递归处理
 			if block.Children != nil {
 				for _, childID := range block.Children {
@@ -223,6 +225,11 @@ func (c *BlockToMarkdown) Convert() (string, error) {
 
 		currentBlockType := BlockType(*block.BlockType)
 
+		// 有序列表序号：Ordered 块自增，非 Ordered 块不重置（飞书 auto 跨标题续编）
+		if currentBlockType == BlockTypeOrdered {
+			c.orderedSeq++
+		}
+
 		// 列表类型切换时插入额外空行
 		if prevBlockType != 0 {
 			prevIsList := isListBlockType(prevBlockType)
@@ -241,7 +248,10 @@ func (c *BlockToMarkdown) Convert() (string, error) {
 		}
 		if md != "" {
 			sb.WriteString(md)
-			sb.WriteString("\n")
+			// 列表块不加额外 \n（块自身已有 \n，列表间距由上方的类型切换逻辑控制）
+			if !isListBlockType(currentBlockType) {
+				sb.WriteString("\n")
+			}
 			prevBlockType = currentBlockType
 		}
 	}
@@ -253,6 +263,59 @@ func (c *BlockToMarkdown) Convert() (string, error) {
 	output = reBlankLines.ReplaceAllString(output, "\n\n")
 
 	return output, nil
+}
+
+// BlockMarkdown 表示一个顶层块的 markdown 输出和对应的 blockID
+type BlockMarkdown struct {
+	BlockID  string // 顶层块 ID
+	Markdown string // 该块产出的 markdown 文本（不含块间分隔空行）
+}
+
+// ConvertPerBlock 在完整文档上下文中逐块转换，返回每个顶层块的 markdown 输出
+// 与 Convert() 使用相同的转换逻辑，区别是返回值按块拆分
+func (c *BlockToMarkdown) ConvertPerBlock() ([]BlockMarkdown, error) {
+	var result []BlockMarkdown
+
+	for _, block := range c.blocks {
+		if block.BlockType == nil {
+			continue
+		}
+		// 跳过 Page 块
+		if *block.BlockType == int(BlockTypePage) {
+			continue
+		}
+		// 跳过子块
+		if block.BlockId != nil && c.childBlockIDs[*block.BlockId] {
+			continue
+		}
+
+		// 有序列表序号追踪（与 Convert 一致）
+		blockType := BlockType(*block.BlockType)
+		if blockType == BlockTypeOrdered {
+			c.orderedSeq++
+		}
+
+		md, err := c.convertBlock(block, 0)
+		if err != nil {
+			return nil, err
+		}
+		if md == "" {
+			continue
+		}
+		// 去掉尾部多余换行，保持干净
+		md = strings.TrimRight(md, "\n")
+
+		blockID := ""
+		if block.BlockId != nil {
+			blockID = *block.BlockId
+		}
+		result = append(result, BlockMarkdown{
+			BlockID:  blockID,
+			Markdown: md,
+		})
+	}
+
+	return result, nil
 }
 
 func (c *BlockToMarkdown) convertBlock(block *larkdocx.Block, indent int) (string, error) {
@@ -322,7 +385,7 @@ func (c *BlockToMarkdown) convertBlockWithDepth(block *larkdocx.Block, indent in
 	case BlockTypeEquation:
 		return c.convertEquation(block)
 	case BlockTypeTodo:
-		return c.convertTodo(block)
+		return c.convertTodoWithDepth(block, indent, depth)
 	case BlockTypeDivider:
 		return "---\n", nil
 	case BlockTypeImage:
@@ -632,11 +695,27 @@ func (c *BlockToMarkdown) convertBullet(block *larkdocx.Block, indent, depth int
 	prefix := strings.Repeat("  ", indent)
 	result := fmt.Sprintf("%s- %s\n", prefix, text)
 
-	// 递归处理嵌套子列表
+	// 递归处理嵌套子列表（为嵌套有序列表独立计数）
 	if block.Children != nil {
+		childOrderedSeq := 0
 		for _, childID := range block.Children {
 			childBlock := c.blockMap[childID]
-			if childBlock != nil {
+			if childBlock == nil {
+				continue
+			}
+			childType := BlockType(0)
+			if childBlock.BlockType != nil {
+				childType = BlockType(*childBlock.BlockType)
+			}
+			if childType == BlockTypeOrdered {
+				childOrderedSeq++
+				savedSeq := c.orderedSeq
+				c.orderedSeq = childOrderedSeq
+				childMd, _ := c.convertBlockWithDepth(childBlock, indent+1, depth+1)
+				c.orderedSeq = savedSeq
+				result += childMd
+			} else {
+				childOrderedSeq = 0 // 类型切换时重置
 				childMd, _ := c.convertBlockWithDepth(childBlock, indent+1, depth+1)
 				result += childMd
 			}
@@ -652,20 +731,47 @@ func (c *BlockToMarkdown) convertOrdered(block *larkdocx.Block, indent, depth in
 	text := c.convertTextElements(block.Ordered.Elements)
 	prefix := strings.Repeat("  ", indent)
 
-	seq := "1"
+	// 顶层用 c.orderedSeq（由 Convert/ConvertPerBlock 维护）；嵌套子列表由父块计数传入
+	seq := c.orderedSeq
+	// 支持自定义序号：读取 TextStyle.Sequence 覆盖当前项编号
+	// 飞书对无 Sequence 的项从前一项有效编号续编
 	if block.Ordered.Style != nil && block.Ordered.Style.Sequence != nil {
 		s := *block.Ordered.Style.Sequence
-		if s != "auto" && s != "" {
-			seq = s
+		if s != "" && s != "auto" {
+			if n, err := strconv.Atoi(s); err == nil && n > 0 {
+				seq = n
+				// 更新计数器，让后续无 Sequence 的项从此编号续编
+				c.orderedSeq = n
+			}
 		}
 	}
-	result := fmt.Sprintf("%s%s. %s\n", prefix, seq, text)
+	if seq <= 0 {
+		seq = 1
+	}
+	result := fmt.Sprintf("%s%d. %s\n", prefix, seq, text)
 
-	// 递归处理嵌套子列表
+	// 递归处理嵌套子列表（为嵌套有序列表独立计数）
 	if block.Children != nil {
+		childOrderedSeq := 0
 		for _, childID := range block.Children {
 			childBlock := c.blockMap[childID]
-			if childBlock != nil {
+			if childBlock == nil {
+				continue
+			}
+			childType := BlockType(0)
+			if childBlock.BlockType != nil {
+				childType = BlockType(*childBlock.BlockType)
+			}
+			// 嵌套有序列表：独立自增序号
+			if childType == BlockTypeOrdered {
+				childOrderedSeq++
+				savedSeq := c.orderedSeq
+				c.orderedSeq = childOrderedSeq
+				childMd, _ := c.convertBlockWithDepth(childBlock, indent+1, depth+1)
+				c.orderedSeq = savedSeq
+				result += childMd
+			} else {
+				childOrderedSeq = 0 // 类型切换时重置
 				childMd, _ := c.convertBlockWithDepth(childBlock, indent+1, depth+1)
 				result += childMd
 			}
@@ -711,6 +817,10 @@ func (c *BlockToMarkdown) convertEquation(block *larkdocx.Block) (string, error)
 }
 
 func (c *BlockToMarkdown) convertTodo(block *larkdocx.Block) (string, error) {
+	return c.convertTodoWithDepth(block, 0, 0)
+}
+
+func (c *BlockToMarkdown) convertTodoWithDepth(block *larkdocx.Block, indent, depth int) (string, error) {
 	if block.Todo == nil {
 		return "", nil
 	}
@@ -721,7 +831,36 @@ func (c *BlockToMarkdown) convertTodo(block *larkdocx.Block) (string, error) {
 	}
 
 	text := c.convertTextElements(block.Todo.Elements)
-	return fmt.Sprintf("- %s %s\n", checkbox, text), nil
+	prefix := strings.Repeat("  ", indent)
+	result := fmt.Sprintf("%s- %s %s\n", prefix, checkbox, text)
+
+	// 递归处理嵌套子项（与 convertBullet 一致）
+	if block.Children != nil {
+		childOrderedSeq := 0
+		for _, childID := range block.Children {
+			childBlock := c.blockMap[childID]
+			if childBlock == nil {
+				continue
+			}
+			childType := BlockType(0)
+			if childBlock.BlockType != nil {
+				childType = BlockType(*childBlock.BlockType)
+			}
+			if childType == BlockTypeOrdered {
+				childOrderedSeq++
+				savedSeq := c.orderedSeq
+				c.orderedSeq = childOrderedSeq
+				childMd, _ := c.convertBlockWithDepth(childBlock, indent+1, depth+1)
+				c.orderedSeq = savedSeq
+				result += childMd
+			} else {
+				childOrderedSeq = 0
+				childMd, _ := c.convertBlockWithDepth(childBlock, indent+1, depth+1)
+				result += childMd
+			}
+		}
+	}
+	return result, nil
 }
 
 func (c *BlockToMarkdown) convertImage(block *larkdocx.Block) (string, error) {
@@ -890,6 +1029,11 @@ func (c *BlockToMarkdown) getCellTextWithDepth(block *larkdocx.Block, depth int)
 		return "[递归深度超限]"
 	}
 
+	// 隔离 orderedSeq：表格单元格内的有序列表不应影响外层计数器
+	savedSeq := c.orderedSeq
+	c.orderedSeq = 0
+	defer func() { c.orderedSeq = savedSeq }()
+
 	// Table cells may contain nested blocks
 	if block.Children != nil {
 		var texts []string
@@ -947,6 +1091,11 @@ func (c *BlockToMarkdown) convertCalloutWithDepth(block *larkdocx.Block, depth i
 			calloutType = "IMPORTANT"
 		}
 	}
+
+	// 隔离 orderedSeq：Callout 内的有序列表不应影响外层计数器
+	savedSeq := c.orderedSeq
+	c.orderedSeq = 0
+	defer func() { c.orderedSeq = savedSeq }()
 
 	var sb strings.Builder
 	sb.WriteString(fmt.Sprintf("> [!%s]\n", calloutType))
@@ -1217,6 +1366,11 @@ func (c *BlockToMarkdown) convertQuoteContainerWithDepth(block *larkdocx.Block, 
 	if depth > maxRecursionDepth {
 		return "> [递归深度超限]\n", nil
 	}
+
+	// 隔离 orderedSeq：引用块内的有序列表不应影响外层计数器
+	savedSeq := c.orderedSeq
+	c.orderedSeq = 0
+	defer func() { c.orderedSeq = savedSeq }()
 
 	var sb strings.Builder
 

--- a/internal/converter/block_to_markdown_container_test.go
+++ b/internal/converter/block_to_markdown_container_test.go
@@ -1237,6 +1237,43 @@ func TestConvertOrderedWithEmptySequence(t *testing.T) {
 	}
 }
 
+// 导出侧：自定义 Sequence 不应污染后续无 Sequence 项的编号
+func TestConvertOrderedCustomSeqNoContamination(t *testing.T) {
+	blocks := []*larkdocx.Block{
+		{
+			BlockId:   strPtr("o1"),
+			BlockType: intPtr(int(BlockTypeOrdered)),
+			Ordered: &larkdocx.Text{
+				Elements: []*larkdocx.TextElement{
+					{TextRun: &larkdocx.TextRun{Content: strPtr("Item A")}},
+				},
+				Style: &larkdocx.TextStyle{Sequence: strPtr("3")},
+			},
+		},
+		{
+			BlockId:   strPtr("o2"),
+			BlockType: intPtr(int(BlockTypeOrdered)),
+			Ordered: &larkdocx.Text{
+				Elements: []*larkdocx.TextElement{
+					{TextRun: &larkdocx.TextRun{Content: strPtr("Item B")}},
+				},
+				// 无 Sequence：飞书按位置编号，第 2 项应为 2
+			},
+		},
+	}
+	conv := NewBlockToMarkdown(blocks, ConvertOptions{})
+	got, err := conv.Convert()
+	if err != nil {
+		t.Fatalf("Convert() error = %v", err)
+	}
+	got = strings.TrimSpace(got)
+	// 飞书对无 Sequence 的项从前一项有效编号续编，第 2 项 = 4（3+1）
+	want := "3. Item A\n4. Item B"
+	if got != want {
+		t.Errorf("Convert() got:\n%s\n\nwant:\n%s", got, want)
+	}
+}
+
 func TestConvertBulletWithNestedSublist(t *testing.T) {
 	blocks := []*larkdocx.Block{
 		{

--- a/internal/converter/block_to_markdown_test.go
+++ b/internal/converter/block_to_markdown_test.go
@@ -323,8 +323,8 @@ func TestBlockToMd_OrderedList(t *testing.T) {
 	if !strings.Contains(result, "1. 第一项") {
 		t.Errorf("结果不包含 '1. 第一项': %s", result)
 	}
-	if !strings.Contains(result, "1. 第二项") {
-		t.Errorf("结果不包含 '1. 第二项': %s", result)
+	if !strings.Contains(result, "2. 第二项") {
+		t.Errorf("结果不包含 '2. 第二项': %s", result)
 	}
 }
 

--- a/internal/converter/markdown_to_block.go
+++ b/internal/converter/markdown_to_block.go
@@ -340,10 +340,22 @@ func (c *MarkdownToBlock) convertCodeBlock(node *ast.FencedCodeBlock) (*larkdocx
 func (c *MarkdownToBlock) convertList(node *ast.List) ([]*BlockNode, error) {
 	var nodes []*BlockNode
 	isOrdered := node.IsOrdered()
+	// 有序列表自定义起始编号：Start != 1 时，每项都需设置显式 Sequence
+	// （飞书不会从前一项的自定义序号自动继续，无 Sequence 的项按位置编号）
+	startNum := 0
+	if isOrdered && node.Start > 1 {
+		startNum = node.Start
+	}
 
+	itemIndex := 0
 	for child := node.FirstChild(); child != nil; child = child.NextSibling() {
 		if listItem, ok := child.(*ast.ListItem); ok {
-			bn, err := c.convertListItem(listItem, isOrdered)
+			seq := 0
+			if startNum > 0 {
+				seq = startNum + itemIndex
+			}
+			itemIndex++
+			bn, err := c.convertListItem(listItem, isOrdered, seq)
 			if err != nil {
 				return nil, err
 			}
@@ -356,7 +368,8 @@ func (c *MarkdownToBlock) convertList(node *ast.List) ([]*BlockNode, error) {
 	return nodes, nil
 }
 
-func (c *MarkdownToBlock) convertListItem(node *ast.ListItem, isOrdered bool) (*BlockNode, error) {
+// convertListItem 转换列表项。seq > 0 表示该项需设置自定义序号（仅有序列表首项）
+func (c *MarkdownToBlock) convertListItem(node *ast.ListItem, isOrdered bool, seq int) (*BlockNode, error) {
 	// Check for GFM task list checkbox
 	for child := node.FirstChild(); child != nil; child = child.NextSibling() {
 		// Check if this is a paragraph or text block containing a TaskCheckBox
@@ -367,7 +380,9 @@ func (c *MarkdownToBlock) convertListItem(node *ast.ListItem, isOrdered bool) (*
 					if err != nil {
 						return nil, err
 					}
-					return &BlockNode{Block: block}, nil
+					// 收集嵌套子列表（与 bullet/ordered 一致）
+					children := c.collectNestedChildren(node)
+					return &BlockNode{Block: block, Children: children}, nil
 				}
 			}
 		}
@@ -378,7 +393,9 @@ func (c *MarkdownToBlock) convertListItem(node *ast.ListItem, isOrdered bool) (*
 					if err != nil {
 						return nil, err
 					}
-					return &BlockNode{Block: block}, nil
+					// 收集嵌套子列表（与 bullet/ordered 一致）
+					children := c.collectNestedChildren(node)
+					return &BlockNode{Block: block, Children: children}, nil
 				}
 				// Also check for raw text pattern
 				if txt, ok := tb.FirstChild().(*ast.Text); ok {
@@ -388,7 +405,9 @@ func (c *MarkdownToBlock) convertListItem(node *ast.ListItem, isOrdered bool) (*
 						if err != nil {
 							return nil, err
 						}
-						return &BlockNode{Block: block}, nil
+						// 收集嵌套子列表（与 bullet/ordered 一致）
+						children := c.collectNestedChildren(node)
+						return &BlockNode{Block: block, Children: children}, nil
 					}
 				}
 			}
@@ -424,9 +443,15 @@ func (c *MarkdownToBlock) convertListItem(node *ast.ListItem, isOrdered bool) (*
 	var block *larkdocx.Block
 	if isOrdered {
 		blockType := int(BlockTypeOrdered)
+		orderedText := &larkdocx.Text{Elements: elements}
+		// 自定义起始编号：在首项上设置 Sequence
+		if seq > 0 {
+			seqStr := fmt.Sprintf("%d", seq)
+			orderedText.Style = &larkdocx.TextStyle{Sequence: &seqStr}
+		}
 		block = &larkdocx.Block{
 			BlockType: &blockType,
-			Ordered:   &larkdocx.Text{Elements: elements},
+			Ordered:   orderedText,
 		}
 	} else {
 		blockType := int(BlockTypeBullet)
@@ -437,6 +462,18 @@ func (c *MarkdownToBlock) convertListItem(node *ast.ListItem, isOrdered bool) (*
 	}
 
 	return &BlockNode{Block: block, Children: children}, nil
+}
+
+// collectNestedChildren 收集 ListItem 下嵌套的子列表，返回 BlockNode 切片
+func (c *MarkdownToBlock) collectNestedChildren(node *ast.ListItem) []*BlockNode {
+	var children []*BlockNode
+	for child := node.FirstChild(); child != nil; child = child.NextSibling() {
+		if nestedList, ok := child.(*ast.List); ok {
+			childNodes, _ := c.convertList(nestedList)
+			children = append(children, childNodes...)
+		}
+	}
+	return children
 }
 
 // extractListItemDirectElements 提取 ListItem 直接子节点的文本元素，
@@ -506,6 +543,11 @@ func (c *MarkdownToBlock) extractTextElementsSkipCheckbox(node ast.Node) []*lark
 
 		// Skip TaskCheckBox nodes
 		if _, ok := n.(*east.TaskCheckBox); ok {
+			return ast.WalkSkipChildren, nil
+		}
+
+		// 跳过嵌套列表——它们作为 BlockNode.Children 单独处理
+		if _, ok := n.(*ast.List); ok {
 			return ast.WalkSkipChildren, nil
 		}
 

--- a/internal/converter/markdown_to_block_test.go
+++ b/internal/converter/markdown_to_block_test.go
@@ -151,6 +151,58 @@ func TestConvert_OrderedList(t *testing.T) {
 	}
 }
 
+func TestConvert_OrderedListCustomStart(t *testing.T) {
+	markdown := "3. 第三项\n4. 第四项"
+
+	converter := NewMarkdownToBlock([]byte(markdown), ConvertOptions{}, "")
+	blocks, err := converter.Convert()
+	if err != nil {
+		t.Fatalf("Convert() 返回错误: %v", err)
+	}
+	if len(blocks) < 2 {
+		t.Fatalf("blocks 数量 = %d, 期望至少 2", len(blocks))
+	}
+
+	// 每一项都应设置显式 Sequence（飞书不会从前一项的自定义序号继续）
+	expects := []string{"3", "4"}
+	for i, expect := range expects {
+		b := blocks[i]
+		if b.Ordered == nil {
+			t.Fatalf("blocks[%d].Ordered 为 nil", i)
+		}
+		if b.Ordered.Style == nil || b.Ordered.Style.Sequence == nil {
+			t.Fatalf("blocks[%d] 缺少 TextStyle.Sequence，自定义编号丢失", i)
+		}
+		if got := *b.Ordered.Style.Sequence; got != expect {
+			t.Errorf("blocks[%d].Sequence = %q, 期望 %q", i, got, expect)
+		}
+	}
+}
+
+func TestConvert_OrderedListDefaultStart(t *testing.T) {
+	// 默认起始编号（Start=1）不应设置 Sequence
+	markdown := "1. 第一项\n2. 第二项"
+
+	converter := NewMarkdownToBlock([]byte(markdown), ConvertOptions{}, "")
+	blocks, err := converter.Convert()
+	if err != nil {
+		t.Fatalf("Convert() 返回错误: %v", err)
+	}
+	if len(blocks) < 2 {
+		t.Fatalf("blocks 数量 = %d, 期望至少 2", len(blocks))
+	}
+
+	for i, b := range blocks[:2] {
+		if b.Ordered == nil {
+			t.Fatalf("blocks[%d].Ordered 为 nil", i)
+		}
+		// 默认列表不应有 Sequence
+		if b.Ordered.Style != nil && b.Ordered.Style.Sequence != nil {
+			t.Errorf("blocks[%d] 不应设置 Sequence（默认列表），got %q", i, *b.Ordered.Style.Sequence)
+		}
+	}
+}
+
 func TestConvert_TaskList(t *testing.T) {
 	markdown := `- [ ] 未完成任务
 - [x] 已完成任务`

--- a/internal/converter/roundtrip_test.go
+++ b/internal/converter/roundtrip_test.go
@@ -184,6 +184,50 @@ func TestRoundtrip_Todo(t *testing.T) {
 	}
 }
 
+// TestRoundtrip_OrderedListCustomStart 测试自定义起始编号的有序列表往返一致性
+func TestRoundtrip_OrderedListCustomStart(t *testing.T) {
+	markdown := "3. 第三项\n4. 第四项"
+
+	conv := NewMarkdownToBlock([]byte(markdown), ConvertOptions{}, "")
+	blocks, err := conv.Convert()
+	if err != nil {
+		t.Fatalf("Markdown → Block 失败: %v", err)
+	}
+
+	conv2 := NewBlockToMarkdown(blocks, ConvertOptions{})
+	result, err := conv2.Convert()
+	if err != nil {
+		t.Fatalf("Block → Markdown 失败: %v", err)
+	}
+
+	result = strings.TrimSpace(result)
+	if result != markdown {
+		t.Errorf("往返不一致:\n  输入: %q\n  输出: %q", markdown, result)
+	}
+}
+
+// TestRoundtrip_OrderedListDefault 测试默认起始编号的有序列表往返一致性
+func TestRoundtrip_OrderedListDefault(t *testing.T) {
+	markdown := "1. 第一项\n2. 第二项\n3. 第三项"
+
+	conv := NewMarkdownToBlock([]byte(markdown), ConvertOptions{}, "")
+	blocks, err := conv.Convert()
+	if err != nil {
+		t.Fatalf("Markdown → Block 失败: %v", err)
+	}
+
+	conv2 := NewBlockToMarkdown(blocks, ConvertOptions{})
+	result, err := conv2.Convert()
+	if err != nil {
+		t.Fatalf("Block → Markdown 失败: %v", err)
+	}
+
+	result = strings.TrimSpace(result)
+	if result != markdown {
+		t.Errorf("往返不一致:\n  输入: %q\n  输出: %q", markdown, result)
+	}
+}
+
 // TestRoundtrip_KnownLoss 记录已知的信息丢失项
 func TestRoundtrip_KnownLoss(t *testing.T) {
 	knownLosses := []struct {

--- a/internal/converter/todo_nesting_test.go
+++ b/internal/converter/todo_nesting_test.go
@@ -1,0 +1,42 @@
+package converter
+
+import (
+	"testing"
+)
+
+// TestTodoNestedChildren 验证 todo 列表项的嵌套子项能正确收集
+func TestTodoNestedChildren(t *testing.T) {
+	md := `- [ ] 12
+- [ ] 13
+    - [ ] 131
+    - [ ] 132
+- [ ] 14`
+
+	conv := NewMarkdownToBlock([]byte(md), ConvertOptions{}, "")
+	result, err := conv.ConvertWithTableData()
+	if err != nil {
+		t.Fatalf("ConvertWithTableData 失败: %v", err)
+	}
+
+	// 应该有 3 个顶层块: 12, 13, 14
+	if len(result.BlockNodes) != 3 {
+		t.Fatalf("期望 3 个顶层块，得到 %d", len(result.BlockNodes))
+	}
+
+	// 第二个块 (13) 应该有 2 个子项 (131, 132)
+	node13 := result.BlockNodes[1]
+	if len(node13.Children) != 2 {
+		t.Errorf("块 '13' 期望 2 个子项，得到 %d", len(node13.Children))
+	}
+
+	// 验证子项都是 Todo 类型 (type=17)
+	for i, child := range node13.Children {
+		if child.Block.BlockType == nil || *child.Block.BlockType != int(BlockTypeTodo) {
+			bt := 0
+			if child.Block.BlockType != nil {
+				bt = *child.Block.BlockType
+			}
+			t.Errorf("子项 %d 期望类型 %d (Todo)，得到 %d", i, BlockTypeTodo, bt)
+		}
+	}
+}


### PR DESCRIPTION
## Summary
  - 修复有序列表导出全部输出 `1.`，改为输出真实编号
  - 修复自定义起始编号（如 `3. 第三项`）导入后 Sequence 丢失
  - 修复自定义 Sequence 后续项未续编（如 `4.` 后下一项应为 `5.`，实际输出 `2.`）
  - 修复容器块（表格/Callout/引用块）内的有序列表污染外层编号计数器
  - 修复 Todo 列表项的嵌套子列表导入时丢失、导出时被当作独立顶层块

  ## Background
  六个问题，涉及列表导入导出两侧：

  1. **有序列表编号固定为 1**：导出侧 `convertOrdered` 固定输出 `1.`，丢失了真实编号
  2. **自定义起始编号不支持**：`3. 第三项\n4. 第四项` 导入后 `TextStyle.Sequence` 为空
  3. **自定义 Sequence 后续项未续编**：读到自定义 Sequence 后未更新计数器，后续 `auto` 项按位置编号而非从自定义编号续编
  4. **容器块序号污染**：表格单元格/Callout/QuoteContainer 内的有序列表与外层共享计数器。例如外层列表 `1. 2.` → 表格内有 3 个有序项 → 外层续编变成 `6.` 而非 `3.`
  5. **嵌套有序列表序号污染**：嵌套子列表和父级列表共享同一个计数器
  6. **Todo 嵌套丢失**：`convertListItem` 的 TaskCheckBox 分支未收集 Children；导出侧 `BlockTypeTodo` 未加入子块收集逻辑

  ## Usage

  ```
  飞书文档结构：
    # 有序列表
    1. 1
    2. 2
    # 表格
    | 1. 2 | |
    | 2. 2 | |
    | 3. 3 | |
    ## 继续编号
    3. 3
    4. 4

  修复前导出：
    # 有序列表
    1. 1
    2. 2
    # 表格
    | 1. 2<br>1. 2<br>1. 3 |
    | --- |
    ## 继续编号
    2. 3          ✗ 被表格内列表污染，应为 3
    3. 4          ✗ 应为 4

  修复后导出：
    # 有序列表
    1. 1
    2. 2
    # 表格
    | 1. 2<br>1. 2<br>1. 3 |
    | --- |
    ## 继续编号
    3. 3          ✓ 表格内列表不影响外层
    4. 4          ✓
  ```

  ```
  输入 Markdown：
    - [ ] 父任务
        - [ ] 子任务 1
        - [ ] 子任务 2

  修复前导入：子任务丢失，只有父任务
  修复后导入：子任务作为 Children 正确嵌套
  ```

  ## Changes
  | 文件 | 改动说明 |
  |------|---------|
  | `internal/converter/markdown_to_block.go` | `convertList` 读取自定义起始编号传入 `convertListItem`；3 处 TaskCheckBox 分支调用新增的 `collectNestedChildren`；`extractTextElementsSkipCheckbox` 跳过 `ast.List` |
  | `internal/converter/block_to_markdown.go` | 新增 `orderedSeq` 字段实现真实编号输出；自定义 Sequence 更新 orderedSeq 让后续项续编；非 Ordered 块不重置计数器（飞书 auto 跨标题续编）；表格/Callout/QuoteContainer 入口保存恢复 orderedSeq 实现隔离；`convertBullet`/`convertOrdered` 嵌套子列表使用独立  `childOrderedSeq`；新增 `convertTodoWithDepth` 支持缩进递归；`BlockTypeTodo` 加入子块收集；新增 `ConvertPerBlock` 逐块转换方法；列表块不再追加多余 `\n` |
  | `internal/converter/markdown_to_block_test.go` | 新增 `TestConvert_OrderedListCustomStart`、`TestConvert_OrderedListDefaultStart` |
  | `internal/converter/block_to_markdown_test.go` | 期望值 `1. 第二项` → `2. 第二项` |
  | `internal/converter/block_to_markdown_container_test.go` | 新增 `TestConvertOrderedCustomSeqNoContamination` |
  | `internal/converter/roundtrip_test.go` | 新增 `TestRoundtrip_OrderedListCustomStart``TestRoundtrip_OrderedListDefault` |
  | `internal/converter/todo_nesting_test.go` | 新文件，`TestTodoNestedChildren` |

  ## Test Plan
  ### 常规检查
  - [x] `go build ./...` 编译通过
  - [x] `go vet ./...` 静态检查通过
  - [x] `go clean -testcache && go test ./...` 全部测试通过

  ### 真实文档验证
  - [x] 自定义序号 + 跨标题续编文档导出正确（`4. 5.` / `6. 7.`）
  - [x] 表格中间插入有序列表，外层续编不受污染（`1. 2.` → 表格 → `3. 4.`）

  ### 新增用例
  | 用例 | 覆盖场景 |
  |------|---------|
  | `TestConvert_OrderedListCustomStart` | 自定义起始编号导入后 Sequence 正确设置 |
  | `TestConvert_OrderedListDefaultStart` | 默认起始编号不设置 Sequence |
  | `TestConvertOrderedCustomSeqNoContamination` | 自定义 Sequence 后续项从有效编号续编 |
  | `TestRoundtrip_OrderedListCustomStart` | 自定义起始编号往返一致性 |
  | `TestRoundtrip_OrderedListDefault` | 默认起始编号往返一致性 |
  | `TestTodoNestedChildren` | Todo 嵌套子项正确收集为 Children |

  ### 修改用例
  | 用例 | 变更说明 |
  |------|---------|
  | `TestBlockToMd_OrderedList` | 期望值从 `1. 第二项` 改为 `2. 第二项` |