### PR TITLE
fix: 重新修复 Markdown 导入时反斜杠转义未还原（PR #81 修复在 rebase 中丢失）

### DIFF
--- a/internal/converter/markdown_to_block.go
+++ b/internal/converter/markdown_to_block.go
@@ -19,6 +19,34 @@ import (
 // 最大递归深度常量（在 block_to_markdown.go 中定义）
 // const maxRecursionDepth = 100
 
+// unescapeMarkdownText 去除 CommonMark 反斜杠转义。
+// goldmark 的 Segment.Value 返回源文件原始字节，不处理转义序列。
+// 例如 "1\." 应还原为 "1."，"\[1\]" 应还原为 "[1]"，"prompt\_len" 应还原为 "prompt_len"。
+// 按 CommonMark 规范，反斜杠后跟 ASCII 标点符号（!-/:-@[-`{-~）是转义序列。
+func unescapeMarkdownText(s string) string {
+	var buf strings.Builder
+	buf.Grow(len(s))
+	for i := 0; i < len(s); i++ {
+		if s[i] == '\\' && i+1 < len(s) {
+			next := s[i+1]
+			// ASCII punctuation: !"#$%&'()*+,-./:;<=>?@[\]^_`{|}~
+			if (next >= '!' && next <= '/') || (next >= ':' && next <= '@') ||
+				(next >= '[' && next <= '`') || (next >= '{' && next <= '~') {
+				buf.WriteByte(next)
+				i++ // skip next
+				continue
+			}
+		}
+		buf.WriteByte(s[i])
+	}
+	return buf.String()
+}
+
+// unescapeMarkdownBytes 是 unescapeMarkdownText 的 []byte 版本，用于 buf.Write 场景。
+func unescapeMarkdownBytes(b []byte) []byte {
+	return []byte(unescapeMarkdownText(string(b)))
+}
+
 // 飞书 API 限制单个表格最多 9 行（包括表头）、9 列
 const maxTableRows = 9
 const maxTableCols = 9
@@ -460,7 +488,7 @@ func (c *MarkdownToBlock) convertListItem(node *ast.ListItem, isOrdered bool) (*
 				}
 				// Also check for raw text pattern
 				if txt, ok := tb.FirstChild().(*ast.Text); ok {
-					text := string(txt.Segment.Value(c.source))
+					text := unescapeMarkdownText(string(txt.Segment.Value(c.source)))
 					if strings.HasPrefix(text, "[ ] ") || strings.HasPrefix(text, "[x] ") || strings.HasPrefix(text, "[X] ") {
 						block, err := c.convertTaskListItem(node, text)
 						if err != nil {
@@ -625,7 +653,7 @@ func (c *MarkdownToBlock) extractTextElementsSkipCheckbox(node ast.Node) []*lark
 
 		switch child := n.(type) {
 		case *ast.Text:
-			text := string(child.Segment.Value(c.source))
+			text := unescapeMarkdownText(string(child.Segment.Value(c.source)))
 			if text != "" {
 				elements = append(elements, &larkdocx.TextElement{
 					TextRun: &larkdocx.TextRun{
@@ -714,7 +742,7 @@ func (c *MarkdownToBlock) convertBlockquote(node *ast.Blockquote) ([]*BlockNode,
 			var firstLineText string
 			for inline := para.FirstChild(); inline != nil; inline = inline.NextSibling() {
 				if txt, ok := inline.(*ast.Text); ok {
-					firstLineText += string(txt.Segment.Value(c.source))
+					firstLineText += unescapeMarkdownText(string(txt.Segment.Value(c.source)))
 					if txt.SoftLineBreak() {
 						break
 					}
@@ -840,7 +868,7 @@ func (c *MarkdownToBlock) extractQuoteLines(node ast.Node) [][]*larkdocx.TextEle
 
 		switch child := n.(type) {
 		case *ast.Text:
-			text := string(child.Segment.Value(c.source))
+			text := unescapeMarkdownText(string(child.Segment.Value(c.source)))
 			if text != "" {
 				currentLine = append(currentLine, &larkdocx.TextElement{
 					TextRun: &larkdocx.TextRun{Content: &text},
@@ -1530,7 +1558,7 @@ func (c *MarkdownToBlock) extractTextElements(node ast.Node) []*larkdocx.TextEle
 
 		switch child := n.(type) {
 		case *ast.Text:
-			text := string(child.Segment.Value(c.source))
+			text := unescapeMarkdownText(string(child.Segment.Value(c.source)))
 			if text != "" {
 				elements = append(elements, &larkdocx.TextElement{
 					TextRun: &larkdocx.TextRun{
@@ -1644,7 +1672,7 @@ func (c *MarkdownToBlock) getNodeTextWithDepth(node ast.Node, depth int) string 
 	for child := node.FirstChild(); child != nil; child = child.NextSibling() {
 		switch n := child.(type) {
 		case *ast.Text:
-			buf.Write(n.Segment.Value(c.source))
+			buf.Write(unescapeMarkdownBytes(n.Segment.Value(c.source)))
 		case *ast.String:
 			buf.Write(n.Value)
 		case *ast.RawHTML:
@@ -1674,7 +1702,7 @@ func (c *MarkdownToBlock) extractChildElements(node ast.Node) []*larkdocx.TextEl
 	for child := node.FirstChild(); child != nil; child = child.NextSibling() {
 		switch n := child.(type) {
 		case *ast.Text:
-			text := string(n.Segment.Value(c.source))
+			text := unescapeMarkdownText(string(n.Segment.Value(c.source)))
 			if text != "" {
 				elem := &larkdocx.TextElement{
 					TextRun: &larkdocx.TextRun{Content: &text},

--- a/internal/converter/markdown_unescape_test.go
+++ b/internal/converter/markdown_unescape_test.go
@@ -1,0 +1,270 @@
+package converter
+
+import (
+	"strings"
+	"testing"
+
+	larkdocx "github.com/larksuite/oapi-sdk-go/v3/service/docx/v1"
+)
+
+// TestUnescapeMarkdownText 测试 CommonMark 反斜杠转义的去除。
+// goldmark 的 Segment.Value 返回源文件原始字节，不处理转义序列，
+// 需要 unescapeMarkdownText 将 "1\." 还原为 "1."、"\[1\]" 还原为 "[1]"。
+func TestUnescapeMarkdownText(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  string
+	}{
+		// 数字+点号转义（Defuddle 最常见的产物）
+		{"escaped_dot_1", `1\. 反逆向`, "1. 反逆向"},
+		{"escaped_dot_2", `2\. 反不合规`, "2. 反不合规"},
+		{"escaped_dot_in_text", `正文 3\. 内容`, "正文 3. 内容"},
+
+		// 方括号转义（脚注引用）
+		{"escaped_brackets", `\[1\]`, "[1]"},
+		{"escaped_brackets_in_text", `参见脚注 \[2\]`, "参见脚注 [2]"},
+
+		// 下划线转义（变量名、字段名）
+		{"escaped_underscore", `prompt\_len`, "prompt_len"},
+		{"escaped_underscore_2", `needs\_web\_search`, "needs_web_search"},
+		{"escaped_underscore_3", `edit\_file`, "edit_file"},
+		{"escaped_underscore_4", `has\_attachments`, "has_attachments"},
+
+		// 其他 ASCII 标点转义
+		{"escaped_asterisk", `\*粗体\*`, "*粗体*"},
+		{"escaped_hash", `\# 不是标题`, "# 不是标题"},
+		{"escaped_backtick", "\\`code\\`", "`code`"},
+		{"escaped_tilde", `\~删除线\~`, "~删除线~"},
+		{"escaped_pipe", `\|表格分隔\|`, "|表格分隔|"},
+		{"escaped_backslash", `\\`, `\`},
+
+		// 不应处理的情况：反斜杠后跟非 ASCII 标点
+		{"no_escape_letter", `\n 不处理`, `\n 不处理`},
+		{"no_escape_space", `\ 后跟空格`, `\ 后跟空格`},
+		{"no_escape_chinese", `\中文`, `\中文`},
+		{"trailing_backslash", `末尾\`, `末尾\`},
+		{"plain_text", "普通文本无转义", "普通文本无转义"},
+		{"empty_string", "", ""},
+
+		// 混合场景
+		{"mixed", `### 1\. 标题 \[1\]`, "### 1. 标题 [1]"},
+		{"mixed_underscores", `file\_name / tos\_key / file\_source`, "file_name / tos_key / file_source"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := unescapeMarkdownText(tt.input)
+			if got != tt.want {
+				t.Errorf("unescapeMarkdownText(%q) = %q, want %q", tt.input, got, tt.want)
+			}
+		})
+	}
+}
+
+// TestUnescapeMarkdownBytes 测试 []byte 版本。
+func TestUnescapeMarkdownBytes(t *testing.T) {
+	input := []byte(`prompt\_len`)
+	got := unescapeMarkdownBytes(input)
+	want := []byte("prompt_len")
+	if string(got) != string(want) {
+		t.Errorf("unescapeMarkdownBytes(%q) = %q, want %q", input, got, want)
+	}
+}
+
+// TestConvert_EscapedHeading 端到端测试：Markdown 标题含转义字符 → Convert → 飞书块文本不含反斜杠。
+// 复现场景：Defuddle 输出 "### 1\. 反逆向" 导入飞书后显示为 "1\. 反逆向"。
+func TestConvert_EscapedHeading(t *testing.T) {
+	tests := []struct {
+		name     string
+		markdown string
+		want     string
+	}{
+		{
+			"heading_with_escaped_dot",
+			"### 1\\. 反逆向 / 反自动化",
+			"1. 反逆向 / 反自动化",
+		},
+		{
+			"heading_with_escaped_dot_2",
+			"### 2\\. 反不合规地区使用",
+			"2. 反不合规地区使用",
+		},
+		{
+			"heading_without_escape",
+			"### 普通标题",
+			"普通标题",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			converter := NewMarkdownToBlock([]byte(tt.markdown), ConvertOptions{}, "")
+			blocks, err := converter.Convert()
+			if err != nil {
+				t.Fatalf("Convert() 返回错误: %v", err)
+			}
+			if len(blocks) == 0 {
+				t.Fatal("blocks 为空")
+			}
+
+			got := collectBlockText(blocks[0])
+			if got != tt.want {
+				t.Errorf("标题文本 = %q, 期望 %q", got, tt.want)
+			}
+		})
+	}
+}
+
+// TestConvert_EscapedParagraph 端到端测试：正文段落含转义字符。
+func TestConvert_EscapedParagraph(t *testing.T) {
+	tests := []struct {
+		name     string
+		markdown string
+		want     string
+	}{
+		{
+			"paragraph_with_escaped_brackets",
+			"参见脚注 \\[1\\]",
+			"参见脚注 [1]",
+		},
+		{
+			"paragraph_with_escaped_dot",
+			"正文 3\\. 某某某",
+			"正文 3. 某某某",
+		},
+		{
+			"paragraph_with_escaped_underscore",
+			"字段名 prompt\\_len 是整数类型",
+			"字段名 prompt_len 是整数类型",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			converter := NewMarkdownToBlock([]byte(tt.markdown), ConvertOptions{}, "")
+			blocks, err := converter.Convert()
+			if err != nil {
+				t.Fatalf("Convert() 返回错误: %v", err)
+			}
+			if len(blocks) == 0 {
+				t.Fatal("blocks 为空")
+			}
+
+			got := collectBlockText(blocks[0])
+			if got != tt.want {
+				t.Errorf("段落文本 = %q, 期望 %q", got, tt.want)
+			}
+		})
+	}
+}
+
+// TestConvert_EscapedListItem 端到端测试：列表项含转义字符。
+func TestConvert_EscapedListItem(t *testing.T) {
+	markdown := "- 选项 A\\: Google Voice\n- 选项 B\\: 实体 SIM"
+
+	converter := NewMarkdownToBlock([]byte(markdown), ConvertOptions{}, "")
+	blocks, err := converter.Convert()
+	if err != nil {
+		t.Fatalf("Convert() 返回错误: %v", err)
+	}
+
+	for _, b := range blocks {
+		text := collectBlockText(b)
+		if strings.Contains(text, `\:`) {
+			t.Errorf("列表项文本含未转义的反斜杠: %q", text)
+		}
+	}
+}
+
+// TestConvert_EscapedTableCell 端到端测试：表格单元格含转义下划线。
+// 复现场景：表格中 "prompt\_len" 导入飞书后显示为 "prompt\_len" 而非 "prompt_len"。
+func TestConvert_EscapedTableCell(t *testing.T) {
+	markdown := `| 字段 | 类型 | 说明 |
+| --- | --- | --- |
+| prompt\_len | int | prompt 字符长度 |
+| needs\_web\_search | bool | 是否需要联网搜索 |
+| edit\_file | string | 编辑文件工具 |`
+
+	converter := NewMarkdownToBlock([]byte(markdown), ConvertOptions{}, "")
+	result, err := converter.ConvertWithTableData()
+	if err != nil {
+		t.Fatalf("ConvertWithTableData() 返回错误: %v", err)
+	}
+
+	if len(result.TableDatas) == 0 {
+		t.Fatal("没有表格数据")
+	}
+
+	td := result.TableDatas[0]
+
+	// 检查所有单元格的纯文本内容中不含反斜杠转义
+	for i, text := range td.CellContents {
+		if strings.Contains(text, `\_`) {
+			t.Errorf("表格单元格 [%d] 含未转义的反斜杠: %q", i, text)
+		}
+	}
+
+	// 检查所有单元格的富文本元素中不含反斜杠转义
+	for i, elements := range td.CellElements {
+		for _, elem := range elements {
+			if elem.TextRun != nil && elem.TextRun.Content != nil {
+				text := *elem.TextRun.Content
+				if strings.Contains(text, `\_`) {
+					t.Errorf("表格富文本 [%d] 含未转义的反斜杠: %q", i, text)
+				}
+			}
+		}
+	}
+
+	// 验证具体字段名出现在单元格纯文本中
+	wantFields := []string{"prompt_len", "needs_web_search", "edit_file"}
+	for _, want := range wantFields {
+		found := false
+		for _, text := range td.CellContents {
+			if strings.Contains(text, want) {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Errorf("表格中未找到正确的字段名 %q（可能仍含反斜杠转义）", want)
+		}
+	}
+}
+
+// collectBlockText 从 larkdocx.Block 中提取所有 TextElement 的拼接文本。
+func collectBlockText(block *larkdocx.Block) string {
+	var elements []*larkdocx.TextElement
+
+	switch {
+	case block.Heading1 != nil:
+		elements = block.Heading1.Elements
+	case block.Heading2 != nil:
+		elements = block.Heading2.Elements
+	case block.Heading3 != nil:
+		elements = block.Heading3.Elements
+	case block.Heading4 != nil:
+		elements = block.Heading4.Elements
+	case block.Heading5 != nil:
+		elements = block.Heading5.Elements
+	case block.Heading6 != nil:
+		elements = block.Heading6.Elements
+	case block.Text != nil:
+		elements = block.Text.Elements
+	case block.Bullet != nil:
+		elements = block.Bullet.Elements
+	case block.Ordered != nil:
+		elements = block.Ordered.Elements
+	default:
+		return ""
+	}
+
+	var buf strings.Builder
+	for _, e := range elements {
+		if e != nil && e.TextRun != nil && e.TextRun.Content != nil {
+			buf.WriteString(*e.TextRun.Content)
+		}
+	}
+	return buf.String()
+}


### PR DESCRIPTION
## Summary

- PR #81 的 `unescapeMarkdownText` 修复在后续上游 rebase（commit `3f8c991`）中丢失，导致反斜杠转义问题再次出现
- 重新添加 `unescapeMarkdownText` 函数，按 CommonMark 规范去除反斜杠转义（反斜杠 + ASCII 标点 → 只保留标点）
- 在全部 7 处 `Segment.Value` 调用点统一应用，覆盖标题、段落、列表项、引用块、**表格单元格**等所有路径
- 新增 `unescapeMarkdownBytes` 辅助函数，用于 `buf.Write` 场景

**受影响场景示例：**
- 表格中 `prompt\_len` → 应显示为 `prompt_len`
- 标题中 `1\. 反逆向` → 应显示为 `1. 反逆向`
- 正文中 `\[1\]` → 应显示为 `[1]`

## 7 个修复点

| # | 函数 | 说明 |
|---|------|------|
| 1 | `convertListItem` | Task list 原始文本检测 |
| 2 | `extractTextElementsSkipCheckbox` | 列表项文本提取 |
| 3 | `convertBlockquote` | 引用块首行文本 |
| 4 | `extractQuoteLines` | 引用块多行文本 |
| 5 | `extractTextElements` | 主文本元素提取（标题/段落/表格等共用） |
| 6 | `getNodeTextWithDepth` | 节点纯文本计算（表格列宽等） |
| 7 | `extractChildElements` | 子元素递归提取（表格单元格/粗体/斜体等） |

## Test plan

- [x] `TestUnescapeMarkdownText`：23 个 case 覆盖点号、方括号、下划线、星号、反斜杠等转义及不应处理的情况
- [x] `TestUnescapeMarkdownBytes`：[]byte 版本正确性
- [x] `TestConvert_EscapedHeading`：端到端验证标题中 `1\.` 转义
- [x] `TestConvert_EscapedParagraph`：端到端验证段落中下划线和方括号转义
- [x] `TestConvert_EscapedListItem`：端到端验证列表项中冒号转义
- [x] `TestConvert_EscapedTableCell`：**新增** 端到端验证表格单元格中 `prompt\_len` 等下划线转义
- [x] 全量回归：converter 包所有测试 PASS，零失败

🤖 Generated with [Claude Code](https://claude.ai/claude-code)