### PR TITLE
fix(doc): improve doc import — replace mode, quote container cleanup, folded headings

### DIFF
--- a/cmd/add_content.go
+++ b/cmd/add_content.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
+	"time"
 
 	larkdocx "github.com/larksuite/oapi-sdk-go/v3/service/docx/v1"
 	"github.com/riba2534/feishu-cli/internal/client"
@@ -134,10 +135,34 @@ var addContentCmd = &cobra.Command{
 	},
 }
 
+// isEmptyTextBlock 判断一个块是否为空文本块（API 自动生成的占位块）。
+// 只有 Elements 为空或全是 content="" 的 TextRun 才视为空块；
+// 含有 MentionUser/MentionDoc/File 等非 TextRun 元素的块不视为空。
+func isEmptyTextBlock(block *larkdocx.Block) bool {
+	if block.BlockType == nil || *block.BlockType != int(converter.BlockTypeText) {
+		return false
+	}
+	if block.Text == nil || len(block.Text.Elements) == 0 {
+		return true
+	}
+	for _, elem := range block.Text.Elements {
+		if elem.MentionUser != nil || elem.MentionDoc != nil || elem.File != nil ||
+			elem.Reminder != nil || elem.InlineBlock != nil || elem.Equation != nil ||
+			elem.Undefined != nil {
+			return false
+		}
+		if elem.TextRun != nil && elem.TextRun.Content != nil && *elem.TextRun.Content != "" {
+			return false
+		}
+	}
+	return true
+}
+
 // deleteContainerAutoEmptyBlock 删除 QuoteContainer/Callout 容器块中飞书 API 自动生成的空文本子块。
 // 飞书 API 在创建容器块时会异步在 index 0 插入一个空 Text 块，导致渲染时顶部出现多余空行。
-// 必须在 createNestedChildren 完成后调用，此时 API 已稳定：实际子块内容均非空，
-// 若 index 0 仍为空 Text 块则可安全判定为自动生成块并删除。
+// 必须在 createNestedChildren 完成后调用，此时实际子块内容均非空。
+// 仅检查 index 0 处的子块（自动生成块始终插入到 index 0），不会误删用户显式创建的段落间空行。
+// 如果首次未发现空块，会短暂等待后重试，以应对 API 异步插入空块的时序问题。
 // 对非容器块类型直接 no-op，由调用方无条件传入 block type 即可。
 func deleteContainerAutoEmptyBlock(documentID, parentID string, blockType int, userAccessToken string) {
 	var blockTypeName string
@@ -149,42 +174,42 @@ func deleteContainerAutoEmptyBlock(documentID, parentID string, blockType int, u
 	default:
 		return
 	}
-	childrenResult := client.DoWithRetry(func() ([]*larkdocx.Block, http.Header, error) {
-		return client.GetBlockChildren(documentID, parentID, userAccessToken)
-	}, client.RetryConfig{
-		MaxRetries:       3,
-		RetryOnRateLimit: true,
-	})
-	if childrenResult.Err != nil || len(childrenResult.Value) == 0 {
-		return
-	}
-	firstChild := childrenResult.Value[0]
-	if firstChild.BlockType == nil || *firstChild.BlockType != int(converter.BlockTypeText) {
-		return
-	}
-	// 检查是否为空文本块：任何非空 TextRun 或非 TextRun 类型的元素（Link/MentionUser 等）
-	// 均视为有内容，不删除；只有 Elements 为空或全是 content="" 的 TextRun 才是自动生成的空块
-	if firstChild.Text != nil {
-		for _, elem := range firstChild.Text.Elements {
-			if elem.MentionUser != nil || elem.MentionDoc != nil || elem.File != nil ||
-				elem.Reminder != nil || elem.InlineBlock != nil || elem.Equation != nil ||
-				elem.Undefined != nil {
-				return
-			}
-			if elem.TextRun != nil && elem.TextRun.Content != nil && *elem.TextRun.Content != "" {
-				return
-			}
+
+	// 尝试多次查找并删除 index 0 处的自动生成空块，处理 API 异步插入的时序问题。
+	// 重试逻辑：首次立即检查；若 index 0 不是空块，说明自动生成块可能尚未出现或已被
+	// 我们的内容块推到其他位置，等待后重试以确保捕获异步插入的空块。
+	for attempt := 0; attempt < 3; attempt++ {
+		if attempt > 0 {
+			time.Sleep(300 * time.Millisecond)
 		}
-	}
-	delResult := client.DoWithRetry(func() (struct{}, http.Header, error) {
-		headers, err := client.DeleteBlocks(documentID, parentID, 0, 1, userAccessToken)
-		return struct{}{}, headers, err
-	}, client.RetryConfig{
-		MaxRetries:       5,
-		RetryOnRateLimit: true,
-	})
-	if delResult.Err != nil {
-		fmt.Fprintf(os.Stderr, "[Warning] %s 空子块删除失败 (parent=%s): %v\n", blockTypeName, parentID, delResult.Err)
+
+		childrenResult := client.DoWithRetry(func() ([]*larkdocx.Block, http.Header, error) {
+			return client.GetBlockChildren(documentID, parentID, userAccessToken)
+		}, client.RetryConfig{
+			MaxRetries:       3,
+			RetryOnRateLimit: true,
+		})
+		if childrenResult.Err != nil || len(childrenResult.Value) == 0 {
+			continue
+		}
+
+		firstChild := childrenResult.Value[0]
+		if !isEmptyTextBlock(firstChild) {
+			// index 0 不是空块，可能自动生成块尚未出现，重试
+			continue
+		}
+
+		delResult := client.DoWithRetry(func() (struct{}, http.Header, error) {
+			headers, err := client.DeleteBlocks(documentID, parentID, 0, 1, userAccessToken)
+			return struct{}{}, headers, err
+		}, client.RetryConfig{
+			MaxRetries:       5,
+			RetryOnRateLimit: true,
+		})
+		if delResult.Err != nil {
+			fmt.Fprintf(os.Stderr, "[Warning] %s 空子块删除失败 (parent=%s): %v\n", blockTypeName, parentID, delResult.Err)
+		}
+		return
 	}
 }
 

--- a/cmd/import_markdown.go
+++ b/cmd/import_markdown.go
@@ -382,6 +382,19 @@ var importMarkdownCmd = &cobra.Command{
 			documentID = *doc.DocumentId
 			fmt.Printf("已创建文档: %s\n", documentID)
 			fmt.Printf("链接: https://feishu.cn/docx/%s\n\n", documentID)
+		} else {
+			// --document-id was provided: clear existing content before importing
+			fmt.Println("清除已有文档内容...")
+			children, _, err := client.GetBlockChildren(documentID, documentID, userAccessToken)
+			if err != nil {
+				return fmt.Errorf("获取文档子块失败: %w", err)
+			}
+			if len(children) > 0 {
+				if _, err := client.DeleteBlocks(documentID, documentID, 0, len(children), userAccessToken); err != nil {
+					return fmt.Errorf("清除文档内容失败: %w", err)
+				}
+				fmt.Printf("已清除 %d 个块\n\n", len(children))
+			}
 		}
 
 		// 解析 Markdown 为片段
@@ -622,54 +635,6 @@ func phase1CreateBlocks(
 			for idx, children := range nodeChildrenMap {
 				if idx < len(createdBlockIDs) {
 					parentID := createdBlockIDs[idx]
-
-					// Callout / QuoteContainer 容器创建时飞书 API 会自动插入一个 index 0 的空文本子块。
-					// 必须在调用 createNestedChildren 之前删除它，否则 GetBlockChildren 可能因 API
-					// 一致性延迟返回不完整结果，导致自动子块残留、容器顶部出现多余空行。
-					if idx < len(result.BlockNodes) {
-						node := result.BlockNodes[idx]
-						if node.Block.BlockType != nil && (*node.Block.BlockType == int(converter.BlockTypeCallout) || *node.Block.BlockType == int(converter.BlockTypeQuoteContainer)) {
-							blockTypeName := "Callout"
-							if *node.Block.BlockType == int(converter.BlockTypeQuoteContainer) {
-								blockTypeName = "QuoteContainer"
-							}
-							childrenResult := client.DoWithRetry(func() ([]*larkdocx.Block, http.Header, error) {
-								return client.GetBlockChildren(documentID, parentID, userAccessToken)
-							}, client.RetryConfig{
-								MaxRetries:       3,
-								RetryOnRateLimit: true,
-							})
-							if childrenResult.Err == nil && len(childrenResult.Value) > 0 {
-								firstChild := childrenResult.Value[0]
-								if firstChild.BlockType != nil && *firstChild.BlockType == int(converter.BlockTypeText) {
-									// 检查是否为空文本块（无 elements 或所有 TextRun 内容为空）
-									isEmpty := true
-									if firstChild.Text != nil && len(firstChild.Text.Elements) > 0 {
-										for _, elem := range firstChild.Text.Elements {
-											if elem.TextRun != nil && elem.TextRun.Content != nil && *elem.TextRun.Content != "" {
-												isEmpty = false
-												break
-											}
-										}
-									}
-									if isEmpty {
-										delResult := client.DoWithRetry(func() (struct{}, http.Header, error) {
-											headers, err := client.DeleteBlocks(documentID, parentID, 0, 1, userAccessToken)
-											return struct{}{}, headers, err
-										}, client.RetryConfig{
-											MaxRetries:       5,
-											RetryOnRateLimit: true,
-										})
-										if delResult.Err != nil {
-											fmt.Fprintf(os.Stderr, "  ⚠ %s 空子块删除失败 (parent=%s): %v\n", blockTypeName, parentID, delResult.Err)
-										}
-									}
-								}
-							} else if childrenResult.Err != nil && verbose {
-								syncPrintf("  ⚠ %s 子块查询失败 (parent=%s): %v\n", blockTypeName, parentID, childrenResult.Err)
-							}
-						}
-					}
 
 					nestedCount, nestedErr := createNestedChildren(documentID, parentID, children, userAccessToken)
 					if nestedErr != nil {

--- a/internal/converter/markdown_to_block.go
+++ b/internal/converter/markdown_to_block.go
@@ -353,6 +353,21 @@ func (c *MarkdownToBlock) Convert() ([]*larkdocx.Block, error) {
 func (c *MarkdownToBlock) convertHeading(node *ast.Heading) (*larkdocx.Block, error) {
 	elements := c.extractTextElements(node)
 
+	// Check for {folded="true"} attribute in the last text element
+	folded := false
+	if len(elements) > 0 {
+		lastElem := elements[len(elements)-1]
+		if lastElem.TextRun != nil && lastElem.TextRun.Content != nil {
+			content := *lastElem.TextRun.Content
+			if strings.HasSuffix(strings.TrimSpace(content), `{folded="true"}`) {
+				folded = true
+				trimmed := strings.TrimSuffix(strings.TrimSpace(content), `{folded="true"}`)
+				trimmed = strings.TrimRight(trimmed, " ")
+				lastElem.TextRun.Content = &trimmed
+			}
+		}
+	}
+
 	level := node.Level
 	if level > 9 {
 		level = 9
@@ -365,6 +380,9 @@ func (c *MarkdownToBlock) convertHeading(node *ast.Heading) (*larkdocx.Block, er
 	}
 
 	headingText := &larkdocx.Text{Elements: elements}
+	if folded {
+		headingText.Style = &larkdocx.TextStyle{Folded: &folded}
+	}
 	switch level {
 	case 1:
 		block.Heading1 = headingText


### PR DESCRIPTION
## Summary

Three fixes for `doc import`:

- **Replace existing content when `--document-id` is provided**: Previously appended new content after existing blocks. Now clears all existing blocks before importing, making it a true replace operation.
- **Fix leading empty line in QuoteContainer/Callout blocks**: Removed race-prone pre-cleanup, added retry logic to post-cleanup to reliably catch async API-inserted empty blocks.
- **Support `{folded="true"}` in heading markdown**: Headings with `{folded="true"}` suffix now render as collapsible/toggle headings in Feishu. The marker is stripped from heading text.

## Details

### 1. Import replace mode (`cmd/import_markdown.go`)

When `--document-id` is set, the `else` branch now calls `GetBlockChildren` + `DeleteBlocks` to clear existing content before importing. This matches user expectation that updating an existing doc replaces its content.

### 2. Quote container empty line fix (`cmd/add_content.go`)

**Root cause**: The Feishu API asynchronously inserts an empty text block at index 0 inside newly created containers (QuoteContainer, Callout). The previous approach deleted this block *before* adding children, which triggered the API to insert another empty block — a race condition.

**Fix**: Removed the pre-cleanup block in `phase1CreateBlocks`. Rewrote `deleteContainerAutoEmptyBlock` with a polling retry mechanism (up to 3 attempts, 300ms delay) to handle the async timing. Extracted `isEmptyTextBlock()` helper for cleaner detection logic.

### 3. Folded headings (`internal/converter/markdown_to_block.go`)

Parses `{folded="true"}` suffix from the last text element of headings. When found, sets `TextStyle.Folded = true` on the heading's `Text` struct and strips the marker from the heading text. This uses the existing Feishu API `folded` field on `TextStyle`.

## Test plan

- [x] `doc import file.md --document-id EXISTING` replaces content (not appends)
- [x] Blockquotes (`> text`) render without leading empty line
- [x] Callouts (`> [!NOTE]`) render without leading empty line
- [x] `# Heading {folded="true"}` renders as collapsible heading in Feishu
- [x] `# Heading` without marker renders as normal heading
- [x] `go build` succeeds