### PR TITLE
fix: preserve fenced code blocks inside list items

### DIFF
--- a/internal/converter/markdown_to_block.go
+++ b/internal/converter/markdown_to_block.go
@@ -468,7 +468,7 @@ func (c *MarkdownToBlock) convertListItem(node *ast.ListItem, isOrdered bool) (*
 	// 只提取直接子节点的文本（跳过嵌套的 ast.List）
 	elements := c.extractListItemDirectElements(node)
 
-	// 收集嵌套子列表
+	// 收集嵌套子列表和代码块
 	var children []*BlockNode
 	for child := node.FirstChild(); child != nil; child = child.NextSibling() {
 		if nestedList, ok := child.(*ast.List); ok {
@@ -477,6 +477,14 @@ func (c *MarkdownToBlock) convertListItem(node *ast.ListItem, isOrdered bool) (*
 				return nil, err
 			}
 			children = append(children, childNodes...)
+		} else if codeBlock, ok := child.(*ast.FencedCodeBlock); ok {
+			block, err := c.convertCodeBlock(codeBlock)
+			if err != nil {
+				return nil, err
+			}
+			if block != nil {
+				children = append(children, &BlockNode{Block: block})
+			}
 		}
 	}
 

--- a/internal/converter/markdown_to_block_test.go
+++ b/internal/converter/markdown_to_block_test.go
@@ -128,6 +128,53 @@ func TestConvert_UnorderedList(t *testing.T) {
 	}
 }
 
+func TestConvert_ListItemWithCodeBlock(t *testing.T) {
+	markdown := "- **消息**：\n  ```\n  这是列表内的代码块\n  第二行\n  ```"
+
+	converter := NewMarkdownToBlock([]byte(markdown), ConvertOptions{}, "")
+	blocks, err := converter.Convert()
+
+	if err != nil {
+		t.Fatalf("Convert() 返回错误: %v", err)
+	}
+
+	if len(blocks) == 0 {
+		t.Fatal("blocks 为空")
+	}
+
+	// First block should be a bullet list item
+	if blocks[0].BlockType == nil || *blocks[0].BlockType != int(BlockTypeBullet) {
+		t.Errorf("blocks[0].BlockType = %v, 期望 %d (Bullet)", blocks[0].BlockType, int(BlockTypeBullet))
+	}
+
+	// Should have a code block as child
+	if len(blocks) < 2 {
+		t.Fatal("期望列表项后有代码块子节点，但 blocks 数量不足")
+	}
+
+	found := false
+	for _, b := range blocks {
+		if b.BlockType != nil && *b.BlockType == int(BlockTypeCode) {
+			found = true
+			// Verify code content
+			if b.Code != nil && b.Code.Elements != nil {
+				content := ""
+				for _, elem := range b.Code.Elements {
+					if elem.TextRun != nil && elem.TextRun.Content != nil {
+						content += *elem.TextRun.Content
+					}
+				}
+				if !strings.Contains(content, "这是列表内的代码块") {
+					t.Errorf("代码块内容 = %q, 期望包含 '这是列表内的代码块'", content)
+				}
+			}
+		}
+	}
+	if !found {
+		t.Error("未找到代码块，列表项内的代码块被丢弃了")
+	}
+}
+
 func TestConvert_OrderedList(t *testing.T) {
 	markdown := `1. 第一项
 2. 第二项


### PR DESCRIPTION
## Summary
- Fenced code blocks nested inside list items were silently dropped during `doc import`
- Root cause: `convertListItem` only collected `*ast.List` children, ignoring `*ast.FencedCodeBlock`
- Added handling for `FencedCodeBlock` in the child collection loop

## Reproduction

```markdown
- **消息**：
  ```
  这段内容会丢失
  ```
```

Before this fix, the code block content is dropped. After the fix, it is preserved as a child code block of the list item.

## Test plan
- [x] Added `TestConvert_ListItemWithCodeBlock` test case
- [x] All existing converter tests pass (`go test ./internal/converter/`)
- [x] Verified end-to-end: `feishu-cli doc import` + `doc export` roundtrip preserves the content

🤖 Generated with [Claude Code](https://claude.com/claude-code)