### PR TITLE
fix(comment): expose quote field for anchor comments

### DIFF
--- a/cmd/comment_reply.go
+++ b/cmd/comment_reply.go
@@ -68,6 +68,9 @@ var listReplyCmd = &cobra.Command{
 			if r.UserID != "" {
 				fmt.Printf("    用户 ID: %s\n", r.UserID)
 			}
+			if r.Content != "" {
+				fmt.Printf("    内容:     %s\n", r.Content)
+			}
 			if r.CreateTime != 0 {
 				fmt.Printf("    创建时间: %d\n", r.CreateTime)
 			}

--- a/cmd/list_comments.go
+++ b/cmd/list_comments.go
@@ -63,6 +63,9 @@ var listCommentsCmd = &cobra.Command{
 				fmt.Printf("[%d] 评论 ID: %s\n", i+1, c.CommentID)
 				fmt.Printf("    状态:     %s\n", status)
 				fmt.Printf("    类型:     %s\n", scope)
+				if !c.IsWhole && c.Quote != "" {
+					fmt.Printf("    划词原文: %s\n", c.Quote)
+				}
 				if c.CreateTime > 0 {
 					t := time.Unix(int64(c.CreateTime), 0)
 					fmt.Printf("    创建时间: %s\n", t.Format("2006-01-02 15:04:05"))

--- a/internal/client/comment.go
+++ b/internal/client/comment.go
@@ -16,7 +16,9 @@ type Comment struct {
 	SolvedTime   int             `json:"solved_time,omitempty"`
 	SolverUserID string          `json:"solver_user_id,omitempty"`
 	IsWhole      bool            `json:"is_whole"`
-	Content      *CommentContent `json:"reply_list,omitempty"`
+	// Quote 划词评论选中的原文；IsWhole=true 时为空
+	Quote   string          `json:"quote,omitempty"`
+	Content *CommentContent `json:"reply_list,omitempty"`
 }
 
 // CommentContent 评论内容
@@ -71,6 +73,7 @@ func ListComments(fileToken string, fileType string, pageSize int, pageToken str
 				SolvedTime:   IntVal(item.SolvedTime),
 				SolverUserID: StringVal(item.SolverUserId),
 				IsWhole:      BoolVal(item.IsWhole),
+				Quote:        StringVal(item.Quote),
 			})
 		}
 	}
@@ -164,6 +167,7 @@ func GetComment(fileToken string, commentID string, fileType string) (*Comment, 
 		CreateTime: IntVal(resp.Data.CreateTime),
 		IsSolved:   BoolVal(resp.Data.IsSolved),
 		IsWhole:    BoolVal(resp.Data.IsWhole),
+		Quote:      StringVal(resp.Data.Quote),
 	}, nil
 }
 


### PR DESCRIPTION
## Summary

- `Comment` 结构体新增 `Quote` 字段，`ListComments` / `GetComment` 映射 SDK 返回的 `quote`（局部评论的划词原文）
- `comment list` 非 JSON 输出在局部评论场景额外打印"划词原文"
- 顺手修 `comment reply list` 非 JSON 输出漏打印 `Content` 的缺陷，与 JSON 输出保持一致

## Background

issue #106 反馈 `comment reply list` 拿不到划词内容。根因是两点：

1. 飞书 SDK v3 的 `FileComment.Quote` / `GetFileCommentRespData.Quote`（注释：*如果是局部评论，引用字段*）承载了划词选中的原文，但 CLI 的 `Comment` 结构体完全没有这个字段，`--output json` 也拿不到
2. 划词原文挂在 **comment（父评论）** 上，不在 **reply（回复）** 上，所以 `comment reply list` 无论如何都不会返回 quote；正确的命令是 `comment list` 或 `comment get`

本 PR 修复 (1)，并顺手修 `comment reply list` 非 JSON 输出漏印 content 的次级缺陷。

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./internal/client/... ./cmd/...`
- [ ] 手动验证：对含划词评论的文档执行
  - `feishu-cli comment list <file_token> --type docx --output json` → 输出含 `quote` 字段
  - `feishu-cli comment list <file_token> --type docx` → 非 JSON 输出包含"划词原文"行
  - `feishu-cli comment reply list <file_token> <comment_id> --type docx` → 非 JSON 输出包含"内容"行

Closes #106