### PR TITLE
feat(comment): 新增 comment reply add 命令 + 统一 User Token 处理

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,44 @@
 
 ## 未发布
 
+### 新增 — `comment reply add`：为已有评论添加回复
+
+新增命令 `feishu-cli comment reply add <file_token> <comment_id> --text "..."`，补齐评论回复
+生命周期的最后一块拼图（此前只有 list / delete）。
+
+**背景**：飞书 Open SDK v3.5.3 的 `fileCommentReply` 只暴露 `List`/`Delete`/`Update`，没有
+`Create` 方法，而 Open API 本身是支持的（`POST /drive/v1/files/:token/comments/:comment_id/replies`）。
+此 PR 不依赖 SDK 升级，用通用 HTTP client（`client.Post`）直接调用 API 实现。
+
+**同时改进**：
+
+- `comment reply add` / `delete` / `list` 全部加上 `--user-access-token` 参数支持，并走
+  `resolveOptionalUserTokenWithFallback` 自动读取登录态，和 msg/chat/doc export 等模块保持一致
+- **重要修复**：`comment reply delete` 在 App Token（Bot 身份）下调用飞书侧会返回 `1069303
+  forbidden`——飞书只允许回复作者本人删除。现在命令默认优先使用 User Token（如果已登录），
+  行为才符合用户预期。命令帮助中也显式说明了这个权限模型
+- `comment reply add` 默认也走 User Token fallback，回复会以用户身份发布（而非显示为 Bot），
+  且该回复能被后续 `reply delete` 正常删除
+
+**权限要求**：`docs:document.comment:create`（User Token）
+
+**使用示例**：
+
+```bash
+feishu-cli auth login                       # 确保有 User Token
+feishu-cli comment reply add <file_token> <comment_id> --text "已处理"
+feishu-cli comment reply delete <file_token> <comment_id> <reply_id>  # 自动用 User Token
+```
+
+**代码影响范围**：
+
+- `internal/client/comment.go`：新增 `CreateCommentReply`（HTTP client 直调），
+  `ListCommentReplies` / `DeleteCommentReply` 签名增加 `userAccessToken` 参数
+- `cmd/comment_reply.go`：新增 `addReplyCmd`，三个子命令统一加 `--user-access-token` flag
+- `cmd/comment.go`：Long help 中补充 reply add 示例
+
+---
+
 ### Breaking Changes — 移除 `config add-scopes` 命令
 
 `feishu-cli config add-scopes` 子命令及其 `--domain` / `--scopes` / `--print-only` flag 全部删除。

--- a/cmd/comment.go
+++ b/cmd/comment.go
@@ -16,7 +16,7 @@ var commentCmd = &cobra.Command{
   delete      删除评论
   resolve     标记评论为已解决
   unresolve   标记评论为未解决
-  reply       评论回复管理（list/delete）
+  reply       评论回复管理（list/add/delete）
 
 文件类型（--type）:
   doc       旧版文档
@@ -40,7 +40,10 @@ var commentCmd = &cobra.Command{
   # 列出评论回复
   feishu-cli comment reply list <file_token> <comment_id> --type docx
 
-  # 删除评论回复
+  # 添加评论回复（推荐登录后以用户身份发布）
+  feishu-cli comment reply add <file_token> <comment_id> --text "回复内容"
+
+  # 删除评论回复（飞书只允许回复作者删除，需 User Token）
   feishu-cli comment reply delete <file_token> <comment_id> <reply_id> --type docx`,
 }
 

--- a/cmd/comment_reply.go
+++ b/cmd/comment_reply.go
@@ -11,17 +11,21 @@ import (
 var replyCmd = &cobra.Command{
 	Use:   "reply",
 	Short: "评论回复管理",
-	Long: `评论回复管理命令，包括列出回复和删除回复。
+	Long: `评论回复管理命令，包括列出、添加、删除回复。
 
 子命令:
   list      列出评论的回复
+  add       为已有评论添加回复
   delete    删除评论回复
 
 示例:
   # 列出评论回复
   feishu-cli comment reply list <file_token> <comment_id> --type docx
 
-  # 删除评论回复
+  # 添加评论回复（推荐登录后使用，以用户身份发布）
+  feishu-cli comment reply add <file_token> <comment_id> --text "回复内容"
+
+  # 删除评论回复（飞书只允许回复作者删除，需 User Token）
   feishu-cli comment reply delete <file_token> <comment_id> <reply_id> --type docx`,
 }
 
@@ -47,8 +51,9 @@ var listReplyCmd = &cobra.Command{
 		fileType, _ := cmd.Flags().GetString("type")
 		pageSize, _ := cmd.Flags().GetInt("page-size")
 		output, _ := cmd.Flags().GetString("output")
+		userAccessToken := resolveOptionalUserToken(cmd)
 
-		replies, _, _, err := client.ListCommentReplies(fileToken, commentID, fileType, pageSize, "")
+		replies, _, _, err := client.ListCommentReplies(fileToken, commentID, fileType, pageSize, "", userAccessToken)
 		if err != nil {
 			return err
 		}
@@ -81,6 +86,66 @@ var listReplyCmd = &cobra.Command{
 	},
 }
 
+var addReplyCmd = &cobra.Command{
+	Use:   "add <file_token> <comment_id>",
+	Short: "为已有评论添加回复",
+	Long: `为已有评论追加一条回复。
+
+参数:
+  file_token    文档 Token
+  comment_id    评论 ID
+
+建议使用 User Access Token（登录态），回复会以用户身份发出；否则以 App/Bot 身份发出，
+且该回复只能被同一 App 自己删除（Bot 身份经常收到 1069303 forbidden）。
+
+示例:
+  # 登录后自动使用 User Token（推荐）
+  feishu-cli auth login
+  feishu-cli comment reply add doccnXXX 6916106822734578184 \
+    --text "已处理，请查看最新版本。" --type docx
+
+  # 显式传入 User Token
+  feishu-cli comment reply add doccnXXX 6916106822734578184 \
+    --text "回复内容" --user-access-token "u-xxxxx"`,
+	Args: cobra.ExactArgs(2),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		if err := config.Validate(); err != nil {
+			return err
+		}
+
+		fileToken := args[0]
+		commentID := args[1]
+		fileType, _ := cmd.Flags().GetString("type")
+		text, _ := cmd.Flags().GetString("text")
+		output, _ := cmd.Flags().GetString("output")
+
+		if text == "" {
+			return fmt.Errorf("回复内容不能为空，请通过 --text 提供")
+		}
+
+		userAccessToken := resolveOptionalUserTokenWithFallback(cmd)
+
+		reply, err := client.CreateCommentReply(fileToken, commentID, fileType, text, userAccessToken)
+		if err != nil {
+			return err
+		}
+
+		if output == "json" {
+			return printJSON(reply)
+		}
+
+		fmt.Printf("回复添加成功！\n")
+		fmt.Printf("  文档 Token: %s\n", fileToken)
+		fmt.Printf("  评论 ID:    %s\n", commentID)
+		fmt.Printf("  回复 ID:    %s\n", reply.ReplyID)
+		if reply.UserID != "" {
+			fmt.Printf("  用户 ID:    %s\n", reply.UserID)
+		}
+
+		return nil
+	},
+}
+
 var deleteReplyCmd = &cobra.Command{
 	Use:   "delete <file_token> <comment_id> <reply_id>",
 	Short: "删除评论回复",
@@ -90,6 +155,9 @@ var deleteReplyCmd = &cobra.Command{
   file_token    文档 Token
   comment_id    评论 ID
   reply_id      回复 ID
+
+注意：飞书 Open API 只允许回复作者本人删除；使用 App Token（Bot 身份）删除用户回复会得到
+1069303 forbidden。通常需要先 feishu-cli auth login 或显式提供 --user-access-token。
 
 示例:
   feishu-cli comment reply delete doccnXXX 6916106822734578184 6916106822734594568 --type docx`,
@@ -103,8 +171,9 @@ var deleteReplyCmd = &cobra.Command{
 		commentID := args[1]
 		replyID := args[2]
 		fileType, _ := cmd.Flags().GetString("type")
+		userAccessToken := resolveOptionalUserTokenWithFallback(cmd)
 
-		if err := client.DeleteCommentReply(fileToken, commentID, replyID, fileType); err != nil {
+		if err := client.DeleteCommentReply(fileToken, commentID, replyID, fileType, userAccessToken); err != nil {
 			return err
 		}
 
@@ -124,7 +193,16 @@ func init() {
 	listReplyCmd.Flags().String("type", "docx", "文件类型（doc/docx/sheet/bitable）")
 	listReplyCmd.Flags().Int("page-size", 50, "每页数量")
 	listReplyCmd.Flags().StringP("output", "o", "", "输出格式（json）")
+	listReplyCmd.Flags().String("user-access-token", "", "User Access Token（覆盖 App Token）")
+
+	replyCmd.AddCommand(addReplyCmd)
+	addReplyCmd.Flags().String("type", "docx", "文件类型（doc/docx/sheet/bitable）")
+	addReplyCmd.Flags().String("text", "", "回复内容（必填）")
+	addReplyCmd.Flags().StringP("output", "o", "", "输出格式（json）")
+	addReplyCmd.Flags().String("user-access-token", "", "User Access Token（推荐，以用户身份发布）")
+	_ = addReplyCmd.MarkFlagRequired("text")
 
 	replyCmd.AddCommand(deleteReplyCmd)
 	deleteReplyCmd.Flags().String("type", "docx", "文件类型（doc/docx/sheet/bitable）")
+	deleteReplyCmd.Flags().String("user-access-token", "", "User Access Token（删除用户回复时必需）")
 }

--- a/internal/client/comment.go
+++ b/internal/client/comment.go
@@ -1,7 +1,10 @@
 package client
 
 import (
+	"encoding/json"
 	"fmt"
+	"net/http"
+	"net/url"
 
 	larkdrive "github.com/larksuite/oapi-sdk-go/v3/service/drive/v1"
 )
@@ -215,7 +218,8 @@ type CommentReply struct {
 }
 
 // ListCommentReplies 获取评论回复列表
-func ListCommentReplies(fileToken, commentID, fileType string, pageSize int, pageToken string) ([]*CommentReply, string, bool, error) {
+// userAccessToken 非空时使用 User Token（用户身份），否则使用 App Token（租户身份）。
+func ListCommentReplies(fileToken, commentID, fileType string, pageSize int, pageToken, userAccessToken string) ([]*CommentReply, string, bool, error) {
 	client, err := GetClient()
 	if err != nil {
 		return nil, "", false, err
@@ -233,7 +237,8 @@ func ListCommentReplies(fileToken, commentID, fileType string, pageSize int, pag
 		reqBuilder.PageToken(pageToken)
 	}
 
-	resp, err := client.Drive.FileCommentReply.List(Context(), reqBuilder.Build())
+	opts := UserTokenOption(userAccessToken)
+	resp, err := client.Drive.FileCommentReply.List(Context(), reqBuilder.Build(), opts...)
 	if err != nil {
 		return nil, "", false, fmt.Errorf("获取评论回复列表失败: %w", err)
 	}
@@ -274,7 +279,9 @@ func ListCommentReplies(fileToken, commentID, fileType string, pageSize int, pag
 }
 
 // DeleteCommentReply 删除评论回复
-func DeleteCommentReply(fileToken, commentID, replyID, fileType string) error {
+// 注意：飞书 Open API 只允许回复作者本人删除（App Bot 身份会得到 1069303 forbidden），
+// 因此调用方几乎总是需要提供 userAccessToken（回复作者的 User Token）。
+func DeleteCommentReply(fileToken, commentID, replyID, fileType, userAccessToken string) error {
 	client, err := GetClient()
 	if err != nil {
 		return err
@@ -287,7 +294,8 @@ func DeleteCommentReply(fileToken, commentID, replyID, fileType string) error {
 		FileType(fileType).
 		Build()
 
-	resp, err := client.Drive.FileCommentReply.Delete(Context(), req)
+	opts := UserTokenOption(userAccessToken)
+	resp, err := client.Drive.FileCommentReply.Delete(Context(), req, opts...)
 	if err != nil {
 		return fmt.Errorf("删除评论回复失败: %w", err)
 	}
@@ -297,4 +305,90 @@ func DeleteCommentReply(fileToken, commentID, replyID, fileType string) error {
 	}
 
 	return nil
+}
+
+// CreateCommentReply 为已有评论添加回复
+//
+// 飞书 Open SDK v3.5.3 尚未封装此接口（只暴露 List/Delete/Update），
+// 此处用通用 HTTP client 直接调用 Open API：
+//
+//	POST /open-apis/drive/v1/files/{file_token}/comments/{comment_id}/replies?file_type=docx
+//
+// 权限要求（User Token）：docs:document.comment:create
+// App Token 同样可以调用（tenant 身份），但飞书侧多数场景推荐用户身份发起回复，
+// 否则回复人会显示为 Bot，且该回复无法通过 DeleteCommentReply 删除（只有作者能删）。
+func CreateCommentReply(fileToken, commentID, fileType, content, userAccessToken string) (*CommentReply, error) {
+	client, err := GetClient()
+	if err != nil {
+		return nil, err
+	}
+
+	body := map[string]any{
+		"content": map[string]any{
+			"elements": []map[string]any{
+				{
+					"type": "text_run",
+					"text_run": map[string]any{
+						"text": content,
+					},
+				},
+			},
+		},
+	}
+
+	apiPath := fmt.Sprintf(
+		"/open-apis/drive/v1/files/%s/comments/%s/replies?file_type=%s",
+		url.PathEscape(fileToken),
+		url.PathEscape(commentID),
+		url.QueryEscape(fileType),
+	)
+
+	tokenType, opts := resolveTokenOpts(userAccessToken)
+	resp, err := client.Post(Context(), apiPath, body, tokenType, opts...)
+	if err != nil {
+		return nil, fmt.Errorf("创建评论回复失败: %w", err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("创建评论回复失败: HTTP %d, body: %s", resp.StatusCode, string(resp.RawBody))
+	}
+
+	var apiResp struct {
+		Code int    `json:"code"`
+		Msg  string `json:"msg"`
+		Data struct {
+			ReplyID    string `json:"reply_id"`
+			UserID     string `json:"user_id"`
+			CreateTime int    `json:"create_time"`
+			UpdateTime int    `json:"update_time"`
+			Content    *struct {
+				Elements []struct {
+					Type    string `json:"type"`
+					TextRun *struct {
+						Text string `json:"text"`
+					} `json:"text_run,omitempty"`
+				} `json:"elements"`
+			} `json:"content,omitempty"`
+		} `json:"data"`
+	}
+	if err := json.Unmarshal(resp.RawBody, &apiResp); err != nil {
+		return nil, fmt.Errorf("解析响应失败: %w", err)
+	}
+	if apiResp.Code != 0 {
+		return nil, fmt.Errorf("创建评论回复失败: code=%d, msg=%s", apiResp.Code, apiResp.Msg)
+	}
+
+	reply := &CommentReply{
+		ReplyID:    apiResp.Data.ReplyID,
+		UserID:     apiResp.Data.UserID,
+		CreateTime: apiResp.Data.CreateTime,
+		UpdateTime: apiResp.Data.UpdateTime,
+	}
+	if apiResp.Data.Content != nil {
+		for _, el := range apiResp.Data.Content.Elements {
+			if el.TextRun != nil {
+				reply.Content += el.TextRun.Text
+			}
+		}
+	}
+	return reply, nil
 }


### PR DESCRIPTION
## 背景

`feishu-cli comment reply` 当前只实现了 `list` 和 `delete`，缺少 `add`——没法用 CLI 回复一条已有评论。

最近在真实场景里遇到：收到一份飞书文档，评论区有 5 条划词评论需要逐条回复解释，只能绕开 CLI 直接 `curl` 打 Open API 才完成。根因是 Open SDK v3.5.3 的 `fileCommentReply` 服务只暴露 `List`/`Delete`/`Update`，没有 `Create`——但飞书 Open API 本身是支持的：

```
POST /open-apis/drive/v1/files/{file_token}/comments/{comment_id}/replies?file_type=docx
```

## 改动

### 1. 新增 `comment reply add` 命令

```bash
feishu-cli comment reply add <file_token> <comment_id> --text "回复内容"
```

不依赖 SDK 升级，用通用 HTTP client (`client.Post`) 直接调用 Open API。模式与 `internal/client/drive_comment.go` 中的 `CreateNewComment` 一致。

### 2. 修复 `comment reply delete` 的 Token 陷阱

飞书 Open API 只允许**回复作者本人**删除该回复——App Token（Bot 身份）调用一律返回 `code=1069303, msg=forbidden`。此前 `comment reply delete` 只走 SDK 默认的 App Token 路径，对于用户发的回复一定会失败。

现在三个子命令（`list` / `add` / `delete`）统一加 `--user-access-token` flag，并走 `resolveOptionalUserTokenWithFallback` 自动读取登录态（`~/.feishu-cli/token.json`），行为和 `msg` / `chat` / `doc export` 等模块保持一致。

### 3. 代码影响范围

- `internal/client/comment.go`
  - 新增 `CreateCommentReply`（HTTP 直调 + JSON 解析 + 用 `resolveTokenOpts` 选 Token）
  - `ListCommentReplies` / `DeleteCommentReply` 签名新增 `userAccessToken string` 参数
- `cmd/comment_reply.go`
  - 新增 `addReplyCmd`（含 `--text` 必填、`--output json`、`--user-access-token`）
  - 三个子命令统一加 `--user-access-token` flag
  - `delete` / `add` 走 `resolveOptionalUserTokenWithFallback`（自动读登录态），`list` 走 `resolveOptionalUserToken`（不强制，保持只读轻量）
- `cmd/comment.go`：Long help 补充 `reply add` 示例、`reply delete` 标注"需 User Token"
- `CHANGELOG.md`：未发布区块新增条目

## 测试

- `go build ./...`、`go vet ./...`、`go test ./cmd/... ./internal/client/...` 全部通过
- 真实飞书文档端到端实测：
  - `comment reply add`（User Token 路径）：创建回复成功，返回新 `reply_id`
  - `comment reply delete`（User Token 路径）：删除自己发的回复成功
  - 未带 User Token 的 `delete`（App Token 路径）：按预期返回 `1069303 forbidden`——这是飞书侧权限设计，属于正确行为，`--help` 文案已显式说明

## 兼容性

- `ListCommentReplies` / `DeleteCommentReply` 是 `internal` 包的函数，新增参数只影响 `cmd/comment_reply.go` 一处调用，已同步更新
- 所有 CLI 命令 flag 均为新增，无现有行为变更