### PR TITLE
fix(config): trim trailing slash from base_url in config layer

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"github.com/spf13/viper"
 )
@@ -86,6 +87,9 @@ func Init(cfgFile string) error {
 	if err := viper.Unmarshal(cfg); err != nil {
 		return fmt.Errorf("解析配置失败: %w", err)
 	}
+
+	// 统一去除 BaseURL 尾部斜杠，避免拼接 API 路径时产生双斜杠
+	cfg.BaseURL = strings.TrimRight(cfg.BaseURL, "/")
 
 	return nil
 }

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -372,6 +372,60 @@ func TestInit_BaseURLFromEnv(t *testing.T) {
 	}
 }
 
+func TestInit_BaseURLTrimsTrailingSlash(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{"单斜杠", "https://private.example.com/", "https://private.example.com"},
+		{"多斜杠", "https://private.example.com///", "https://private.example.com"},
+		{"无斜杠", "https://private.example.com", "https://private.example.com"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			resetConfig()
+
+			// 通过环境变量设置带尾部斜杠的 BaseURL
+			os.Setenv("FEISHU_BASE_URL", tt.input)
+			defer os.Unsetenv("FEISHU_BASE_URL")
+
+			if err := Init(""); err != nil {
+				t.Fatalf("Init() 返回错误: %v", err)
+			}
+
+			c := Get()
+			if c.BaseURL != tt.expected {
+				t.Errorf("BaseURL = %q, 期望 %q", c.BaseURL, tt.expected)
+			}
+		})
+	}
+}
+
+func TestInit_BaseURLTrimsTrailingSlashFromFile(t *testing.T) {
+	resetConfig()
+
+	// 配置文件中 base_url 带尾部斜杠
+	tmpDir := t.TempDir()
+	configFile := filepath.Join(tmpDir, "config.yaml")
+	content := "app_id: \"\"\napp_secret: \"\"\nbase_url: \"https://private.example.com/\"\n"
+	if err := os.WriteFile(configFile, []byte(content), 0600); err != nil {
+		t.Fatalf("创建配置文件失败: %v", err)
+	}
+
+	os.Unsetenv("FEISHU_BASE_URL")
+
+	if err := Init(configFile); err != nil {
+		t.Fatalf("Init() 返回错误: %v", err)
+	}
+
+	c := Get()
+	if c.BaseURL != "https://private.example.com" {
+		t.Errorf("BaseURL = %q, 期望 %q", c.BaseURL, "https://private.example.com")
+	}
+}
+
 func TestInit_DebugFromEnv(t *testing.T) {
 	resetConfig()
 


### PR DESCRIPTION
## Summary
- 在 `config.Init()` 中对 `BaseURL` 统一执行 `strings.TrimRight(url, "/")`，从源头消除尾部斜杠
- 新增 2 个测试函数覆盖环境变量和配置文件两种来源

## Background
私有化部署用户在 `config.yaml` 中配置 `base_url` 时，尾部可能带斜杠（如 `https://private-deploy.example.com/`）。飞书 SDK 和项目中多处手动拼接路径时会产生双斜杠（`https://host//open-apis/...`），部分私有化部署服务器对双斜杠返回 404，导致所有 API 调用失败。

此 PR 是 #66 的改进方案。#66 仅在 `client.go` 的 `GetClient()` 做 TrimRight，但 `message.go`（2 处）和 `oauth.go`（2 处）中手动拼接 URL 的代码未覆盖。维护者建议在 config 层统一处理。

新方案将 TrimRight 移至 `config.Init()` —— 所有配置的唯一入口点，无论配置来源（环境变量、配置文件、默认值），BaseURL 都在此处完成清理，所有下游消费方自动受益，无需逐个修补。

## Changes
| 文件 | 改动说明 |
|------|---------|
| `internal/config/config.go` | `Init()` 中 `Unmarshal` 后新增 `strings.TrimRight(cfg.BaseURL, "/")` |
| `internal/config/config_test.go` | 新增 `TestInit_BaseURLTrimsTrailingSlash`（表驱动，3 子测试）和 `TestInit_BaseURLTrimsTrailingSlashFromFile` |

## Test Plan
### 常规检查
- [x] `go build ./...` 编译通过
- [x] `go vet ./...` 静态检查通过
- [x] `go clean -testcache && go test ./...` 全部测试通过

### 新增用例
- `TestInit_BaseURLTrimsTrailingSlash`：表驱动覆盖单斜杠 `/`、多斜杠 `///`、无斜杠三种输入（环境变量来源）
- `TestInit_BaseURLTrimsTrailingSlashFromFile`：配置文件来源的尾部斜杠处理