### PR TITLE
feat(doc): doc import 新增 --replace 标志，支持覆盖已有文档内容

### DIFF
--- a/cmd/import_markdown.go
+++ b/cmd/import_markdown.go
@@ -288,6 +288,7 @@ var importMarkdownCmd = &cobra.Command{
 示例:
   feishu-cli doc import doc.md --title "我的文档"
   feishu-cli doc import doc.md --document-id ABC123def456
+  feishu-cli doc import doc.md --document-id ABC123def456 --replace
   feishu-cli doc import doc.md --title "我的文档" --verbose
   feishu-cli doc import doc.md --title "测试" --diagram-workers 5 --table-workers 8`,
 	Args: cobra.ExactArgs(1),
@@ -299,6 +300,7 @@ var importMarkdownCmd = &cobra.Command{
 		filePath := args[0]
 		title, _ := cmd.Flags().GetString("title")
 		documentID, _ := cmd.Flags().GetString("document-id")
+		replace, _ := cmd.Flags().GetBool("replace")
 		uploadImages, _ := cmd.Flags().GetBool("upload-images")
 		folder, _ := cmd.Flags().GetString("folder")
 		verbose, _ := cmd.Flags().GetBool("verbose")
@@ -382,6 +384,19 @@ var importMarkdownCmd = &cobra.Command{
 			documentID = *doc.DocumentId
 			fmt.Printf("已创建文档: %s\n", documentID)
 			fmt.Printf("链接: https://feishu.cn/docx/%s\n\n", documentID)
+		} else if replace {
+			// --replace: 清除已有文档内容后再导入
+			fmt.Println("清除已有文档内容...")
+			children, _, err := client.GetBlockChildren(documentID, documentID, userAccessToken)
+			if err != nil {
+				return fmt.Errorf("获取文档子块失败: %w", err)
+			}
+			if len(children) > 0 {
+				if _, err := client.DeleteBlocks(documentID, documentID, 0, len(children), userAccessToken); err != nil {
+					return fmt.Errorf("清除文档内容失败: %w", err)
+				}
+				fmt.Printf("已清除 %d 个块\n\n", len(children))
+			}
 		}
 
 		// 解析 Markdown 为片段
@@ -1291,6 +1306,7 @@ func init() {
 	docCmd.AddCommand(importMarkdownCmd)
 	importMarkdownCmd.Flags().StringP("title", "t", "", "文档标题 (用于新建文档)")
 	importMarkdownCmd.Flags().StringP("document-id", "d", "", "已有文档ID (用于更新)")
+	importMarkdownCmd.Flags().Bool("replace", false, "配合 --document-id 使用：先清除已有内容再导入（默认为追加）")
 	importMarkdownCmd.Flags().Bool("upload-images", true, "上传本地图片")
 	importMarkdownCmd.Flags().StringP("folder", "f", "", "新文档的文件夹 Token")
 	importMarkdownCmd.Flags().StringP("output", "o", "", "输出格式 (json)")

--- a/cmd/import_markdown.go
+++ b/cmd/import_markdown.go
@@ -301,6 +301,9 @@ var importMarkdownCmd = &cobra.Command{
 		title, _ := cmd.Flags().GetString("title")
 		documentID, _ := cmd.Flags().GetString("document-id")
 		replace, _ := cmd.Flags().GetBool("replace")
+		if replace && documentID == "" {
+			return fmt.Errorf("--replace 需要配合 --document-id 使用")
+		}
 		uploadImages, _ := cmd.Flags().GetBool("upload-images")
 		folder, _ := cmd.Flags().GetString("folder")
 		verbose, _ := cmd.Flags().GetBool("verbose")
@@ -387,7 +390,7 @@ var importMarkdownCmd = &cobra.Command{
 		} else if replace {
 			// --replace: 清除已有文档内容后再导入
 			fmt.Println("清除已有文档内容...")
-			children, _, err := client.GetBlockChildren(documentID, documentID, userAccessToken)
+			children, err := client.GetAllBlockChildren(documentID, documentID, userAccessToken)
 			if err != nil {
 				return fmt.Errorf("获取文档子块失败: %w", err)
 			}


### PR DESCRIPTION
## 背景

当前 `doc import --document-id` 仅支持追加语义。用户如果需要用完整导入管道（含图表转换、表格并发填充等）覆盖已有文档，只能手动先调用 `doc content-update --mode overwrite` 清除内容，再 `doc import --document-id` 追加——两步操作较繁琐。

`doc content-update --mode overwrite` 虽然也能覆盖文档，但它不经过 `doc import` 的三阶段管道（Mermaid/PlantUML 图表转换、表格并发填充、降级容错等），对于含图表的 Markdown 无法直接使用。

## 方案

新增 `--replace` 标志（opt-in），配合 `--document-id` 使用：

```bash
# 追加（默认行为，不变）
feishu-cli doc import doc.md --document-id ABC123

# 覆盖（新增）
feishu-cli doc import doc.md --document-id ABC123 --replace
```

**不改变默认行为**：不加 `--replace` 时保持原有追加语义，不影响已有用户脚本。

## 实现

在 `cmd/import_markdown.go` 中：

1. 新增 `--replace` bool flag（默认 `false`）
2. 当 `--document-id` 已指定且 `--replace` 为 `true` 时，在导入前调用 `GetBlockChildren` + `DeleteBlocks` 清除所有已有块
3. 清除完成后进入正常的三阶段导入管道

改动量：+16 行，仅修改 1 个文件。

## 测试

- [x] `doc import doc.md --document-id XXX`（无 `--replace`）：行为不变，追加内容
- [x] `doc import doc.md --document-id XXX --replace`：先清除再导入，最终文档仅包含新内容
- [x] `doc import doc.md --title "新文档"`：创建新文档，`--replace` 不生效
- [x] `go build` 通过