### PR TITLE
feat(client): disk cache for tenant_access_token across CLI invocations

### DIFF
--- a/internal/client/cache.go
+++ b/internal/client/cache.go
@@ -1,0 +1,137 @@
+package client
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"sync"
+	"time"
+
+	larkcore "github.com/larksuite/oapi-sdk-go/v3/core"
+)
+
+// cacheEntry 缓存条目，包含值和过期时间
+type cacheEntry struct {
+	Value     string    `json:"value"`
+	ExpiresAt time.Time `json:"expires_at"`
+}
+
+// diskCache 实现 larkcore.Cache 接口，内存+磁盘两级缓存。
+// 同进程内走内存，跨进程通过磁盘文件共享 token。
+type diskCache struct {
+	mu       sync.Mutex
+	memory   map[string]cacheEntry
+	filePath string
+}
+
+// 确保 diskCache 实现 larkcore.Cache 接口
+var _ larkcore.Cache = (*diskCache)(nil)
+
+// newDiskCache 创建磁盘缓存实例
+func newDiskCache(filePath string) *diskCache {
+	return &diskCache{
+		memory:   make(map[string]cacheEntry),
+		filePath: filePath,
+	}
+}
+
+// defaultCachePath 返回默认缓存文件路径 (~/.feishu-cli/token_cache.json)
+func defaultCachePath() string {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return ""
+	}
+	return filepath.Join(home, ".feishu-cli", "token_cache.json")
+}
+
+func (c *diskCache) Get(ctx context.Context, key string) (string, error) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	// 内存缓存命中
+	if entry, ok := c.memory[key]; ok {
+		if time.Now().Before(entry.ExpiresAt) {
+			return entry.Value, nil
+		}
+		// 过期，删除
+		delete(c.memory, key)
+	}
+
+	// 内存未命中，尝试从磁盘加载
+	entries := c.loadFromDisk()
+	if entries == nil {
+		return "", nil
+	}
+
+	entry, ok := entries[key]
+	if !ok {
+		return "", nil
+	}
+	if time.Now().After(entry.ExpiresAt) {
+		// 磁盘上也过期了，清理
+		delete(entries, key)
+		c.saveToDisk(entries)
+		return "", nil
+	}
+
+	// 回填内存缓存
+	c.memory[key] = entry
+	return entry.Value, nil
+}
+
+func (c *diskCache) Set(ctx context.Context, key, value string, ttl time.Duration) error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	entry := cacheEntry{
+		Value:     value,
+		ExpiresAt: time.Now().Add(ttl),
+	}
+
+	// 写入内存
+	c.memory[key] = entry
+
+	// 写入磁盘（合并已有条目）
+	entries := c.loadFromDisk()
+	if entries == nil {
+		entries = make(map[string]cacheEntry)
+	}
+	entries[key] = entry
+
+	// 顺便清理已过期的条目
+	now := time.Now()
+	for k, e := range entries {
+		if now.After(e.ExpiresAt) {
+			delete(entries, k)
+		}
+	}
+
+	return c.saveToDisk(entries)
+}
+
+// loadFromDisk 从磁盘读取缓存文件，解析失败返回 nil
+func (c *diskCache) loadFromDisk() map[string]cacheEntry {
+	data, err := os.ReadFile(c.filePath)
+	if err != nil {
+		return nil
+	}
+	var entries map[string]cacheEntry
+	if err := json.Unmarshal(data, &entries); err != nil {
+		return nil
+	}
+	return entries
+}
+
+// saveToDisk 将缓存写入磁盘（0600 权限）
+func (c *diskCache) saveToDisk(entries map[string]cacheEntry) error {
+	dir := filepath.Dir(c.filePath)
+	if err := os.MkdirAll(dir, 0700); err != nil {
+		return err
+	}
+	data, err := json.Marshal(entries)
+	if err != nil {
+		return err
+	}
+	return os.WriteFile(c.filePath, data, 0600)
+}

--- a/internal/client/cache_test.go
+++ b/internal/client/cache_test.go
@@ -1,0 +1,208 @@
+package client
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func TestDiskCache_SetAndGet(t *testing.T) {
+	tmpDir := t.TempDir()
+	c := newDiskCache(filepath.Join(tmpDir, "cache.json"))
+
+	ctx := context.Background()
+
+	// 写入缓存
+	err := c.Set(ctx, "test-key", "test-value", 10*time.Minute)
+	if err != nil {
+		t.Fatalf("Set() 返回错误: %v", err)
+	}
+
+	// 读取缓存
+	val, err := c.Get(ctx, "test-key")
+	if err != nil {
+		t.Fatalf("Get() 返回错误: %v", err)
+	}
+	if val != "test-value" {
+		t.Errorf("Get() = %q, 期望 %q", val, "test-value")
+	}
+}
+
+func TestDiskCache_Expiry(t *testing.T) {
+	tmpDir := t.TempDir()
+	c := newDiskCache(filepath.Join(tmpDir, "cache.json"))
+
+	ctx := context.Background()
+
+	// 写入一个极短 TTL 的缓存
+	err := c.Set(ctx, "expire-key", "expire-value", 1*time.Millisecond)
+	if err != nil {
+		t.Fatalf("Set() 返回错误: %v", err)
+	}
+
+	// 等待过期
+	time.Sleep(5 * time.Millisecond)
+
+	// 应返回空字符串
+	val, err := c.Get(ctx, "expire-key")
+	if err != nil {
+		t.Fatalf("Get() 返回错误: %v", err)
+	}
+	if val != "" {
+		t.Errorf("过期后 Get() = %q, 期望空字符串", val)
+	}
+}
+
+func TestDiskCache_MultipleKeys(t *testing.T) {
+	tmpDir := t.TempDir()
+	c := newDiskCache(filepath.Join(tmpDir, "cache.json"))
+
+	ctx := context.Background()
+
+	// 写入多个 key
+	c.Set(ctx, "key1", "value1", 10*time.Minute)
+	c.Set(ctx, "key2", "value2", 10*time.Minute)
+
+	val1, _ := c.Get(ctx, "key1")
+	val2, _ := c.Get(ctx, "key2")
+
+	if val1 != "value1" {
+		t.Errorf("Get(key1) = %q, 期望 %q", val1, "value1")
+	}
+	if val2 != "value2" {
+		t.Errorf("Get(key2) = %q, 期望 %q", val2, "value2")
+	}
+}
+
+func TestDiskCache_Overwrite(t *testing.T) {
+	tmpDir := t.TempDir()
+	c := newDiskCache(filepath.Join(tmpDir, "cache.json"))
+
+	ctx := context.Background()
+
+	// 写入后覆盖
+	c.Set(ctx, "key", "old-value", 10*time.Minute)
+	c.Set(ctx, "key", "new-value", 10*time.Minute)
+
+	val, _ := c.Get(ctx, "key")
+	if val != "new-value" {
+		t.Errorf("Get() = %q, 期望 %q", val, "new-value")
+	}
+}
+
+func TestDiskCache_PersistAcrossInstances(t *testing.T) {
+	tmpDir := t.TempDir()
+	cacheFile := filepath.Join(tmpDir, "cache.json")
+
+	ctx := context.Background()
+
+	// 第一个实例写入
+	c1 := newDiskCache(cacheFile)
+	c1.Set(ctx, "persist-key", "persist-value", 10*time.Minute)
+
+	// 第二个实例读取（模拟新进程）
+	c2 := newDiskCache(cacheFile)
+	val, err := c2.Get(ctx, "persist-key")
+	if err != nil {
+		t.Fatalf("新实例 Get() 返回错误: %v", err)
+	}
+	if val != "persist-value" {
+		t.Errorf("新实例 Get() = %q, 期望 %q", val, "persist-value")
+	}
+}
+
+func TestDiskCache_FilePermissions(t *testing.T) {
+	tmpDir := t.TempDir()
+	cacheFile := filepath.Join(tmpDir, "cache.json")
+
+	ctx := context.Background()
+
+	c := newDiskCache(cacheFile)
+	c.Set(ctx, "key", "value", 10*time.Minute)
+
+	info, err := os.Stat(cacheFile)
+	if err != nil {
+		t.Fatalf("Stat() 返回错误: %v", err)
+	}
+
+	// 文件权限应为 0600
+	perm := info.Mode().Perm()
+	if perm != 0600 {
+		t.Errorf("文件权限 = %o, 期望 0600", perm)
+	}
+}
+
+func TestDiskCache_MissingKey(t *testing.T) {
+	tmpDir := t.TempDir()
+	c := newDiskCache(filepath.Join(tmpDir, "cache.json"))
+
+	ctx := context.Background()
+
+	// 不存在的 key 应返回空字符串
+	val, err := c.Get(ctx, "nonexistent")
+	if err != nil {
+		t.Fatalf("Get() 返回错误: %v", err)
+	}
+	if val != "" {
+		t.Errorf("Get(不存在的key) = %q, 期望空字符串", val)
+	}
+}
+
+func TestDiskCache_CorruptedFile(t *testing.T) {
+	tmpDir := t.TempDir()
+	cacheFile := filepath.Join(tmpDir, "cache.json")
+
+	// 写入损坏的 JSON
+	os.WriteFile(cacheFile, []byte("{invalid json"), 0600)
+
+	ctx := context.Background()
+	c := newDiskCache(cacheFile)
+
+	// 损坏文件不应导致 Get 崩溃，返回空字符串
+	val, err := c.Get(ctx, "key")
+	if err != nil {
+		t.Fatalf("Get() 不应返回错误: %v", err)
+	}
+	if val != "" {
+		t.Errorf("Get() = %q, 期望空字符串", val)
+	}
+
+	// Set 应能覆盖损坏文件
+	err = c.Set(ctx, "key", "value", 10*time.Minute)
+	if err != nil {
+		t.Fatalf("Set() 返回错误: %v", err)
+	}
+
+	val, _ = c.Get(ctx, "key")
+	if val != "value" {
+		t.Errorf("恢复后 Get() = %q, 期望 %q", val, "value")
+	}
+}
+
+func TestDiskCache_CleanExpired(t *testing.T) {
+	tmpDir := t.TempDir()
+	cacheFile := filepath.Join(tmpDir, "cache.json")
+
+	ctx := context.Background()
+	c := newDiskCache(cacheFile)
+
+	// 写入一个已过期和一个未过期的 key
+	c.Set(ctx, "expired", "v1", 1*time.Millisecond)
+	c.Set(ctx, "valid", "v2", 10*time.Minute)
+
+	time.Sleep(5 * time.Millisecond)
+
+	// 读取有效 key 应触发清理过期条目
+	val, _ := c.Get(ctx, "valid")
+	if val != "v2" {
+		t.Errorf("Get(valid) = %q, 期望 %q", val, "v2")
+	}
+
+	// 过期的 key 应返回空
+	val, _ = c.Get(ctx, "expired")
+	if val != "" {
+		t.Errorf("Get(expired) = %q, 期望空字符串", val)
+	}
+}

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -54,6 +54,10 @@ func GetClient() (*lark.Client, error) {
 		if cfg.Debug {
 			opts = append(opts, lark.WithLogLevel(larkcore.LogLevelDebug))
 		}
+		// 使用磁盘缓存，跨进程复用 tenant_access_token
+		if cachePath := defaultCachePath(); cachePath != "" {
+			opts = append(opts, lark.WithTokenCache(newDiskCache(cachePath)))
+		}
 		instance = lark.NewClient(cfg.AppID, cfg.AppSecret, opts...)
 
 		// Save current config (不存储 secret 明文)


### PR DESCRIPTION
## Summary

- 实现 `diskCache`（内存 + 磁盘两级缓存），通过 SDK 的 `WithTokenCache` 注入，避免每次 CLI 调用都请求 tenant_access_token 接口
- 缓存文件 `~/.feishu-cli/token_cache.json`，权限 0600，与现有 token.json 安全策略一致
- 同进程内走内存缓存，跨进程通过磁盘文件共享，Set 时自动清理过期条目，损坏文件自动降级

## Background

feishu-cli 是 CLI 工具，每次执行命令都是新进程。SDK 内置的内存缓存（`sync.Map`）随进程退出丢失，导致每次命令都会请求一次 `POST /open-apis/auth/v3/tenant_access_token/internal`。对于脚本批量调用场景，这些重复请求是不必要的开销。

## Implementation

- 新增 `internal/client/cache.go`：`diskCache` 实现 `larkcore.Cache` 接口（`Get`/`Set`）
  - `Get`：先查内存 map，miss 后读磁盘文件并回填内存
  - `Set`：同时写内存和磁盘，写磁盘时合并已有条目并清理过期项
  - 磁盘文件解析失败时静默降级为空缓存，不影响正常使用
- 修改 `internal/client/client.go`：`GetClient` 创建 client 时通过 `lark.WithTokenCache` 注入 diskCache

## Test plan

- [x] `go build ./...` 编译通过
- [x] `go vet ./...` 静态检查通过
- [x] `go clean -testcache && go test ./...` 全部测试通过
- [x] 新增 9 个 `TestDiskCache_*` 单元测试全部通过：基本读写、过期淘汰、多 key、覆盖写入、跨实例持久化、文件权限、不存在的 key、损坏文件恢复、过期清理