### PR TITLE
fix: thorough fix for QuoteContainer/Callout auto-empty block (doc add + import + nested)

### DIFF
--- a/cmd/add_content.go
+++ b/cmd/add_content.go
@@ -156,8 +156,9 @@ func deleteContainerAutoEmptyBlock(documentID, parentID, blockTypeName string) {
 	if firstChild.Text != nil {
 		for _, elem := range firstChild.Text.Elements {
 			if elem.MentionUser != nil || elem.MentionDoc != nil || elem.File != nil ||
-				elem.Reminder != nil || elem.InlineBlock != nil || elem.Equation != nil {
-				return // 有非 TextRun 元素（@用户/@文档/附件/提醒/内联块/公式），不删
+				elem.Reminder != nil || elem.InlineBlock != nil || elem.Equation != nil ||
+				elem.Undefined != nil {
+				return // 有非 TextRun 元素（@用户/@文档/附件/提醒/内联块/公式/未知类型），不删
 			}
 			if elem.TextRun != nil && elem.TextRun.Content != nil && *elem.TextRun.Content != "" {
 				return // 有非空文本，不删
@@ -246,25 +247,29 @@ func addContentMarkdown(documentID, blockID, contentData, basePath string, uploa
 	for idx, children := range nodeChildrenMap {
 		if idx < len(createdBlockIDs) {
 			parentID := createdBlockIDs[idx]
-
 			nestedCount, nestedErr := createNestedChildren(documentID, parentID, children)
 			if nestedErr != nil {
 				fmt.Fprintf(os.Stderr, "[Warning] 嵌套子块创建失败: %v\n", nestedErr)
 			}
 			totalCreated += nestedCount
+		}
+	}
 
-			// QuoteContainer / Callout：在 createNestedChildren 完成后清理飞书 API 自动生成的空子块
-			if idx < len(result.BlockNodes) {
-				node := result.BlockNodes[idx]
-				if node.Block.BlockType != nil {
-					switch *node.Block.BlockType {
-					case int(converter.BlockTypeQuoteContainer):
-						deleteContainerAutoEmptyBlock(documentID, parentID, "QuoteContainer")
-					case int(converter.BlockTypeCallout):
-						deleteContainerAutoEmptyBlock(documentID, parentID, "Callout")
-					}
-				}
-			}
+	// QuoteContainer / Callout：遍历所有顶层节点清理飞书 API 异步生成的空子块。
+	// 必须在所有 createNestedChildren 完成后执行，确保 API 已稳定。
+	// 覆盖有子块和无子块（不在 nodeChildrenMap 中）的容器节点。
+	for i, node := range result.BlockNodes {
+		if i >= len(createdBlockIDs) {
+			break
+		}
+		if node.Block.BlockType == nil {
+			continue
+		}
+		switch *node.Block.BlockType {
+		case int(converter.BlockTypeQuoteContainer):
+			deleteContainerAutoEmptyBlock(documentID, createdBlockIDs[i], "QuoteContainer")
+		case int(converter.BlockTypeCallout):
+			deleteContainerAutoEmptyBlock(documentID, createdBlockIDs[i], "Callout")
 		}
 	}
 

--- a/cmd/add_content.go
+++ b/cmd/add_content.go
@@ -133,6 +133,44 @@ var addContentCmd = &cobra.Command{
 	},
 }
 
+// deleteContainerAutoEmptyBlock 删除 QuoteContainer/Callout 容器块中飞书 API 自动生成的空文本子块。
+// 飞书 API 在创建容器块时会异步在 index 0 插入一个空 Text 块，导致渲染时顶部出现多余空行。
+// 必须在 createNestedChildren 完成后调用，此时 API 已稳定：实际子块内容均非空，
+// 若 index 0 仍为空 Text 块则可安全判定为自动生成块并删除。
+func deleteContainerAutoEmptyBlock(documentID, parentID, blockTypeName string) {
+	childrenResult := client.DoWithRetry(func() ([]*larkdocx.Block, http.Header, error) {
+		return client.GetBlockChildren(documentID, parentID)
+	}, client.RetryConfig{
+		MaxRetries:       3,
+		RetryOnRateLimit: true,
+	})
+	if childrenResult.Err != nil || len(childrenResult.Value) == 0 {
+		return
+	}
+	firstChild := childrenResult.Value[0]
+	if firstChild.BlockType == nil || *firstChild.BlockType != int(converter.BlockTypeText) {
+		return
+	}
+	// 检查是否为空文本块（无元素或所有 TextRun 内容为空字符串）
+	if firstChild.Text != nil {
+		for _, elem := range firstChild.Text.Elements {
+			if elem.TextRun != nil && elem.TextRun.Content != nil && *elem.TextRun.Content != "" {
+				return
+			}
+		}
+	}
+	delResult := client.DoWithRetry(func() (struct{}, http.Header, error) {
+		headers, err := client.DeleteBlocks(documentID, parentID, 0, 1)
+		return struct{}{}, headers, err
+	}, client.RetryConfig{
+		MaxRetries:       5,
+		RetryOnRateLimit: true,
+	})
+	if delResult.Err != nil {
+		fmt.Fprintf(os.Stderr, "[Warning] %s 空子块删除失败 (parent=%s): %v\n", blockTypeName, parentID, delResult.Err)
+	}
+}
+
 // addContentMarkdown 处理 Markdown 模式的内容添加，支持嵌套结构、分批创建、表格 429 重试
 func addContentMarkdown(documentID, blockID, contentData, basePath string, uploadImages bool, index int, output string) error {
 	opts := converter.ConvertOptions{
@@ -210,49 +248,15 @@ func addContentMarkdown(documentID, blockID, contentData, basePath string, uploa
 			}
 			totalCreated += nestedCount
 
-			// QuoteContainer / Callout：飞书 API 创建容器块后会异步在 index 0 生成一个空文本子块，
-			// 导致引用块顶部出现多余空行。在 createNestedChildren 完成后再检查并删除：
-			// 此时 API 已有足够时间生成该空块；我们的实际内容均非空，可安全判断 index 0 是否为自动生成的空块。
+			// QuoteContainer / Callout：在 createNestedChildren 完成后清理飞书 API 自动生成的空子块
 			if idx < len(result.BlockNodes) {
 				node := result.BlockNodes[idx]
-				if node.Block.BlockType != nil &&
-					(*node.Block.BlockType == int(converter.BlockTypeCallout) ||
-						*node.Block.BlockType == int(converter.BlockTypeQuoteContainer)) {
-					blockTypeName := "Callout"
-					if *node.Block.BlockType == int(converter.BlockTypeQuoteContainer) {
-						blockTypeName = "QuoteContainer"
-					}
-					childrenResult := client.DoWithRetry(func() ([]*larkdocx.Block, http.Header, error) {
-						return client.GetBlockChildren(documentID, parentID)
-					}, client.RetryConfig{
-						MaxRetries:       3,
-						RetryOnRateLimit: true,
-					})
-					if childrenResult.Err == nil && len(childrenResult.Value) > 0 {
-						firstChild := childrenResult.Value[0]
-						if firstChild.BlockType != nil && *firstChild.BlockType == int(converter.BlockTypeText) {
-							isEmpty := true
-							if firstChild.Text != nil && len(firstChild.Text.Elements) > 0 {
-								for _, elem := range firstChild.Text.Elements {
-									if elem.TextRun != nil && elem.TextRun.Content != nil && *elem.TextRun.Content != "" {
-										isEmpty = false
-										break
-									}
-								}
-							}
-							if isEmpty {
-								delResult := client.DoWithRetry(func() (struct{}, http.Header, error) {
-									headers, err := client.DeleteBlocks(documentID, parentID, 0, 1)
-									return struct{}{}, headers, err
-								}, client.RetryConfig{
-									MaxRetries:       5,
-									RetryOnRateLimit: true,
-								})
-								if delResult.Err != nil {
-									fmt.Fprintf(os.Stderr, "[Warning] %s 空子块删除失败 (parent=%s): %v\n", blockTypeName, parentID, delResult.Err)
-								}
-							}
-						}
+				if node.Block.BlockType != nil {
+					switch *node.Block.BlockType {
+					case int(converter.BlockTypeQuoteContainer):
+						deleteContainerAutoEmptyBlock(documentID, parentID, "QuoteContainer")
+					case int(converter.BlockTypeCallout):
+						deleteContainerAutoEmptyBlock(documentID, parentID, "Callout")
 					}
 				}
 			}

--- a/cmd/add_content.go
+++ b/cmd/add_content.go
@@ -203,11 +203,59 @@ func addContentMarkdown(documentID, blockID, contentData, basePath string, uploa
 	for idx, children := range nodeChildrenMap {
 		if idx < len(createdBlockIDs) {
 			parentID := createdBlockIDs[idx]
+
 			nestedCount, nestedErr := createNestedChildren(documentID, parentID, children)
 			if nestedErr != nil {
 				fmt.Fprintf(os.Stderr, "[Warning] 嵌套子块创建失败: %v\n", nestedErr)
 			}
 			totalCreated += nestedCount
+
+			// QuoteContainer / Callout：飞书 API 创建容器块后会异步在 index 0 生成一个空文本子块，
+			// 导致引用块顶部出现多余空行。在 createNestedChildren 完成后再检查并删除：
+			// 此时 API 已有足够时间生成该空块；我们的实际内容均非空，可安全判断 index 0 是否为自动生成的空块。
+			if idx < len(result.BlockNodes) {
+				node := result.BlockNodes[idx]
+				if node.Block.BlockType != nil &&
+					(*node.Block.BlockType == int(converter.BlockTypeCallout) ||
+						*node.Block.BlockType == int(converter.BlockTypeQuoteContainer)) {
+					blockTypeName := "Callout"
+					if *node.Block.BlockType == int(converter.BlockTypeQuoteContainer) {
+						blockTypeName = "QuoteContainer"
+					}
+					childrenResult := client.DoWithRetry(func() ([]*larkdocx.Block, http.Header, error) {
+						return client.GetBlockChildren(documentID, parentID)
+					}, client.RetryConfig{
+						MaxRetries:       3,
+						RetryOnRateLimit: true,
+					})
+					if childrenResult.Err == nil && len(childrenResult.Value) > 0 {
+						firstChild := childrenResult.Value[0]
+						if firstChild.BlockType != nil && *firstChild.BlockType == int(converter.BlockTypeText) {
+							isEmpty := true
+							if firstChild.Text != nil && len(firstChild.Text.Elements) > 0 {
+								for _, elem := range firstChild.Text.Elements {
+									if elem.TextRun != nil && elem.TextRun.Content != nil && *elem.TextRun.Content != "" {
+										isEmpty = false
+										break
+									}
+								}
+							}
+							if isEmpty {
+								delResult := client.DoWithRetry(func() (struct{}, http.Header, error) {
+									headers, err := client.DeleteBlocks(documentID, parentID, 0, 1)
+									return struct{}{}, headers, err
+								}, client.RetryConfig{
+									MaxRetries:       5,
+									RetryOnRateLimit: true,
+								})
+								if delResult.Err != nil {
+									fmt.Fprintf(os.Stderr, "[Warning] %s 空子块删除失败 (parent=%s): %v\n", blockTypeName, parentID, delResult.Err)
+								}
+							}
+						}
+					}
+				}
+			}
 		}
 	}
 

--- a/cmd/add_content.go
+++ b/cmd/add_content.go
@@ -151,11 +151,16 @@ func deleteContainerAutoEmptyBlock(documentID, parentID, blockTypeName string) {
 	if firstChild.BlockType == nil || *firstChild.BlockType != int(converter.BlockTypeText) {
 		return
 	}
-	// 检查是否为空文本块（无元素或所有 TextRun 内容为空字符串）
+	// 检查是否为空文本块：任何非空 TextRun 或非 TextRun 类型的元素（Link/MentionUser 等）
+	// 均视为有内容，不删除；只有 Elements 为空或全是 content="" 的 TextRun 才是自动生成的空块
 	if firstChild.Text != nil {
 		for _, elem := range firstChild.Text.Elements {
+			if elem.MentionUser != nil || elem.MentionDoc != nil || elem.File != nil ||
+				elem.Reminder != nil || elem.InlineBlock != nil || elem.Equation != nil {
+				return // 有非 TextRun 元素（@用户/@文档/附件/提醒/内联块/公式），不删
+			}
 			if elem.TextRun != nil && elem.TextRun.Content != nil && *elem.TextRun.Content != "" {
-				return
+				return // 有非空文本，不删
 			}
 		}
 	}

--- a/cmd/import_markdown.go
+++ b/cmd/import_markdown.go
@@ -619,28 +619,30 @@ func phase1CreateBlocks(
 			// 递归创建嵌套子块（如嵌套列表）
 			for idx, children := range nodeChildrenMap {
 				if idx < len(createdBlockIDs) {
-					parentID := createdBlockIDs[idx]
-
-					nestedCount, nestedErr := createNestedChildren(documentID, parentID, children)
+					nestedCount, nestedErr := createNestedChildren(documentID, createdBlockIDs[idx], children)
 					if nestedErr != nil {
 						if verbose {
 							syncPrintf("  ⚠ 段落 %d 嵌套子块创建失败: %v\n", segIdx+1, nestedErr)
 						}
 					}
 					stats.totalBlocks += nestedCount
+				}
+			}
 
-					// QuoteContainer / Callout：在 createNestedChildren 完成后清理飞书 API 异步生成的空子块
-					if idx < len(result.BlockNodes) {
-						node := result.BlockNodes[idx]
-						if node.Block.BlockType != nil {
-							switch *node.Block.BlockType {
-							case int(converter.BlockTypeQuoteContainer):
-								deleteContainerAutoEmptyBlock(documentID, parentID, "QuoteContainer")
-							case int(converter.BlockTypeCallout):
-								deleteContainerAutoEmptyBlock(documentID, parentID, "Callout")
-							}
-						}
-					}
+			// QuoteContainer / Callout：遍历所有顶层节点清理飞书 API 异步生成的空子块。
+			// 在所有 createNestedChildren 完成后执行，覆盖有子块和无子块的容器节点。
+			for i, node := range result.BlockNodes {
+				if i >= len(createdBlockIDs) {
+					break
+				}
+				if node.Block.BlockType == nil {
+					continue
+				}
+				switch *node.Block.BlockType {
+				case int(converter.BlockTypeQuoteContainer):
+					deleteContainerAutoEmptyBlock(documentID, createdBlockIDs[i], "QuoteContainer")
+				case int(converter.BlockTypeCallout):
+					deleteContainerAutoEmptyBlock(documentID, createdBlockIDs[i], "Callout")
 				}
 			}
 

--- a/cmd/import_markdown.go
+++ b/cmd/import_markdown.go
@@ -621,53 +621,6 @@ func phase1CreateBlocks(
 				if idx < len(createdBlockIDs) {
 					parentID := createdBlockIDs[idx]
 
-					// Callout / QuoteContainer 容器创建时飞书 API 会自动插入一个 index 0 的空文本子块。
-					// 必须在调用 createNestedChildren 之前删除它，否则 GetBlockChildren 可能因 API
-					// 一致性延迟返回不完整结果，导致自动子块残留、容器顶部出现多余空行。
-					if idx < len(result.BlockNodes) {
-						node := result.BlockNodes[idx]
-						if node.Block.BlockType != nil && (*node.Block.BlockType == int(converter.BlockTypeCallout) || *node.Block.BlockType == int(converter.BlockTypeQuoteContainer)) {
-							blockTypeName := "Callout"
-							if *node.Block.BlockType == int(converter.BlockTypeQuoteContainer) {
-								blockTypeName = "QuoteContainer"
-							}
-							childrenResult := client.DoWithRetry(func() ([]*larkdocx.Block, http.Header, error) {
-								return client.GetBlockChildren(documentID, parentID)
-							}, client.RetryConfig{
-								MaxRetries:       3,
-								RetryOnRateLimit: true,
-							})
-							if childrenResult.Err == nil && len(childrenResult.Value) > 0 {
-								firstChild := childrenResult.Value[0]
-								if firstChild.BlockType != nil && *firstChild.BlockType == int(converter.BlockTypeText) {
-									// 检查是否为空文本块（无 elements 或所有 TextRun 内容为空）
-									isEmpty := true
-									if firstChild.Text != nil && len(firstChild.Text.Elements) > 0 {
-										for _, elem := range firstChild.Text.Elements {
-											if elem.TextRun != nil && elem.TextRun.Content != nil && *elem.TextRun.Content != "" {
-												isEmpty = false
-												break
-											}
-										}
-									}
-									if isEmpty {
-										delResult := client.DoWithRetry(func() (struct{}, http.Header, error) {
-											headers, err := client.DeleteBlocks(documentID, parentID, 0, 1)
-											return struct{}{}, headers, err
-										}, client.RetryConfig{
-											MaxRetries:       5,
-											RetryOnRateLimit: true,
-										})
-										if delResult.Err != nil {
-											fmt.Fprintf(os.Stderr, "  ⚠ %s 空子块删除失败 (parent=%s): %v\n", blockTypeName, parentID, delResult.Err)
-										}
-									}
-								}
-							} else if childrenResult.Err != nil && verbose {
-								syncPrintf("  ⚠ %s 子块查询失败 (parent=%s): %v\n", blockTypeName, parentID, childrenResult.Err)
-							}
-						}
-					}
 
 					nestedCount, nestedErr := createNestedChildren(documentID, parentID, children)
 					if nestedErr != nil {
@@ -676,6 +629,19 @@ func phase1CreateBlocks(
 						}
 					}
 					stats.totalBlocks += nestedCount
+
+					// QuoteContainer / Callout：在 createNestedChildren 完成后清理飞书 API 异步生成的空子块
+					if idx < len(result.BlockNodes) {
+						node := result.BlockNodes[idx]
+						if node.Block.BlockType != nil {
+							switch *node.Block.BlockType {
+							case int(converter.BlockTypeQuoteContainer):
+								deleteContainerAutoEmptyBlock(documentID, parentID, "QuoteContainer")
+							case int(converter.BlockTypeCallout):
+								deleteContainerAutoEmptyBlock(documentID, parentID, "Callout")
+							}
+						}
+					}
 				}
 			}
 
@@ -1152,11 +1118,24 @@ func createNestedChildren(documentID string, parentBlockID string, children []*c
 
 	// 递归创建更深层的子块
 	for i, child := range children {
-		if len(child.Children) > 0 && i < len(createdBlockIDs) {
-			nestedCount, err := createNestedChildren(documentID, createdBlockIDs[i], child.Children)
+		if i >= len(createdBlockIDs) {
+			continue
+		}
+		childID := createdBlockIDs[i]
+		if len(child.Children) > 0 {
+			nestedCount, err := createNestedChildren(documentID, childID, child.Children)
 			totalCreated += nestedCount
 			if err != nil {
 				return totalCreated, err
+			}
+			// QuoteContainer / Callout 嵌套场景：在子块创建完成后清理自动生成的空块
+			if child.Block.BlockType != nil {
+				switch *child.Block.BlockType {
+				case int(converter.BlockTypeQuoteContainer):
+					deleteContainerAutoEmptyBlock(documentID, childID, "QuoteContainer")
+				case int(converter.BlockTypeCallout):
+					deleteContainerAutoEmptyBlock(documentID, childID, "Callout")
+				}
 			}
 		}
 	}

--- a/cmd/import_markdown.go
+++ b/cmd/import_markdown.go
@@ -621,7 +621,6 @@ func phase1CreateBlocks(
 				if idx < len(createdBlockIDs) {
 					parentID := createdBlockIDs[idx]
 
-
 					nestedCount, nestedErr := createNestedChildren(documentID, parentID, children)
 					if nestedErr != nil {
 						if verbose {
@@ -1128,14 +1127,14 @@ func createNestedChildren(documentID string, parentBlockID string, children []*c
 			if err != nil {
 				return totalCreated, err
 			}
-			// QuoteContainer / Callout 嵌套场景：在子块创建完成后清理自动生成的空块
-			if child.Block.BlockType != nil {
-				switch *child.Block.BlockType {
-				case int(converter.BlockTypeQuoteContainer):
-					deleteContainerAutoEmptyBlock(documentID, childID, "QuoteContainer")
-				case int(converter.BlockTypeCallout):
-					deleteContainerAutoEmptyBlock(documentID, childID, "Callout")
-				}
+		}
+		// QuoteContainer / Callout 嵌套场景：无论是否有子块，均清理 API 自动生成的空块
+		if child.Block.BlockType != nil {
+			switch *child.Block.BlockType {
+			case int(converter.BlockTypeQuoteContainer):
+				deleteContainerAutoEmptyBlock(documentID, childID, "QuoteContainer")
+			case int(converter.BlockTypeCallout):
+				deleteContainerAutoEmptyBlock(documentID, childID, "Callout")
 			}
 		}
 	}


### PR DESCRIPTION
## 问题

飞书 API 在创建 QuoteContainer/Callout 块时，会**异步**在 index 0 插入一个空 Text 子块，导致引用块顶部渲染出多余的空行。

## 历次修复的问题

| 修复 | 方法 | 为什么失败 |
|------|------|-----------|
| 未修 | 无 | bug 一直存在 |
| fix/quote-container-empty-child | 只扩展 Callout 逻辑到 QuoteContainer，仍在 createNestedChildren *之后*查 | GetBlockChildren 返回不完整结果时漏删 |
| PR #100 | 将检查移到 createNestedChildren *之前* | API 生成空块是异步的，查询时容器还没有任何子块（返回 0），跳过了删除 |

## 本次修复

**根本原因**：空块是异步生成的，在 `createNestedChildren` 完成*之后*才稳定可见；而实际内容永远非空，所以检查 index 0 是否为空是安全的。

**三处修改**：

1. **提取共享 helper `deleteContainerAutoEmptyBlock`** — 唯一实现，消除代码重复
2. **`addContentMarkdown`（`doc add` / `doc content-update`）** — 改为在 `createNestedChildren` 之后调用 helper（此路径之前完全没有修复）
3. **`phase1CreateBlocks`（`doc import`）** — 把 PR #100 的"之前"方案改为"之后"，使用同一个 helper
4. **`createNestedChildren`** — 递归处理嵌套 QuoteContainer/Callout（blockquote 嵌套 blockquote 场景）

## 验证

```
QuoteContainer (中间位置插入): children_count=2，无空块
QuoteContainer (文档末尾):     children_count=1，无空块
```

两个 QuoteContainer 均无 index 0 空块，文档渲染正常。

🤖 Generated with [Claude Code](https://claude.com/claude-code)