### PR TITLE
fix(converter): split consecutive paragraph lines into separate Text blocks

### DIFF
--- a/internal/converter/markdown_to_block.go
+++ b/internal/converter/markdown_to_block.go
@@ -977,6 +977,19 @@ func (c *MarkdownToBlock) extractQuoteLines(node ast.Node) [][]*larkdocx.TextEle
 func (c *MarkdownToBlock) extractParagraphLines(node ast.Node) [][]*larkdocx.TextElement {
 	var lines [][]*larkdocx.TextElement
 	var currentLine []*larkdocx.TextElement
+	inUnderline := false // 跟踪 <u>...</u> 状态，避免 RawHTML 内容被静默丢失
+
+	// 辅助：将 <u>/<mark> 等样式状态应用到 elem
+	applyUnderlineIfNeeded := func(elem *larkdocx.TextElement) {
+		if !inUnderline || elem == nil || elem.TextRun == nil {
+			return
+		}
+		underline := true
+		if elem.TextRun.TextElementStyle == nil {
+			elem.TextRun.TextElementStyle = &larkdocx.TextElementStyle{}
+		}
+		elem.TextRun.TextElementStyle.Underline = &underline
+	}
 
 	ast.Walk(node, func(n ast.Node, entering bool) (ast.WalkStatus, error) {
 		if !entering {
@@ -985,11 +998,13 @@ func (c *MarkdownToBlock) extractParagraphLines(node ast.Node) [][]*larkdocx.Tex
 
 		switch child := n.(type) {
 		case *ast.Text:
-			text := string(child.Segment.Value(c.source))
+			text := unescapeMarkdownText(string(child.Segment.Value(c.source)))
 			if text != "" {
-				currentLine = append(currentLine, &larkdocx.TextElement{
+				elem := &larkdocx.TextElement{
 					TextRun: &larkdocx.TextRun{Content: &text},
-				})
+				}
+				applyUnderlineIfNeeded(elem)
+				currentLine = append(currentLine, elem)
 			}
 			if child.SoftLineBreak() {
 				if len(currentLine) > 0 {
@@ -1001,9 +1016,11 @@ func (c *MarkdownToBlock) extractParagraphLines(node ast.Node) [][]*larkdocx.Tex
 		case *ast.String:
 			text := string(child.Value)
 			if text != "" {
-				currentLine = append(currentLine, &larkdocx.TextElement{
+				elem := &larkdocx.TextElement{
 					TextRun: &larkdocx.TextRun{Content: &text},
-				})
+				}
+				applyUnderlineIfNeeded(elem)
+				currentLine = append(currentLine, elem)
 			}
 
 		case *ast.Emphasis:
@@ -1012,6 +1029,7 @@ func (c *MarkdownToBlock) extractParagraphLines(node ast.Node) [][]*larkdocx.Tex
 			italic := child.Level == 1
 			for _, elem := range childElems {
 				applyTextStyle(elem, bold, italic, false)
+				applyUnderlineIfNeeded(elem)
 				currentLine = append(currentLine, elem)
 			}
 			return ast.WalkSkipChildren, nil
@@ -1020,12 +1038,14 @@ func (c *MarkdownToBlock) extractParagraphLines(node ast.Node) [][]*larkdocx.Tex
 			text := c.getNodeText(child)
 			if text != "" {
 				inlineCode := true
-				currentLine = append(currentLine, &larkdocx.TextElement{
+				elem := &larkdocx.TextElement{
 					TextRun: &larkdocx.TextRun{
 						Content:          &text,
 						TextElementStyle: &larkdocx.TextElementStyle{InlineCode: &inlineCode},
 					},
-				})
+				}
+				applyUnderlineIfNeeded(elem)
+				currentLine = append(currentLine, elem)
 			}
 			return ast.WalkSkipChildren, nil
 
@@ -1033,6 +1053,7 @@ func (c *MarkdownToBlock) extractParagraphLines(node ast.Node) [][]*larkdocx.Tex
 			childElems := c.extractChildElements(child)
 			for _, elem := range childElems {
 				applyTextStyle(elem, false, false, true)
+				applyUnderlineIfNeeded(elem)
 				currentLine = append(currentLine, elem)
 			}
 			return ast.WalkSkipChildren, nil
@@ -1041,7 +1062,9 @@ func (c *MarkdownToBlock) extractParagraphLines(node ast.Node) [][]*larkdocx.Tex
 			text := c.getNodeText(child)
 			url := string(child.Destination)
 			if text != "" {
-				currentLine = append(currentLine, createLinkElement(text, url))
+				elem := createLinkElement(text, url)
+				applyUnderlineIfNeeded(elem)
+				currentLine = append(currentLine, elem)
 			}
 			return ast.WalkSkipChildren, nil
 
@@ -1052,7 +1075,9 @@ func (c *MarkdownToBlock) extractParagraphLines(node ast.Node) [][]*larkdocx.Tex
 				label = linkURL
 			}
 			if linkURL != "" {
-				currentLine = append(currentLine, createLinkElement(label, linkURL))
+				elem := createLinkElement(label, linkURL)
+				applyUnderlineIfNeeded(elem)
+				currentLine = append(currentLine, elem)
 			}
 			return ast.WalkSkipChildren, nil
 
@@ -1063,13 +1088,51 @@ func (c *MarkdownToBlock) extractParagraphLines(node ast.Node) [][]*larkdocx.Tex
 			if alt == "" {
 				alt = dest
 			}
+			var elem *larkdocx.TextElement
 			if strings.HasPrefix(dest, "http://") || strings.HasPrefix(dest, "https://") {
-				currentLine = append(currentLine, createLinkElement(fmt.Sprintf("[图片: %s]", alt), dest))
+				elem = createLinkElement(fmt.Sprintf("[图片: %s]", alt), dest)
 			} else {
 				placeholder := fmt.Sprintf("[Image: %s]", dest)
-				currentLine = append(currentLine, &larkdocx.TextElement{
+				elem = &larkdocx.TextElement{
 					TextRun: &larkdocx.TextRun{Content: &placeholder},
-				})
+				}
+			}
+			applyUnderlineIfNeeded(elem)
+			currentLine = append(currentLine, elem)
+			return ast.WalkSkipChildren, nil
+
+		case *ast.RawHTML:
+			// 处理内联 HTML 标签：<br> 作为软换行拆分，<u>/</u> 切换下划线状态，
+			// <mark>/</mark>（暂以下划线近似）、其他标签按占位/纯文本保留，避免静默丢失。
+			var htmlBuf bytes.Buffer
+			for i := 0; i < child.Segments.Len(); i++ {
+				seg := child.Segments.At(i)
+				htmlBuf.Write(c.source[seg.Start:seg.Stop])
+			}
+			rawOriginal := strings.TrimSpace(htmlBuf.String())
+			raw := strings.ToLower(rawOriginal)
+			switch {
+			case raw == "<br>" || raw == "<br/>" || raw == "<br />":
+				// <br> 视为软换行，当前行收尾并开启新行
+				if len(currentLine) > 0 {
+					lines = append(lines, splitInlineMath(currentLine))
+					currentLine = nil
+				}
+			case raw == "<u>", raw == "<mark>":
+				inUnderline = true
+			case raw == "</u>", raw == "</mark>":
+				inUnderline = false
+			default:
+				// 尝试解析自定义 HTML 标签（如 <mention-user/>）
+				if tag := ParseHTMLTag(rawOriginal); tag != nil {
+					if elems := c.handleInlineHTMLTag(tag, &inUnderline); len(elems) > 0 {
+						for _, elem := range elems {
+							applyUnderlineIfNeeded(elem)
+							currentLine = append(currentLine, elem)
+						}
+					}
+				}
+				// 其他未识别的 HTML 标签丢弃（与 extractTextElements/extractChildElements 保持一致）
 			}
 			return ast.WalkSkipChildren, nil
 		}

--- a/internal/converter/markdown_to_block.go
+++ b/internal/converter/markdown_to_block.go
@@ -256,13 +256,11 @@ func (c *MarkdownToBlock) ConvertWithTableData() (*ConvertResult, error) {
 			return ast.WalkSkipChildren, nil
 
 		case *ast.Paragraph:
-			block, err := c.convertParagraph(node)
+			nodes, err := c.convertParagraph(node)
 			if err != nil {
 				return ast.WalkStop, err
 			}
-			if block != nil {
-				result.BlockNodes = append(result.BlockNodes, &BlockNode{Block: block})
-			}
+			result.BlockNodes = append(result.BlockNodes, nodes...)
 			return ast.WalkSkipChildren, nil
 
 		case *ast.FencedCodeBlock:
@@ -378,29 +376,47 @@ func (c *MarkdownToBlock) convertHeading(node *ast.Heading) (*larkdocx.Block, er
 	return block, nil
 }
 
-func (c *MarkdownToBlock) convertParagraph(node *ast.Paragraph) (*larkdocx.Block, error) {
+func (c *MarkdownToBlock) convertParagraph(node *ast.Paragraph) ([]*BlockNode, error) {
 	// Check if paragraph contains only an image
 	if node.ChildCount() == 1 {
 		if img, ok := node.FirstChild().(*ast.Image); ok {
-			return c.convertImage(img)
+			block, err := c.convertImage(img)
+			if err != nil {
+				return nil, err
+			}
+			if block == nil {
+				return nil, nil
+			}
+			return []*BlockNode{{Block: block}}, nil
 		}
 	}
 
 	// 检查段落是否只包含一个 <image> HTML 标签
 	if block := c.tryConvertHTMLImageParagraph(node); block != nil {
-		return block, nil
+		return []*BlockNode{{Block: block}}, nil
 	}
 
-	elements := c.extractTextElements(node)
-	if len(elements) == 0 {
+	// 按 SoftLineBreak 分行，每行创建独立的 Text 块
+	// 解决连续行（无空行分隔）被合并为一段的问题
+	lines := c.extractParagraphLines(node)
+	if len(lines) == 0 {
 		return nil, nil
 	}
 
-	blockType := int(BlockTypeText)
-	return &larkdocx.Block{
-		BlockType: &blockType,
-		Text:      &larkdocx.Text{Elements: elements},
-	}, nil
+	var nodes []*BlockNode
+	for _, lineElements := range lines {
+		if len(lineElements) == 0 {
+			continue
+		}
+		bt := int(BlockTypeText)
+		nodes = append(nodes, &BlockNode{
+			Block: &larkdocx.Block{
+				BlockType: &bt,
+				Text:      &larkdocx.Text{Elements: lineElements},
+			},
+		})
+	}
+	return nodes, nil
 }
 
 func (c *MarkdownToBlock) convertCodeBlock(node *ast.FencedCodeBlock) (*larkdocx.Block, error) {
@@ -946,6 +962,124 @@ func (c *MarkdownToBlock) extractQuoteLines(node ast.Node) [][]*larkdocx.TextEle
 	// 添加最后一行
 	if len(currentLine) > 0 {
 		lines = append(lines, currentLine)
+	}
+
+	return lines
+}
+
+// extractParagraphLines 从段落 AST 节点提取文本元素，按 SoftLineBreak 拆分为多行
+// 与 extractQuoteLines 逻辑相同，额外支持内联图片和行内公式后处理
+// 解决连续行（无空行分隔）被合并为一段的飞书文档问题
+//
+// Known limitation：换行符若位于行内容器（Emphasis/Strikethrough/Link）内部，
+// 如 **行一\n行二**，则不会触发分行（这些节点走 WalkSkipChildren）。
+// 此类写法在实际 Markdown 中极罕见，暂不处理。
+func (c *MarkdownToBlock) extractParagraphLines(node ast.Node) [][]*larkdocx.TextElement {
+	var lines [][]*larkdocx.TextElement
+	var currentLine []*larkdocx.TextElement
+
+	ast.Walk(node, func(n ast.Node, entering bool) (ast.WalkStatus, error) {
+		if !entering {
+			return ast.WalkContinue, nil
+		}
+
+		switch child := n.(type) {
+		case *ast.Text:
+			text := string(child.Segment.Value(c.source))
+			if text != "" {
+				currentLine = append(currentLine, &larkdocx.TextElement{
+					TextRun: &larkdocx.TextRun{Content: &text},
+				})
+			}
+			if child.SoftLineBreak() {
+				if len(currentLine) > 0 {
+					lines = append(lines, splitInlineMath(currentLine))
+					currentLine = nil
+				}
+			}
+
+		case *ast.String:
+			text := string(child.Value)
+			if text != "" {
+				currentLine = append(currentLine, &larkdocx.TextElement{
+					TextRun: &larkdocx.TextRun{Content: &text},
+				})
+			}
+
+		case *ast.Emphasis:
+			childElems := c.extractChildElements(child)
+			bold := child.Level == 2
+			italic := child.Level == 1
+			for _, elem := range childElems {
+				applyTextStyle(elem, bold, italic, false)
+				currentLine = append(currentLine, elem)
+			}
+			return ast.WalkSkipChildren, nil
+
+		case *ast.CodeSpan:
+			text := c.getNodeText(child)
+			if text != "" {
+				inlineCode := true
+				currentLine = append(currentLine, &larkdocx.TextElement{
+					TextRun: &larkdocx.TextRun{
+						Content:          &text,
+						TextElementStyle: &larkdocx.TextElementStyle{InlineCode: &inlineCode},
+					},
+				})
+			}
+			return ast.WalkSkipChildren, nil
+
+		case *east.Strikethrough:
+			childElems := c.extractChildElements(child)
+			for _, elem := range childElems {
+				applyTextStyle(elem, false, false, true)
+				currentLine = append(currentLine, elem)
+			}
+			return ast.WalkSkipChildren, nil
+
+		case *ast.Link:
+			text := c.getNodeText(child)
+			url := string(child.Destination)
+			if text != "" {
+				currentLine = append(currentLine, createLinkElement(text, url))
+			}
+			return ast.WalkSkipChildren, nil
+
+		case *ast.AutoLink:
+			linkURL := string(child.URL(c.source))
+			label := string(child.Label(c.source))
+			if label == "" {
+				label = linkURL
+			}
+			if linkURL != "" {
+				currentLine = append(currentLine, createLinkElement(label, linkURL))
+			}
+			return ast.WalkSkipChildren, nil
+
+		case *ast.Image:
+			// 内联图片：网络 URL 转为可点击链接，本地路径转为文本占位符
+			dest := string(child.Destination)
+			alt := c.getNodeText(child)
+			if alt == "" {
+				alt = dest
+			}
+			if strings.HasPrefix(dest, "http://") || strings.HasPrefix(dest, "https://") {
+				currentLine = append(currentLine, createLinkElement(fmt.Sprintf("[图片: %s]", alt), dest))
+			} else {
+				placeholder := fmt.Sprintf("[Image: %s]", dest)
+				currentLine = append(currentLine, &larkdocx.TextElement{
+					TextRun: &larkdocx.TextRun{Content: &placeholder},
+				})
+			}
+			return ast.WalkSkipChildren, nil
+		}
+
+		return ast.WalkContinue, nil
+	})
+
+	// 添加最后一行
+	if len(currentLine) > 0 {
+		lines = append(lines, splitInlineMath(currentLine))
 	}
 
 	return lines

--- a/internal/converter/markdown_to_block_test.go
+++ b/internal/converter/markdown_to_block_test.go
@@ -181,6 +181,103 @@ func TestConvert_ConsecutiveBoldLinesPreserveContent(t *testing.T) {
 	}
 }
 
+func TestConvert_ConsecutiveLinesPreserveInlineUnderline(t *testing.T) {
+	// 验证段落拆分时 <u>...</u> 包裹的内容不丢失，且下划线样式保留
+	markdown := "line1 <u>under</u>\nline2"
+	converter := NewMarkdownToBlock([]byte(markdown), ConvertOptions{}, "")
+	blocks, err := converter.Convert()
+	if err != nil {
+		t.Fatalf("Convert() 返回错误: %v", err)
+	}
+	if len(blocks) != 2 {
+		t.Fatalf("期望 2 个 block，实际 %d 个", len(blocks))
+	}
+
+	// 第一行应包含 "under" 并带下划线
+	firstBlock := blocks[0]
+	if firstBlock.Text == nil {
+		t.Fatal("blocks[0].Text 为 nil")
+	}
+	foundUnderline := false
+	combined := strings.Builder{}
+	for _, elem := range firstBlock.Text.Elements {
+		if elem.TextRun == nil || elem.TextRun.Content == nil {
+			continue
+		}
+		combined.WriteString(*elem.TextRun.Content)
+		if *elem.TextRun.Content == "under" &&
+			elem.TextRun.TextElementStyle != nil &&
+			elem.TextRun.TextElementStyle.Underline != nil &&
+			*elem.TextRun.TextElementStyle.Underline {
+			foundUnderline = true
+		}
+	}
+	if !strings.Contains(combined.String(), "under") {
+		t.Errorf("blocks[0] 应包含 'under'，实际内容 %q", combined.String())
+	}
+	if !foundUnderline {
+		t.Errorf("blocks[0] 中 'under' 应带下划线样式")
+	}
+
+	// 第二行应为 "line2"
+	secondBlock := blocks[1]
+	if secondBlock.Text == nil {
+		t.Fatal("blocks[1].Text 为 nil")
+	}
+	line2 := strings.Builder{}
+	for _, elem := range secondBlock.Text.Elements {
+		if elem.TextRun != nil && elem.TextRun.Content != nil {
+			line2.WriteString(*elem.TextRun.Content)
+		}
+	}
+	if !strings.Contains(line2.String(), "line2") {
+		t.Errorf("blocks[1] 应包含 'line2'，实际内容 %q", line2.String())
+	}
+}
+
+func TestConvert_ConsecutiveLinesPreserveInlineMark(t *testing.T) {
+	// 验证段落拆分时 <mark>...</mark> 包裹的内容不丢失
+	markdown := "line1 <mark>hl</mark>\nline2"
+	converter := NewMarkdownToBlock([]byte(markdown), ConvertOptions{}, "")
+	blocks, err := converter.Convert()
+	if err != nil {
+		t.Fatalf("Convert() 返回错误: %v", err)
+	}
+	if len(blocks) != 2 {
+		t.Fatalf("期望 2 个 block，实际 %d 个", len(blocks))
+	}
+
+	// 第一行应包含 "hl"（高亮内容不能丢失）
+	firstBlock := blocks[0]
+	if firstBlock.Text == nil {
+		t.Fatal("blocks[0].Text 为 nil")
+	}
+	combined := strings.Builder{}
+	for _, elem := range firstBlock.Text.Elements {
+		if elem.TextRun != nil && elem.TextRun.Content != nil {
+			combined.WriteString(*elem.TextRun.Content)
+		}
+	}
+	if !strings.Contains(combined.String(), "hl") {
+		t.Errorf("blocks[0] 应包含 'hl'（<mark> 内容不应丢失），实际内容 %q", combined.String())
+	}
+
+	// 第二行应为 "line2"
+	secondBlock := blocks[1]
+	if secondBlock.Text == nil {
+		t.Fatal("blocks[1].Text 为 nil")
+	}
+	line2 := strings.Builder{}
+	for _, elem := range secondBlock.Text.Elements {
+		if elem.TextRun != nil && elem.TextRun.Content != nil {
+			line2.WriteString(*elem.TextRun.Content)
+		}
+	}
+	if !strings.Contains(line2.String(), "line2") {
+		t.Errorf("blocks[1] 应包含 'line2'，实际内容 %q", line2.String())
+	}
+}
+
 func TestConvert_CodeBlock(t *testing.T) {
 	markdown := "```go\nfmt.Println(\"Hello\")\n```"
 

--- a/internal/converter/markdown_to_block_test.go
+++ b/internal/converter/markdown_to_block_test.go
@@ -79,6 +79,108 @@ func TestConvert_Paragraph(t *testing.T) {
 	}
 }
 
+func TestConvert_ConsecutiveLinesBecomeSeparateBlocks(t *testing.T) {
+	// 回归测试：连续行（无空行分隔）应生成独立 Text 块，而非合并为一段
+	// 典型场景：**A派**：xxx\n**B派**：yyy 导入飞书后应为两行
+	tests := []struct {
+		name          string
+		markdown      string
+		expectedCount int
+	}{
+		{
+			name:          "两行粗体各自独立",
+			markdown:      "**A派**：xxx\n**B派**：yyy",
+			expectedCount: 2,
+		},
+		{
+			name:          "三行普通文本各自独立",
+			markdown:      "第一行\n第二行\n第三行",
+			expectedCount: 3,
+		},
+		{
+			name:          "单行段落不拆分",
+			markdown:      "只有一行文本",
+			expectedCount: 1,
+		},
+		{
+			name:          "空行分隔的两段保持两个块",
+			markdown:      "第一段\n\n第二段",
+			expectedCount: 2,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			converter := NewMarkdownToBlock([]byte(tt.markdown), ConvertOptions{}, "")
+			blocks, err := converter.Convert()
+
+			if err != nil {
+				t.Fatalf("Convert() 返回错误: %v", err)
+			}
+
+			if len(blocks) != tt.expectedCount {
+				t.Errorf("期望 %d 个 block，实际 %d 个", tt.expectedCount, len(blocks))
+			}
+
+			for i, block := range blocks {
+				if block.BlockType == nil || *block.BlockType != int(BlockTypeText) {
+					t.Errorf("block[%d].BlockType = %v, 期望 %d (Text)", i, block.BlockType, int(BlockTypeText))
+				}
+			}
+		})
+	}
+}
+
+func TestConvert_ConsecutiveBoldLinesPreserveContent(t *testing.T) {
+	// 验证 **A派**：xxx\n**B派**：yyy 分行后每块内容和粗体样式均正确保留
+	markdown := "**A派**：xxx\n**B派**：yyy"
+	converter := NewMarkdownToBlock([]byte(markdown), ConvertOptions{}, "")
+	blocks, err := converter.Convert()
+	if err != nil {
+		t.Fatalf("Convert() 返回错误: %v", err)
+	}
+	if len(blocks) != 2 {
+		t.Fatalf("期望 2 个 block，实际 %d 个", len(blocks))
+	}
+
+	type wantElem struct {
+		text string
+		bold bool
+	}
+	wantBlocks := [][]wantElem{
+		{{"A派", true}, {"：xxx", false}},
+		{{"B派", true}, {"：yyy", false}},
+	}
+
+	for bi, want := range wantBlocks {
+		block := blocks[bi]
+		if block.Text == nil {
+			t.Fatalf("block[%d].Text 为 nil", bi)
+		}
+		elems := block.Text.Elements
+		if len(elems) != len(want) {
+			t.Errorf("block[%d] 期望 %d 个 TextElement，实际 %d 个", bi, len(want), len(elems))
+			continue
+		}
+		for ei, w := range want {
+			elem := elems[ei]
+			if elem.TextRun == nil {
+				t.Errorf("block[%d].elem[%d].TextRun 为 nil", bi, ei)
+				continue
+			}
+			if elem.TextRun.Content == nil || *elem.TextRun.Content != w.text {
+				t.Errorf("block[%d].elem[%d].Content = %v，期望 %q", bi, ei, elem.TextRun.Content, w.text)
+			}
+			hasBold := elem.TextRun.TextElementStyle != nil &&
+				elem.TextRun.TextElementStyle.Bold != nil &&
+				*elem.TextRun.TextElementStyle.Bold
+			if hasBold != w.bold {
+				t.Errorf("block[%d].elem[%d] bold=%v，期望 %v（text=%q）", bi, ei, hasBold, w.bold, w.text)
+			}
+		}
+	}
+}
+
 func TestConvert_CodeBlock(t *testing.T) {
 	markdown := "```go\nfmt.Println(\"Hello\")\n```"
 


### PR DESCRIPTION
## 问题

Markdown 中用单换行符分隔的连续行（无空行）在导入飞书时会合并为一段。常见场景：

```markdown
**A派**：xxx
**B派**：yyy
```

导入后两行出现在同一个 Text block 中，飞书显示为一段连续文本。

## 根因

`extractTextElements` 遍历段落 AST 时未检测 `*ast.Text` 节点的 `SoftLineBreak()` 标志。按 CommonMark 规范，段落内的换行只是 SoftLineBreak，不新建段落，因此整个段落作为一个 AST Paragraph 节点，所有行都被塞进一个 Text block。

有趣的是，引用块（blockquote）已经通过 `extractQuoteLines` 正确处理了这个问题，但普通段落没有。

## 修复

新增 `extractParagraphLines`，逻辑与 `extractQuoteLines` 相同（遇到 `SoftLineBreak` 分行），额外支持内联图片和行内公式后处理。修改 `convertParagraph` 为每行创建独立 Text block。

- 单行段落行为不变
- 空行分隔的多段落行为不变
- 只影响"同一段落内的软换行"场景

**Known limitation**：换行符位于内联容器内部（如 `**行一\n行二**`）不会触发分行，此类写法极罕见，已在注释中记录。

## 测试

新增两个回归测试：
- `TestConvert_ConsecutiveLinesBecomeSeparateBlocks`：验证 block 数量
- `TestConvert_ConsecutiveBoldLinesPreserveContent`：验证分行后每块的内容文本和粗体样式均正确保留

## Test plan

- [x] `go test ./internal/converter/...` 全部通过
- [x] 单行/多行/空行分隔场景均验证
- [x] 粗体样式在分行后正确保留