### PR TITLE
feat(msg): support thread reply/send flags

### DIFF
--- a/cmd/reply_msg.go
+++ b/cmd/reply_msg.go
@@ -15,11 +15,12 @@ var replyMsgCmd = &cobra.Command{
 	Long: `回复指定的消息。
 
 参数:
-  message_id       消息 ID（必填）
-  --msg-type       消息类型（默认 text）
-  --text, -t       简单文本消息（快捷方式）
-  --content, -c    消息内容 JSON
-  --content-file   消息内容 JSON 文件
+  message_id          消息 ID（必填）
+  --msg-type          消息类型（默认 text）
+  --text, -t          简单文本消息（快捷方式）
+  --content, -c       消息内容 JSON
+  --content-file      消息内容 JSON 文件
+  --reply-in-thread   以话题（thread）形式回复；若群聊已是话题模式，则自动回复到消息所在话题
 
 消息类型:
   text         文本消息
@@ -34,7 +35,10 @@ var replyMsgCmd = &cobra.Command{
   feishu-cli msg reply om_xxx --msg-type post --content-file reply.json
 
   # 回复卡片消息
-  feishu-cli msg reply om_xxx --msg-type interactive --content '{"type":"template",...}'`,
+  feishu-cli msg reply om_xxx --msg-type interactive --content '{"type":"template",...}'
+
+  # 以话题形式回复（在非话题群聊中开启一个新话题）
+  feishu-cli msg reply om_xxx --text "这里开个话题" --reply-in-thread`,
 	Args: cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		if err := config.Validate(); err != nil {
@@ -48,6 +52,7 @@ var replyMsgCmd = &cobra.Command{
 		content, _ := cmd.Flags().GetString("content")
 		contentFile, _ := cmd.Flags().GetString("content-file")
 		text, _ := cmd.Flags().GetString("text")
+		replyInThread, _ := cmd.Flags().GetBool("reply-in-thread")
 
 		var msgContent string
 		if contentFile != "" {
@@ -65,7 +70,7 @@ var replyMsgCmd = &cobra.Command{
 			return fmt.Errorf("必须指定 --content、--content-file 或 --text")
 		}
 
-		newMessageID, err := client.ReplyMessage(messageID, msgType, msgContent, token)
+		newMessageID, err := client.ReplyMessage(messageID, msgType, msgContent, replyInThread, token)
 		if err != nil {
 			return err
 		}
@@ -84,5 +89,6 @@ func init() {
 	replyMsgCmd.Flags().StringP("text", "t", "", "简单文本消息")
 	replyMsgCmd.Flags().StringP("content", "c", "", "消息内容 JSON")
 	replyMsgCmd.Flags().String("content-file", "", "消息内容 JSON 文件")
+	replyMsgCmd.Flags().Bool("reply-in-thread", false, "以话题形式回复（reply_in_thread=true）")
 	replyMsgCmd.Flags().String("user-access-token", "", "User Access Token（用户授权令牌）")
 }

--- a/cmd/send_message.go
+++ b/cmd/send_message.go
@@ -96,12 +96,9 @@ var sendMessageCmd = &cobra.Command{
     --thread-id omt_xxx \
     --text "话题内继续聊"`,
 	RunE: func(cmd *cobra.Command, args []string) error {
-		if err := config.Validate(); err != nil {
-			return err
-		}
-
-		token := resolveOptionalUserToken(cmd)
-
+		// 参数校验放在 config.Validate() 之前：之前 mustMarkFlagRequired 由 cobra
+		// 在 RunE 前拦截 missing flag，移除后若先做 config 校验，无凭证用户
+		// 会先看到 config 错误而非参数错误。
 		receiveIDType, _ := cmd.Flags().GetString("receive-id-type")
 		receiveID, _ := cmd.Flags().GetString("receive-id")
 		threadID, _ := cmd.Flags().GetString("thread-id")
@@ -116,6 +113,13 @@ var sendMessageCmd = &cobra.Command{
 		} else if receiveIDType == "" || receiveID == "" {
 			return fmt.Errorf("必须指定 --thread-id，或同时指定 --receive-id-type 和 --receive-id")
 		}
+
+		if err := config.Validate(); err != nil {
+			return err
+		}
+
+		token := resolveOptionalUserToken(cmd)
+
 		msgType, _ := cmd.Flags().GetString("msg-type")
 		content, _ := cmd.Flags().GetString("content")
 		contentFile, _ := cmd.Flags().GetString("content-file")

--- a/cmd/send_message.go
+++ b/cmd/send_message.go
@@ -19,8 +19,9 @@ var sendMessageCmd = &cobra.Command{
 	Long: `向飞书用户或群组发送消息。
 
 参数:
-  --receive-id-type   接收者类型（必填）
-  --receive-id        接收者标识（必填）
+  --receive-id-type   接收者类型（与 --thread-id 二选一）
+  --receive-id        接收者标识（与 --thread-id 二选一）
+  --thread-id         话题 ID（omt_xxx），在已有话题内追加一条消息（等价于 receive_id_type=thread_id）
   --msg-type          消息类型（默认: text）
   --content, -c       消息内容 JSON
   --content-file      消息内容 JSON 文件
@@ -36,6 +37,7 @@ var sendMessageCmd = &cobra.Command{
   user_id     用户 ID
   union_id    Union ID
   chat_id     群组 ID
+  thread_id   话题 ID（在话题内追加消息，通常用 --thread-id 代替）
 
 消息类型:
   text         文本消息
@@ -87,7 +89,12 @@ var sendMessageCmd = &cobra.Command{
     --receive-id user@example.com \
     --msg-type interactive \
     --content-file card.json \
-    --upload-images`,
+    --upload-images
+
+  # 在已有话题内追加消息
+  feishu-cli msg send \
+    --thread-id omt_xxx \
+    --text "话题内继续聊"`,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		if err := config.Validate(); err != nil {
 			return err
@@ -97,6 +104,18 @@ var sendMessageCmd = &cobra.Command{
 
 		receiveIDType, _ := cmd.Flags().GetString("receive-id-type")
 		receiveID, _ := cmd.Flags().GetString("receive-id")
+		threadID, _ := cmd.Flags().GetString("thread-id")
+		if threadID != "" {
+			// --thread-id 是 receive_id_type=thread_id 的语法糖，
+			// 为避免歧义，禁止同时传 --receive-id / --receive-id-type
+			if receiveIDType != "" || receiveID != "" {
+				return fmt.Errorf("--thread-id 与 --receive-id-type/--receive-id 互斥，只能指定一组")
+			}
+			receiveIDType = "thread_id"
+			receiveID = threadID
+		} else if receiveIDType == "" || receiveID == "" {
+			return fmt.Errorf("必须指定 --thread-id，或同时指定 --receive-id-type 和 --receive-id")
+		}
 		msgType, _ := cmd.Flags().GetString("msg-type")
 		content, _ := cmd.Flags().GetString("content")
 		contentFile, _ := cmd.Flags().GetString("content-file")
@@ -223,8 +242,9 @@ var sendMessageCmd = &cobra.Command{
 
 func init() {
 	msgCmd.AddCommand(sendMessageCmd)
-	sendMessageCmd.Flags().String("receive-id-type", "", "接收者类型（email/open_id/user_id/union_id/chat_id）")
+	sendMessageCmd.Flags().String("receive-id-type", "", "接收者类型（email/open_id/user_id/union_id/chat_id/thread_id）")
 	sendMessageCmd.Flags().String("receive-id", "", "接收者标识")
+	sendMessageCmd.Flags().String("thread-id", "", "话题 ID（omt_xxx），在已有话题内追加消息；与 --receive-id-type/--receive-id 互斥")
 	sendMessageCmd.Flags().String("msg-type", "text", "消息类型（text/post/image/interactive 等）")
 	sendMessageCmd.Flags().StringP("content", "c", "", "消息内容 JSON")
 	sendMessageCmd.Flags().String("content-file", "", "消息内容 JSON 文件")
@@ -234,7 +254,6 @@ func init() {
 	sendMessageCmd.Flags().Bool("upload-images", false, "自动解析并上传 post/interactive 消息中的本地图片")
 	sendMessageCmd.Flags().StringP("output", "o", "", "输出格式（json）")
 	sendMessageCmd.Flags().String("user-access-token", "", "User Access Token（用户授权令牌）")
-	mustMarkFlagRequired(sendMessageCmd, "receive-id-type", "receive-id")
 }
 
 // markdown 图片正则: ![alt](path)

--- a/internal/client/message.go
+++ b/internal/client/message.go
@@ -49,19 +49,25 @@ func SendMessage(receiveIDType string, receiveID string, msgType string, content
 	return *resp.Data.MessageId, nil
 }
 
-// ReplyMessage replies to a message
-func ReplyMessage(messageID string, msgType string, content string, userAccessToken string) (string, error) {
+// ReplyMessage replies to a message.
+// 当 replyInThread 为 true 时，以话题（thread）形式回复；
+// 若目标群聊本身就是话题模式，该参数会自动回复到消息所在话题。
+func ReplyMessage(messageID string, msgType string, content string, replyInThread bool, userAccessToken string) (string, error) {
 	client, err := GetClient()
 	if err != nil {
 		return "", err
 	}
 
+	bodyBuilder := larkim.NewReplyMessageReqBodyBuilder().
+		MsgType(msgType).
+		Content(content)
+	if replyInThread {
+		bodyBuilder.ReplyInThread(true)
+	}
+
 	req := larkim.NewReplyMessageReqBuilder().
 		MessageId(messageID).
-		Body(larkim.NewReplyMessageReqBodyBuilder().
-			MsgType(msgType).
-			Content(content).
-			Build()).
+		Body(bodyBuilder.Build()).
 		Build()
 
 	resp, err := client.Im.Message.Reply(Context(), req, UserTokenOption(userAccessToken)...)


### PR DESCRIPTION
## Why

`lark-cli` 有 `+messages-reply --reply-in-thread`，能直接把消息发成话题回复；但 `feishu-cli` 的 `msg reply` 和 `msg send` 目前都没暴露 thread 发送入口：

- `msg reply` 缺 `reply_in_thread` body 字段的开关，无法把一条普通消息的回复转成话题形式（或在话题群里自动落到消息所在话题）
- `msg send` 不能直接发到话题（没有 `--thread-id` 糖，也没人记得能用 `receive_id_type=thread_id`）
- 现有的 `msg thread-messages --thread-id` 是读取话题消息的 flag，不是发送 flag，容易误会

## What

两个最小改动，对齐 OpenAPI：

### 1. `msg reply --reply-in-thread`

透传 OpenAPI `POST /open-apis/im/v1/messages/:id/reply` body 字段 `reply_in_thread:bool`。SDK 已有 `ReplyMessageReqBodyBuilder.ReplyInThread(bool)`，在 CLI 层直接暴露。

\`\`\`bash
# 以话题形式回复一条消息（在非话题群聊中会开启一个新话题）
feishu-cli msg reply om_xxx --text \"这里开个话题\" --reply-in-thread
\`\`\`

### 2. `msg send --thread-id`

`receive_id_type=thread_id` + `receive_id=<omt_xxx>` 的语法糖，在已有话题内追加一条消息。和 `--receive-id-type`/`--receive-id` 互斥，运行时校验。

\`\`\`bash
# 在已有话题里续发
feishu-cli msg send --thread-id omt_xxx --text \"话题内继续聊\"
\`\`\`

## Verify

- \`go build\` / \`go vet\` / \`go test ./...\` 全绿（`cmd`、`internal/client`、`internal/auth`、`internal/converter` 测试全部通过）
- \`msg reply --help\` / \`msg send --help\` 展示新 flag 与示例
- 校验分支手测：
  - 无 flag → `必须指定 --thread-id，或同时指定 --receive-id-type 和 --receive-id`
  - `--thread-id` + `--receive-id-type`/`--receive-id` 同时给 → `互斥，只能指定一组`
  - 只给 `--thread-id` → 进入 API 调用（用假 `omt_xxx` 会命中飞书端 `99992402 field validation failed`，说明 CLI 层参数 validation 通过）