### PR TITLE
fix(converter): Todo 嵌套子项导入丢失与导出未缩进

### DIFF
--- a/internal/converter/block_to_markdown.go
+++ b/internal/converter/block_to_markdown.go
@@ -79,7 +79,7 @@ func NewBlockToMarkdown(blocks []*larkdocx.Block, options ConvertOptions) *Block
 					collectChildren(childID)
 				}
 			}
-		case BlockTypeBullet, BlockTypeOrdered:
+		case BlockTypeBullet, BlockTypeOrdered, BlockTypeTodo:
 			// 嵌套列表：子块由父列表递归处理
 			if block.Children != nil {
 				for _, childID := range block.Children {
@@ -322,7 +322,7 @@ func (c *BlockToMarkdown) convertBlockWithDepth(block *larkdocx.Block, indent in
 	case BlockTypeEquation:
 		return c.convertEquation(block)
 	case BlockTypeTodo:
-		return c.convertTodo(block)
+		return c.convertTodoWithDepth(block, indent, depth)
 	case BlockTypeDivider:
 		return "---\n", nil
 	case BlockTypeImage:
@@ -711,6 +711,10 @@ func (c *BlockToMarkdown) convertEquation(block *larkdocx.Block) (string, error)
 }
 
 func (c *BlockToMarkdown) convertTodo(block *larkdocx.Block) (string, error) {
+	return c.convertTodoWithDepth(block, 0, 0)
+}
+
+func (c *BlockToMarkdown) convertTodoWithDepth(block *larkdocx.Block, indent, depth int) (string, error) {
 	if block.Todo == nil {
 		return "", nil
 	}
@@ -721,7 +725,20 @@ func (c *BlockToMarkdown) convertTodo(block *larkdocx.Block) (string, error) {
 	}
 
 	text := c.convertTextElements(block.Todo.Elements)
-	return fmt.Sprintf("- %s %s\n", checkbox, text), nil
+	prefix := strings.Repeat("  ", indent)
+	result := fmt.Sprintf("%s- %s %s\n", prefix, checkbox, text)
+
+	// 递归处理嵌套子项
+	if block.Children != nil {
+		for _, childID := range block.Children {
+			childBlock := c.blockMap[childID]
+			if childBlock != nil {
+				childMd, _ := c.convertBlockWithDepth(childBlock, indent+1, depth+1)
+				result += childMd
+			}
+		}
+	}
+	return result, nil
 }
 
 func (c *BlockToMarkdown) convertImage(block *larkdocx.Block) (string, error) {

--- a/internal/converter/markdown_to_block.go
+++ b/internal/converter/markdown_to_block.go
@@ -437,7 +437,12 @@ func (c *MarkdownToBlock) convertListItem(node *ast.ListItem, isOrdered bool) (*
 					if err != nil {
 						return nil, err
 					}
-					return &BlockNode{Block: block}, nil
+					// 收集嵌套子列表
+					children, err := c.collectNestedChildren(node)
+					if err != nil {
+						return nil, err
+					}
+					return &BlockNode{Block: block, Children: children}, nil
 				}
 			}
 		}
@@ -448,7 +453,12 @@ func (c *MarkdownToBlock) convertListItem(node *ast.ListItem, isOrdered bool) (*
 					if err != nil {
 						return nil, err
 					}
-					return &BlockNode{Block: block}, nil
+					// 收集嵌套子列表
+					children, err := c.collectNestedChildren(node)
+					if err != nil {
+						return nil, err
+					}
+					return &BlockNode{Block: block, Children: children}, nil
 				}
 				// Also check for raw text pattern
 				if txt, ok := tb.FirstChild().(*ast.Text); ok {
@@ -458,7 +468,12 @@ func (c *MarkdownToBlock) convertListItem(node *ast.ListItem, isOrdered bool) (*
 						if err != nil {
 							return nil, err
 						}
-						return &BlockNode{Block: block}, nil
+						// 收集嵌套子列表
+						children, err := c.collectNestedChildren(node)
+						if err != nil {
+							return nil, err
+						}
+						return &BlockNode{Block: block, Children: children}, nil
 					}
 				}
 			}
@@ -507,6 +522,21 @@ func (c *MarkdownToBlock) convertListItem(node *ast.ListItem, isOrdered bool) (*
 	}
 
 	return &BlockNode{Block: block, Children: children}, nil
+}
+
+// collectNestedChildren 收集 ListItem 下嵌套的子列表，返回 BlockNode 切片
+func (c *MarkdownToBlock) collectNestedChildren(node *ast.ListItem) ([]*BlockNode, error) {
+	var children []*BlockNode
+	for child := node.FirstChild(); child != nil; child = child.NextSibling() {
+		if nestedList, ok := child.(*ast.List); ok {
+			childNodes, err := c.convertList(nestedList)
+			if err != nil {
+				return nil, err
+			}
+			children = append(children, childNodes...)
+		}
+	}
+	return children, nil
 }
 
 // extractListItemDirectElements 提取 ListItem 直接子节点的文本元素，
@@ -576,6 +606,11 @@ func (c *MarkdownToBlock) extractTextElementsSkipCheckbox(node ast.Node) []*lark
 
 		// Skip TaskCheckBox nodes
 		if _, ok := n.(*east.TaskCheckBox); ok {
+			return ast.WalkSkipChildren, nil
+		}
+
+		// 跳过嵌套列表——它们作为 BlockNode.Children 单独处理
+		if _, ok := n.(*ast.List); ok {
 			return ast.WalkSkipChildren, nil
 		}
 

--- a/internal/converter/todo_nesting_test.go
+++ b/internal/converter/todo_nesting_test.go
@@ -1,0 +1,149 @@
+package converter
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	larkdocx "github.com/larksuite/oapi-sdk-go/v3/service/docx/v1"
+)
+
+// TestTodoNestedChildren_Import 验证 todo 列表项的嵌套子项在导入时能正确收集
+func TestTodoNestedChildren_Import(t *testing.T) {
+	md := `- [ ] 父任务
+    - [ ] 子任务1
+    - [ ] 子任务2
+- [ ] 独立任务`
+
+	conv := NewMarkdownToBlock([]byte(md), ConvertOptions{}, "")
+	result, err := conv.ConvertWithTableData()
+	if err != nil {
+		t.Fatalf("ConvertWithTableData 失败: %v", err)
+	}
+
+	// 应该有 2 个顶层块: 父任务, 独立任务
+	if len(result.BlockNodes) != 2 {
+		t.Fatalf("期望 2 个顶层块，得到 %d", len(result.BlockNodes))
+	}
+
+	// 第一个块（父任务）应该有 2 个子项（子任务1, 子任务2）
+	parent := result.BlockNodes[0]
+	if len(parent.Children) != 2 {
+		t.Errorf("'父任务' 期望 2 个子项，得到 %d", len(parent.Children))
+	}
+
+	// 验证子项都是 Todo 类型
+	for i, child := range parent.Children {
+		if child.Block.BlockType == nil || *child.Block.BlockType != int(BlockTypeTodo) {
+			bt := 0
+			if child.Block.BlockType != nil {
+				bt = *child.Block.BlockType
+			}
+			t.Errorf("子项 %d 期望类型 %d (Todo)，得到 %d", i, BlockTypeTodo, bt)
+		}
+	}
+
+	// 第二个块（独立任务）不应有子项
+	if len(result.BlockNodes[1].Children) != 0 {
+		t.Errorf("'独立任务' 不应有子项，得到 %d", len(result.BlockNodes[1].Children))
+	}
+}
+
+// TestTodoNestedChildren_Export 验证 todo 嵌套子项在导出时正确缩进
+func TestTodoNestedChildren_Export(t *testing.T) {
+	falseVal := false
+	blocks := []*larkdocx.Block{
+		{
+			BlockId:   strPtr("parent"),
+			BlockType: intPtr(int(BlockTypeTodo)),
+			Children:  []string{"child1", "child2"},
+			Todo: &larkdocx.Text{
+				Elements: []*larkdocx.TextElement{
+					{TextRun: &larkdocx.TextRun{Content: strPtr("父任务")}},
+				},
+				Style: &larkdocx.TextStyle{Done: &falseVal},
+			},
+		},
+		{
+			BlockId:   strPtr("child1"),
+			BlockType: intPtr(int(BlockTypeTodo)),
+			Todo: &larkdocx.Text{
+				Elements: []*larkdocx.TextElement{
+					{TextRun: &larkdocx.TextRun{Content: strPtr("子任务1")}},
+				},
+				Style: &larkdocx.TextStyle{Done: &falseVal},
+			},
+		},
+		{
+			BlockId:   strPtr("child2"),
+			BlockType: intPtr(int(BlockTypeTodo)),
+			Todo: &larkdocx.Text{
+				Elements: []*larkdocx.TextElement{
+					{TextRun: &larkdocx.TextRun{Content: strPtr("子任务2")}},
+				},
+				Style: &larkdocx.TextStyle{Done: &falseVal},
+			},
+		},
+	}
+
+	conv := NewBlockToMarkdown(blocks, ConvertOptions{})
+	got, err := conv.Convert()
+	if err != nil {
+		t.Fatalf("Convert() error = %v", err)
+	}
+	got = strings.TrimSpace(got)
+
+	want := "- [ ] 父任务\n  - [ ] 子任务1\n  - [ ] 子任务2"
+	if got != want {
+		t.Errorf("Convert() got:\n%s\n\nwant:\n%s", got, want)
+	}
+}
+
+// TestTodoNestedChildren_Roundtrip 验证 todo 嵌套子项的往返一致性
+func TestTodoNestedChildren_Roundtrip(t *testing.T) {
+	md := `- [ ] 父任务
+  - [ ] 子任务1
+  - [x] 子任务2`
+
+	// Markdown → Block
+	conv := NewMarkdownToBlock([]byte(md), ConvertOptions{}, "")
+	result, err := conv.ConvertWithTableData()
+	if err != nil {
+		t.Fatalf("Markdown → Block 失败: %v", err)
+	}
+
+	// 构建带 ID 和 Children 关系的 Block 切片（模拟飞书 API 返回的结构）
+	var allBlocks []*larkdocx.Block
+	idCounter := 0
+	var assignIDs func(nodes []*BlockNode) []string
+	assignIDs = func(nodes []*BlockNode) []string {
+		var ids []string
+		for _, n := range nodes {
+			idCounter++
+			id := fmt.Sprintf("blk_%d", idCounter)
+			n.Block.BlockId = &id
+			// 递归处理子节点
+			childIDs := assignIDs(n.Children)
+			if len(childIDs) > 0 {
+				n.Block.Children = childIDs
+			}
+			allBlocks = append(allBlocks, n.Block)
+			ids = append(ids, id)
+		}
+		return ids
+	}
+	assignIDs(result.BlockNodes)
+
+	// Block → Markdown
+	conv2 := NewBlockToMarkdown(allBlocks, ConvertOptions{})
+	got, err := conv2.Convert()
+	if err != nil {
+		t.Fatalf("Block → Markdown 失败: %v", err)
+	}
+	got = strings.TrimSpace(got)
+
+	want := "- [ ] 父任务\n  - [ ] 子任务1\n  - [x] 子任务2"
+	if got != want {
+		t.Errorf("往返不一致:\n  输入: %q\n  输出: %q", want, got)
+	}
+}


### PR DESCRIPTION
## Summary
- 修复 Todo 列表项的嵌套子列表导入时丢失（子项未收集为 Children）
- 修复 Todo 嵌套子项导出时被当作独立顶层块（未缩进）

## Background
`convertListItem` 中 TaskCheckBox 分支直接返回 `&BlockNode{Block: block}`，未收集 ListItem 下嵌套的子列表；导出侧 `BlockTypeTodo` 未加入子块收集逻辑，`convertTodo` 不支持缩进递归。

输入 Markdown：
```markdown
- [ ] 父任务
    - [ ] 子任务 1
    - [ ] 子任务 2
```
修复前导入：子任务丢失，只有父任务；导出时子任务变成独立顶层块。
修复后：子任务作为 Children 正确嵌套，导出时正确缩进。

## Changes
| 文件 | 改动说明 |
|------|---------|
| `internal/converter/markdown_to_block.go` | 3 处 TaskCheckBox 分支调用新增的 `collectNestedChildren` 收集嵌套子列表（正确传递 error）；`extractTextElementsSkipCheckbox` 跳过 `ast.List` 防止子列表文本渗入父项 |
| `internal/converter/block_to_markdown.go` | `BlockTypeTodo` 加入子块收集逻辑（与 Bullet/Ordered 一致）；新增 `convertTodoWithDepth` 支持缩进递归处理嵌套子项 |
| `internal/converter/todo_nesting_test.go` | 新增 3 个测试用例 |

## Test Plan
### 常规检查
- [x] `go build ./...` 编译通过
- [x] `go vet ./...` 静态检查通过
- [x] `go clean -testcache && go test ./...` 全部测试通过

### 新增用例
| 用例 | 覆盖场景 |
|------|---------|
| `TestTodoNestedChildren_Import` | Todo 嵌套子项导入后正确收集为 Children，独立任务无子项 |
| `TestTodoNestedChildren_Export` | Todo 嵌套子项导出时正确缩进（2 空格） |
| `TestTodoNestedChildren_Roundtrip` | Todo 嵌套子项 Markdown → Block → Markdown 往返一致性 |

### 真实文档验证
使用以下 Markdown 进行真实飞书文档导入/导出验证：
```markdown
# Todo 嵌套子项测试

- [ ] 父任务1
  - [ ] 子任务1-1
  - [x] 子任务1-2
- [x] 父任务2
  - [ ] 子任务2-1
  - [ ] 子任务2-2
  - [x] 子任务2-3
- [ ] 独立任务（无子项）
```

验证步骤：
1. `go run . doc import /tmp/todo_test.md --title "Todo 嵌套测试" --verbose` 导入
2. `go run . doc blocks <doc_id> --all --output json` 检查云端块结构，确认：
   - 父任务1 的 children 包含 子任务1-1（done=false）和 子任务1-2（done=true）
   - 父任务2 的 children 包含 子任务2-1、子任务2-2（done=false）和 子任务2-3（done=true）
   - 独立任务无 children
3. `go run . doc export <doc_id>` 导出，确认嵌套缩进和勾选状态与原始 Markdown 一致

验证结果：3 项全部通过。