### PR TITLE
feat(doc): add table operations (insert/delete rows/columns, merge/unmerge)

### DIFF
--- a/cmd/doc.go
+++ b/cmd/doc.go
@@ -17,6 +17,7 @@ var docCmd = &cobra.Command{
   content-update 更新文档内容（追加/覆盖/替换/插入/删除）
   update         更新块内容
   delete         删除块
+  table          表格操作（插入/删除行列、合并/取消合并单元格）
   export         导出文档为 Markdown
   import         从 Markdown 导入文档
   export-file    导出文档为文件（PDF/DOCX/XLSX）

--- a/cmd/doc_table.go
+++ b/cmd/doc_table.go
@@ -1,0 +1,37 @@
+package cmd
+
+import (
+	"github.com/spf13/cobra"
+)
+
+// docTableCmd 是 doc table 子命令组
+var docTableCmd = &cobra.Command{
+	Use:   "table",
+	Short: "文档表格操作",
+	Long: `文档内嵌表格操作命令组，支持插入/删除行列、合并/取消合并单元格。
+
+所有操作需要指定文档 ID 和表格块 ID（Block 类型 31）。
+
+子命令:
+  insert-row      插入行
+  insert-column   插入列
+  delete-rows     删除行
+  delete-columns  删除列
+  merge-cells     合并单元格
+  unmerge-cells   取消合并
+
+示例:
+  # 在表格末尾插入一行
+  feishu-cli doc table insert-row DOC_ID TABLE_BLOCK_ID --index -1
+
+  # 删除第 2-3 行（左闭右开）
+  feishu-cli doc table delete-rows DOC_ID TABLE_BLOCK_ID --start 1 --end 3
+
+  # 合并 A1:C2 区域的单元格
+  feishu-cli doc table merge-cells DOC_ID TABLE_BLOCK_ID \
+    --row-start 0 --row-end 2 --col-start 0 --col-end 3`,
+}
+
+func init() {
+	docCmd.AddCommand(docTableCmd)
+}

--- a/cmd/doc_table_delete_columns.go
+++ b/cmd/doc_table_delete_columns.go
@@ -1,0 +1,80 @@
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/riba2534/feishu-cli/internal/client"
+	"github.com/riba2534/feishu-cli/internal/config"
+	"github.com/spf13/cobra"
+)
+
+var docTableDeleteColumnsCmd = &cobra.Command{
+	Use:   "delete-columns <document_id> <table_block_id>",
+	Short: "删除表格中的列",
+	Long: `删除指定范围的列（左闭右开区间）。
+
+参数:
+  document_id     文档 ID
+  table_block_id  表格块 ID
+  --start         起始列索引（包含，0 表示第一列）
+  --end           结束列索引（不包含）
+
+示例:
+  # 删除第 2-3 列（索引 1 到 3，左闭右开）
+  feishu-cli doc table delete-columns DOC_ID TABLE_BLOCK_ID --start 1 --end 3
+
+  # 删除第一列
+  feishu-cli doc table delete-columns DOC_ID TABLE_BLOCK_ID --start 0 --end 1`,
+	Args: cobra.ExactArgs(2),
+	RunE: runDocTableDeleteColumns,
+}
+
+func init() {
+	docTableCmd.AddCommand(docTableDeleteColumnsCmd)
+	docTableDeleteColumnsCmd.Flags().Int("start", 0, "起始列索引（包含）")
+	docTableDeleteColumnsCmd.Flags().Int("end", 0, "结束列索引（不包含）")
+	docTableDeleteColumnsCmd.Flags().StringP("output", "o", "", "输出格式 (json)")
+	docTableDeleteColumnsCmd.Flags().String("user-access-token", "", "User Access Token（可选）")
+	mustMarkFlagRequired(docTableDeleteColumnsCmd, "start", "end")
+}
+
+func runDocTableDeleteColumns(cmd *cobra.Command, args []string) error {
+	if err := config.Validate(); err != nil {
+		return err
+	}
+
+	documentID := args[0]
+	tableBlockID := args[1]
+	start, _ := cmd.Flags().GetInt("start")
+	end, _ := cmd.Flags().GetInt("end")
+	output, _ := cmd.Flags().GetString("output")
+	userAccessToken := resolveOptionalUserToken(cmd)
+
+	// 参数验证
+	if start < 0 {
+		return fmt.Errorf("起始索引不能为负数")
+	}
+	if end <= start {
+		return fmt.Errorf("结束索引必须大于起始索引")
+	}
+
+	err := client.DeleteTableColumns(documentID, tableBlockID, start, end, userAccessToken)
+	if err != nil {
+		return fmt.Errorf("删除列失败: %w", err)
+	}
+
+	deletedCount := end - start
+	if output == "json" {
+		return printJSON(map[string]any{
+			"document_id":         documentID,
+			"table_block_id":      tableBlockID,
+			"operation":           "delete_columns",
+			"column_start_index":  start,
+			"column_end_index":    end,
+			"deleted_count":       deletedCount,
+		})
+	}
+
+	fmt.Printf("已成功删除 %d 列（索引 %d 到 %d）\n", deletedCount, start, end-1)
+	return nil
+}

--- a/cmd/doc_table_delete_columns.go
+++ b/cmd/doc_table_delete_columns.go
@@ -15,7 +15,7 @@ var docTableDeleteColumnsCmd = &cobra.Command{
 
 参数:
   document_id     文档 ID
-  table_block_id  表格块 ID
+  table_block_id  表格块 ID（Block 类型 31）
   --start         起始列索引（包含，0 表示第一列）
   --end           结束列索引（不包含）
 

--- a/cmd/doc_table_delete_rows.go
+++ b/cmd/doc_table_delete_rows.go
@@ -1,0 +1,80 @@
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/riba2534/feishu-cli/internal/client"
+	"github.com/riba2534/feishu-cli/internal/config"
+	"github.com/spf13/cobra"
+)
+
+var docTableDeleteRowsCmd = &cobra.Command{
+	Use:   "delete-rows <document_id> <table_block_id>",
+	Short: "删除表格中的行",
+	Long: `删除指定范围的行（左闭右开区间）。
+
+参数:
+  document_id     文档 ID
+  table_block_id  表格块 ID
+  --start         起始行索引（包含，0 表示第一行）
+  --end           结束行索引（不包含）
+
+示例:
+  # 删除第 2-3 行（索引 1 到 3，左闭右开）
+  feishu-cli doc table delete-rows DOC_ID TABLE_BLOCK_ID --start 1 --end 3
+
+  # 删除第一行
+  feishu-cli doc table delete-rows DOC_ID TABLE_BLOCK_ID --start 0 --end 1`,
+	Args: cobra.ExactArgs(2),
+	RunE: runDocTableDeleteRows,
+}
+
+func init() {
+	docTableCmd.AddCommand(docTableDeleteRowsCmd)
+	docTableDeleteRowsCmd.Flags().Int("start", 0, "起始行索引（包含）")
+	docTableDeleteRowsCmd.Flags().Int("end", 0, "结束行索引（不包含）")
+	docTableDeleteRowsCmd.Flags().StringP("output", "o", "", "输出格式 (json)")
+	docTableDeleteRowsCmd.Flags().String("user-access-token", "", "User Access Token（可选）")
+	mustMarkFlagRequired(docTableDeleteRowsCmd, "start", "end")
+}
+
+func runDocTableDeleteRows(cmd *cobra.Command, args []string) error {
+	if err := config.Validate(); err != nil {
+		return err
+	}
+
+	documentID := args[0]
+	tableBlockID := args[1]
+	start, _ := cmd.Flags().GetInt("start")
+	end, _ := cmd.Flags().GetInt("end")
+	output, _ := cmd.Flags().GetString("output")
+	userAccessToken := resolveOptionalUserToken(cmd)
+
+	// 参数验证
+	if start < 0 {
+		return fmt.Errorf("起始索引不能为负数")
+	}
+	if end <= start {
+		return fmt.Errorf("结束索引必须大于起始索引")
+	}
+
+	err := client.DeleteTableRows(documentID, tableBlockID, start, end, userAccessToken)
+	if err != nil {
+		return fmt.Errorf("删除行失败: %w", err)
+	}
+
+	deletedCount := end - start
+	if output == "json" {
+		return printJSON(map[string]any{
+			"document_id":      documentID,
+			"table_block_id":   tableBlockID,
+			"operation":        "delete_rows",
+			"row_start_index":  start,
+			"row_end_index":    end,
+			"deleted_count":    deletedCount,
+		})
+	}
+
+	fmt.Printf("已成功删除 %d 行（索引 %d 到 %d）\n", deletedCount, start, end-1)
+	return nil
+}

--- a/cmd/doc_table_delete_rows.go
+++ b/cmd/doc_table_delete_rows.go
@@ -15,7 +15,7 @@ var docTableDeleteRowsCmd = &cobra.Command{
 
 参数:
   document_id     文档 ID
-  table_block_id  表格块 ID
+  table_block_id  表格块 ID（Block 类型 31）
   --start         起始行索引（包含，0 表示第一行）
   --end           结束行索引（不包含）
 

--- a/cmd/doc_table_insert_column.go
+++ b/cmd/doc_table_insert_column.go
@@ -1,0 +1,69 @@
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/riba2534/feishu-cli/internal/client"
+	"github.com/riba2534/feishu-cli/internal/config"
+	"github.com/spf13/cobra"
+)
+
+var docTableInsertColumnCmd = &cobra.Command{
+	Use:   "insert-column <document_id> <table_block_id>",
+	Short: "在表格中插入列",
+	Long: `在指定位置插入一列，使用 -1 表示插入到表格末尾。
+
+参数:
+  document_id     文档 ID
+  table_block_id  表格块 ID（Block 类型 31）
+  --index         插入位置索引（0 表示第一列，-1 表示末尾）
+
+示例:
+  # 在表格末尾插入一列
+  feishu-cli doc table insert-column DOC_ID TABLE_BLOCK_ID --index -1
+
+  # 在第一列位置插入
+  feishu-cli doc table insert-column DOC_ID TABLE_BLOCK_ID --index 0`,
+	Args: cobra.ExactArgs(2),
+	RunE: runDocTableInsertColumn,
+}
+
+func init() {
+	docTableCmd.AddCommand(docTableInsertColumnCmd)
+	docTableInsertColumnCmd.Flags().Int("index", -1, "插入位置索引（-1 表示末尾）")
+	docTableInsertColumnCmd.Flags().StringP("output", "o", "", "输出格式 (json)")
+	docTableInsertColumnCmd.Flags().String("user-access-token", "", "User Access Token（可选）")
+}
+
+func runDocTableInsertColumn(cmd *cobra.Command, args []string) error {
+	if err := config.Validate(); err != nil {
+		return err
+	}
+
+	documentID := args[0]
+	tableBlockID := args[1]
+	index, _ := cmd.Flags().GetInt("index")
+	output, _ := cmd.Flags().GetString("output")
+	userAccessToken := resolveOptionalUserToken(cmd)
+
+	err := client.InsertTableColumn(documentID, tableBlockID, index, userAccessToken)
+	if err != nil {
+		return fmt.Errorf("插入列失败: %w", err)
+	}
+
+	if output == "json" {
+		return printJSON(map[string]any{
+			"document_id":    documentID,
+			"table_block_id": tableBlockID,
+			"operation":      "insert_column",
+			"index":          index,
+		})
+	}
+
+	posDesc := fmt.Sprintf("索引 %d", index)
+	if index == -1 {
+		posDesc = "表格末尾"
+	}
+	fmt.Printf("已在 %s 成功插入一列\n", posDesc)
+	return nil
+}

--- a/cmd/doc_table_insert_column.go
+++ b/cmd/doc_table_insert_column.go
@@ -46,6 +46,11 @@ func runDocTableInsertColumn(cmd *cobra.Command, args []string) error {
 	output, _ := cmd.Flags().GetString("output")
 	userAccessToken := resolveOptionalUserToken(cmd)
 
+	// 飞书 API 仅接受 index == -1（末尾）或 index >= 0
+	if index < -1 {
+		return fmt.Errorf("索引必须 >= 0 或 -1（表示末尾）")
+	}
+
 	err := client.InsertTableColumn(documentID, tableBlockID, index, userAccessToken)
 	if err != nil {
 		return fmt.Errorf("插入列失败: %w", err)
@@ -56,7 +61,7 @@ func runDocTableInsertColumn(cmd *cobra.Command, args []string) error {
 			"document_id":    documentID,
 			"table_block_id": tableBlockID,
 			"operation":      "insert_column",
-			"index":          index,
+			"column_index":   index,
 		})
 	}
 

--- a/cmd/doc_table_insert_row.go
+++ b/cmd/doc_table_insert_row.go
@@ -1,0 +1,69 @@
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/riba2534/feishu-cli/internal/client"
+	"github.com/riba2534/feishu-cli/internal/config"
+	"github.com/spf13/cobra"
+)
+
+var docTableInsertRowCmd = &cobra.Command{
+	Use:   "insert-row <document_id> <table_block_id>",
+	Short: "在表格中插入行",
+	Long: `在指定位置插入一行，使用 -1 表示插入到表格末尾。
+
+参数:
+  document_id     文档 ID
+  table_block_id  表格块 ID（Block 类型 31）
+  --index         插入位置索引（0 表示第一行，-1 表示末尾）
+
+示例:
+  # 在表格末尾插入一行
+  feishu-cli doc table insert-row DOC_ID TABLE_BLOCK_ID --index -1
+
+  # 在第一行位置插入
+  feishu-cli doc table insert-row DOC_ID TABLE_BLOCK_ID --index 0`,
+	Args: cobra.ExactArgs(2),
+	RunE: runDocTableInsertRow,
+}
+
+func init() {
+	docTableCmd.AddCommand(docTableInsertRowCmd)
+	docTableInsertRowCmd.Flags().Int("index", -1, "插入位置索引（-1 表示末尾）")
+	docTableInsertRowCmd.Flags().StringP("output", "o", "", "输出格式 (json)")
+	docTableInsertRowCmd.Flags().String("user-access-token", "", "User Access Token（可选）")
+}
+
+func runDocTableInsertRow(cmd *cobra.Command, args []string) error {
+	if err := config.Validate(); err != nil {
+		return err
+	}
+
+	documentID := args[0]
+	tableBlockID := args[1]
+	index, _ := cmd.Flags().GetInt("index")
+	output, _ := cmd.Flags().GetString("output")
+	userAccessToken := resolveOptionalUserToken(cmd)
+
+	err := client.InsertTableRow(documentID, tableBlockID, index, userAccessToken)
+	if err != nil {
+		return fmt.Errorf("插入行失败: %w", err)
+	}
+
+	if output == "json" {
+		return printJSON(map[string]any{
+			"document_id":    documentID,
+			"table_block_id": tableBlockID,
+			"operation":      "insert_row",
+			"index":          index,
+		})
+	}
+
+	posDesc := fmt.Sprintf("索引 %d", index)
+	if index == -1 {
+		posDesc = "表格末尾"
+	}
+	fmt.Printf("已在 %s 成功插入一行\n", posDesc)
+	return nil
+}

--- a/cmd/doc_table_insert_row.go
+++ b/cmd/doc_table_insert_row.go
@@ -46,6 +46,11 @@ func runDocTableInsertRow(cmd *cobra.Command, args []string) error {
 	output, _ := cmd.Flags().GetString("output")
 	userAccessToken := resolveOptionalUserToken(cmd)
 
+	// 飞书 API 仅接受 index == -1（末尾）或 index >= 0
+	if index < -1 {
+		return fmt.Errorf("索引必须 >= 0 或 -1（表示末尾）")
+	}
+
 	err := client.InsertTableRow(documentID, tableBlockID, index, userAccessToken)
 	if err != nil {
 		return fmt.Errorf("插入行失败: %w", err)
@@ -56,7 +61,7 @@ func runDocTableInsertRow(cmd *cobra.Command, args []string) error {
 			"document_id":    documentID,
 			"table_block_id": tableBlockID,
 			"operation":      "insert_row",
-			"index":          index,
+			"row_index":      index,
 		})
 	}
 

--- a/cmd/doc_table_merge_cells.go
+++ b/cmd/doc_table_merge_cells.go
@@ -15,7 +15,7 @@ var docTableMergeCellsCmd = &cobra.Command{
 
 参数:
   document_id     文档 ID
-  table_block_id  表格块 ID
+  table_block_id  表格块 ID（Block 类型 31）
   --row-start     起始行索引（包含）
   --row-end       结束行索引（不包含）
   --col-start     起始列索引（包含）

--- a/cmd/doc_table_merge_cells.go
+++ b/cmd/doc_table_merge_cells.go
@@ -1,0 +1,87 @@
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/riba2534/feishu-cli/internal/client"
+	"github.com/riba2534/feishu-cli/internal/config"
+	"github.com/spf13/cobra"
+)
+
+var docTableMergeCellsCmd = &cobra.Command{
+	Use:   "merge-cells <document_id> <table_block_id>",
+	Short: "合并表格单元格",
+	Long: `合并指定范围的单元格（左闭右开区间）。
+
+参数:
+  document_id     文档 ID
+  table_block_id  表格块 ID
+  --row-start     起始行索引（包含）
+  --row-end       结束行索引（不包含）
+  --col-start     起始列索引（包含）
+  --col-end       结束列索引（不包含）
+
+示例:
+  # 合并 A1:C2 区域（行 0-2，列 0-3）
+  feishu-cli doc table merge-cells DOC_ID TABLE_BLOCK_ID \
+    --row-start 0 --row-end 2 --col-start 0 --col-end 3`,
+	Args: cobra.ExactArgs(2),
+	RunE: runDocTableMergeCells,
+}
+
+func init() {
+	docTableCmd.AddCommand(docTableMergeCellsCmd)
+	docTableMergeCellsCmd.Flags().Int("row-start", 0, "起始行索引（包含）")
+	docTableMergeCellsCmd.Flags().Int("row-end", 0, "结束行索引（不包含）")
+	docTableMergeCellsCmd.Flags().Int("col-start", 0, "起始列索引（包含）")
+	docTableMergeCellsCmd.Flags().Int("col-end", 0, "结束列索引（不包含）")
+	docTableMergeCellsCmd.Flags().StringP("output", "o", "", "输出格式 (json)")
+	docTableMergeCellsCmd.Flags().String("user-access-token", "", "User Access Token（可选）")
+	mustMarkFlagRequired(docTableMergeCellsCmd, "row-start", "row-end", "col-start", "col-end")
+}
+
+func runDocTableMergeCells(cmd *cobra.Command, args []string) error {
+	if err := config.Validate(); err != nil {
+		return err
+	}
+
+	documentID := args[0]
+	tableBlockID := args[1]
+	rowStart, _ := cmd.Flags().GetInt("row-start")
+	rowEnd, _ := cmd.Flags().GetInt("row-end")
+	colStart, _ := cmd.Flags().GetInt("col-start")
+	colEnd, _ := cmd.Flags().GetInt("col-end")
+	output, _ := cmd.Flags().GetString("output")
+	userAccessToken := resolveOptionalUserToken(cmd)
+
+	// 参数验证
+	if rowStart < 0 || colStart < 0 {
+		return fmt.Errorf("起始索引不能为负数")
+	}
+	if rowEnd <= rowStart {
+		return fmt.Errorf("行结束索引必须大于起始索引")
+	}
+	if colEnd <= colStart {
+		return fmt.Errorf("列结束索引必须大于起始索引")
+	}
+
+	err := client.MergeTableCells(documentID, tableBlockID, rowStart, rowEnd, colStart, colEnd, userAccessToken)
+	if err != nil {
+		return fmt.Errorf("合并单元格失败: %w", err)
+	}
+
+	if output == "json" {
+		return printJSON(map[string]any{
+			"document_id":        documentID,
+			"table_block_id":     tableBlockID,
+			"operation":          "merge_cells",
+			"row_start_index":    rowStart,
+			"row_end_index":      rowEnd,
+			"column_start_index": colStart,
+			"column_end_index":   colEnd,
+		})
+	}
+
+	fmt.Printf("已成功合并单元格（行 %d-%d，列 %d-%d）\n", rowStart, rowEnd-1, colStart, colEnd-1)
+	return nil
+}

--- a/cmd/doc_table_unmerge_cells.go
+++ b/cmd/doc_table_unmerge_cells.go
@@ -1,0 +1,72 @@
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/riba2534/feishu-cli/internal/client"
+	"github.com/riba2534/feishu-cli/internal/config"
+	"github.com/spf13/cobra"
+)
+
+var docTableUnmergeCellsCmd = &cobra.Command{
+	Use:   "unmerge-cells <document_id> <table_block_id>",
+	Short: "取消合并单元格",
+	Long: `取消指定单元格的合并状态。
+
+参数:
+  document_id     文档 ID
+  table_block_id  表格块 ID
+  --row           单元格所在行索引
+  --col           单元格所在列索引
+
+示例:
+  # 取消 A1 单元格的合并
+  feishu-cli doc table unmerge-cells DOC_ID TABLE_BLOCK_ID --row 0 --col 0`,
+	Args: cobra.ExactArgs(2),
+	RunE: runDocTableUnmergeCells,
+}
+
+func init() {
+	docTableCmd.AddCommand(docTableUnmergeCellsCmd)
+	docTableUnmergeCellsCmd.Flags().Int("row", 0, "单元格所在行索引")
+	docTableUnmergeCellsCmd.Flags().Int("col", 0, "单元格所在列索引")
+	docTableUnmergeCellsCmd.Flags().StringP("output", "o", "", "输出格式 (json)")
+	docTableUnmergeCellsCmd.Flags().String("user-access-token", "", "User Access Token（可选）")
+	mustMarkFlagRequired(docTableUnmergeCellsCmd, "row", "col")
+}
+
+func runDocTableUnmergeCells(cmd *cobra.Command, args []string) error {
+	if err := config.Validate(); err != nil {
+		return err
+	}
+
+	documentID := args[0]
+	tableBlockID := args[1]
+	row, _ := cmd.Flags().GetInt("row")
+	col, _ := cmd.Flags().GetInt("col")
+	output, _ := cmd.Flags().GetString("output")
+	userAccessToken := resolveOptionalUserToken(cmd)
+
+	// 参数验证
+	if row < 0 || col < 0 {
+		return fmt.Errorf("行列索引不能为负数")
+	}
+
+	err := client.UnmergeTableCells(documentID, tableBlockID, row, col, userAccessToken)
+	if err != nil {
+		return fmt.Errorf("取消合并失败: %w", err)
+	}
+
+	if output == "json" {
+		return printJSON(map[string]any{
+			"document_id":     documentID,
+			"table_block_id":  tableBlockID,
+			"operation":       "unmerge_cells",
+			"row_index":       row,
+			"column_index":    col,
+		})
+	}
+
+	fmt.Printf("已成功取消单元格合并（行 %d，列 %d）\n", row, col)
+	return nil
+}

--- a/cmd/doc_table_unmerge_cells.go
+++ b/cmd/doc_table_unmerge_cells.go
@@ -15,7 +15,7 @@ var docTableUnmergeCellsCmd = &cobra.Command{
 
 参数:
   document_id     文档 ID
-  table_block_id  表格块 ID
+  table_block_id  表格块 ID（Block 类型 31）
   --row           单元格所在行索引
   --col           单元格所在列索引
 

--- a/internal/client/docx.go
+++ b/internal/client/docx.go
@@ -851,3 +851,100 @@ func GetTableCellIDs(documentID string, tableBlockID string, userAccessToken ...
 
 	return block.Table.Cells, nil
 }
+
+// ============================================================
+// 文档表格操作（Block 类型 31）
+// ============================================================
+
+// InsertTableRow 在表格中插入一行
+// index = -1 表示插入到表格末尾
+func InsertTableRow(documentID, tableBlockID string, index int, userAccessToken ...string) error {
+	_, err := UpdateBlock(documentID, tableBlockID, map[string]any{
+		"insert_table_row": map[string]any{
+			"row_index": index,
+		},
+	}, userAccessToken...)
+	if err != nil {
+		return fmt.Errorf("插入行失败: %w", err)
+	}
+	return nil
+}
+
+// InsertTableColumn 在表格中插入一列
+// index = -1 表示插入到表格末尾
+func InsertTableColumn(documentID, tableBlockID string, index int, userAccessToken ...string) error {
+	_, err := UpdateBlock(documentID, tableBlockID, map[string]any{
+		"insert_table_column": map[string]any{
+			"column_index": index,
+		},
+	}, userAccessToken...)
+	if err != nil {
+		return fmt.Errorf("插入列失败: %w", err)
+	}
+	return nil
+}
+
+// DeleteTableRows 删除表格中的行（左闭右开区间）
+// rowStartIndex: 起始行索引（包含，0 表示第一行）
+// rowEndIndex: 结束行索引（不包含）
+func DeleteTableRows(documentID, tableBlockID string, rowStartIndex, rowEndIndex int, userAccessToken ...string) error {
+	_, err := UpdateBlock(documentID, tableBlockID, map[string]any{
+		"delete_table_rows": map[string]any{
+			"row_start_index": rowStartIndex,
+			"row_end_index":   rowEndIndex,
+		},
+	}, userAccessToken...)
+	if err != nil {
+		return fmt.Errorf("删除行失败: %w", err)
+	}
+	return nil
+}
+
+// DeleteTableColumns 删除表格中的列（左闭右开区间）
+// columnStartIndex: 起始列索引（包含，0 表示第一列）
+// columnEndIndex: 结束列索引（不包含）
+func DeleteTableColumns(documentID, tableBlockID string, columnStartIndex, columnEndIndex int, userAccessToken ...string) error {
+	_, err := UpdateBlock(documentID, tableBlockID, map[string]any{
+		"delete_table_columns": map[string]any{
+			"column_start_index": columnStartIndex,
+			"column_end_index":   columnEndIndex,
+		},
+	}, userAccessToken...)
+	if err != nil {
+		return fmt.Errorf("删除列失败: %w", err)
+	}
+	return nil
+}
+
+// MergeTableCells 合并表格单元格（左闭右开区间）
+// rowStartIndex, rowEndIndex: 行范围（左闭右开）
+// columnStartIndex, columnEndIndex: 列范围（左闭右开）
+func MergeTableCells(documentID, tableBlockID string, rowStartIndex, rowEndIndex, columnStartIndex, columnEndIndex int, userAccessToken ...string) error {
+	_, err := UpdateBlock(documentID, tableBlockID, map[string]any{
+		"merge_table_cells": map[string]any{
+			"row_start_index":    rowStartIndex,
+			"row_end_index":      rowEndIndex,
+			"column_start_index": columnStartIndex,
+			"column_end_index":   columnEndIndex,
+		},
+	}, userAccessToken...)
+	if err != nil {
+		return fmt.Errorf("合并单元格失败: %w", err)
+	}
+	return nil
+}
+
+// UnmergeTableCells 取消合并单元格
+// rowIndex, columnIndex: 单元格位置
+func UnmergeTableCells(documentID, tableBlockID string, rowIndex, columnIndex int, userAccessToken ...string) error {
+	_, err := UpdateBlock(documentID, tableBlockID, map[string]any{
+		"unmerge_table_cells": map[string]any{
+			"row_index":    rowIndex,
+			"column_index": columnIndex,
+		},
+	}, userAccessToken...)
+	if err != nil {
+		return fmt.Errorf("取消合并失败: %w", err)
+	}
+	return nil
+}

--- a/internal/client/docx.go
+++ b/internal/client/docx.go
@@ -864,10 +864,7 @@ func InsertTableRow(documentID, tableBlockID string, index int, userAccessToken 
 			"row_index": index,
 		},
 	}, userAccessToken...)
-	if err != nil {
-		return fmt.Errorf("插入行失败: %w", err)
-	}
-	return nil
+	return err
 }
 
 // InsertTableColumn 在表格中插入一列
@@ -878,10 +875,7 @@ func InsertTableColumn(documentID, tableBlockID string, index int, userAccessTok
 			"column_index": index,
 		},
 	}, userAccessToken...)
-	if err != nil {
-		return fmt.Errorf("插入列失败: %w", err)
-	}
-	return nil
+	return err
 }
 
 // DeleteTableRows 删除表格中的行（左闭右开区间）
@@ -894,10 +888,7 @@ func DeleteTableRows(documentID, tableBlockID string, rowStartIndex, rowEndIndex
 			"row_end_index":   rowEndIndex,
 		},
 	}, userAccessToken...)
-	if err != nil {
-		return fmt.Errorf("删除行失败: %w", err)
-	}
-	return nil
+	return err
 }
 
 // DeleteTableColumns 删除表格中的列（左闭右开区间）
@@ -910,10 +901,7 @@ func DeleteTableColumns(documentID, tableBlockID string, columnStartIndex, colum
 			"column_end_index":   columnEndIndex,
 		},
 	}, userAccessToken...)
-	if err != nil {
-		return fmt.Errorf("删除列失败: %w", err)
-	}
-	return nil
+	return err
 }
 
 // MergeTableCells 合并表格单元格（左闭右开区间）
@@ -928,10 +916,7 @@ func MergeTableCells(documentID, tableBlockID string, rowStartIndex, rowEndIndex
 			"column_end_index":   columnEndIndex,
 		},
 	}, userAccessToken...)
-	if err != nil {
-		return fmt.Errorf("合并单元格失败: %w", err)
-	}
-	return nil
+	return err
 }
 
 // UnmergeTableCells 取消合并单元格
@@ -943,8 +928,5 @@ func UnmergeTableCells(documentID, tableBlockID string, rowIndex, columnIndex in
 			"column_index": columnIndex,
 		},
 	}, userAccessToken...)
-	if err != nil {
-		return fmt.Errorf("取消合并失败: %w", err)
-	}
-	return nil
+	return err
 }

--- a/skills/feishu-cli-toolkit/SKILL.md
+++ b/skills/feishu-cli-toolkit/SKILL.md
@@ -44,6 +44,7 @@ allowed-tools: Bash, Read, Write
 | # | 模块 | 核心命令 | 详细参考 |
 |---|------|---------|---------|
 | 1 | 电子表格 | `sheet create/get/read/write/append` + V3 富文本 | `references/sheet-commands.md` |
+| 1.5 | 文档表格 | `doc table insert-row/column/delete-rows/columns/merge-cells/unmerge-cells` | — |
 | 2 | 日历日程 | `calendar list/get/primary/create-event/event-search/freebusy` | `references/calendar-commands.md` |
 | 3 | 任务管理 | `task create/complete/delete` + subtask/member/reminder + `tasklist` | `references/task-commands.md` |
 | 4 | 群聊创建 | `chat create/link`（App Token，群信息/成员/消息互动请用 **feishu-cli-chat**） | `references/chat-commands.md` |
@@ -138,6 +139,63 @@ feishu-cli sheet export <spreadsheet_token> -o /tmp/report.xlsx --max-retries 50
 **详细参考**：读取 `references/sheet-commands.md` 获取 V3 富文本格式、工作表管理、单元格图片等完整说明。
 
 **权限要求**：`sheets:spreadsheet`
+
+---
+
+## 1.5. 文档表格（内嵌表格）
+
+**定义**：文档内嵌表格（Block 类型 31），嵌入在飞书文档中的表格，与电子表格（Sheet）不同。
+
+**与电子表格的区别**：
+| 维度 | 文档表格（Table Block） | 电子表格（Sheet） |
+|------|------------------------|------------------|
+| 位置 | 嵌入在文档中 | 独立的云文档 |
+| 行列限制 | **最多 9 行 × 9 列**（API 限制） | 无限制 |
+| 操作方式 | `doc table` 命令 | `sheet` 命令 |
+| 合并单元格 | 支持 | 支持 |
+
+### 常用命令
+
+```bash
+# 插入行（-1 表示末尾）
+feishu-cli doc table insert-row DOC_ID TABLE_BLOCK_ID --index -1
+
+# 插入列
+feishu-cli doc table insert-column DOC_ID TABLE_BLOCK_ID --index 2
+
+# 删除行（左闭右开区间）
+feishu-cli doc table delete-rows DOC_ID TABLE_BLOCK_ID --start 1 --end 3
+
+# 删除列（左闭右开区间）
+feishu-cli doc table delete-columns DOC_ID TABLE_BLOCK_ID --start 0 --end 2
+
+# 合并单元格（左闭右开区间）
+feishu-cli doc table merge-cells DOC_ID TABLE_BLOCK_ID \
+  --row-start 0 --row-end 2 --col-start 0 --col-end 3
+
+# 取消合并
+feishu-cli doc table unmerge-cells DOC_ID TABLE_BLOCK_ID --row 0 --col 0
+```
+
+### 参数说明
+
+| 命令 | 参数 | 说明 |
+|------|------|------|
+| insert-row | `--index` | 插入位置，-1 表示末尾 |
+| insert-column | `--index` | 插入位置，-1 表示末尾 |
+| delete-rows | `--start`, `--end` | 行范围（左闭右开） |
+| delete-columns | `--start`, `--end` | 列范围（左闭右开） |
+| merge-cells | `--row-start/end`, `--col-start/end` | 合并范围（左闭右开） |
+| unmerge-cells | `--row`, `--col` | 单元格位置 |
+
+### 获取表格块 ID
+
+```bash
+# 查看文档结构，找到 block_type=31 的表格块
+feishu-cli doc blocks DOC_ID
+```
+
+**权限要求**：`docx:document`
 
 ---
 

--- a/skills/feishu-cli-write/SKILL.md
+++ b/skills/feishu-cli-write/SKILL.md
@@ -346,6 +346,36 @@ feishu-cli doc add-callout <document_id> "内容" --callout-type error --parent-
 
 > 需要橙色（CAUTION）或紫色（IMPORTANT）时，请使用 Markdown 导入方式（`doc import` 或 `doc add --content-type markdown`）。
 
+### 表格操作
+
+对文档内嵌表格（Block 类型 31）进行行列操作和单元格合并：
+
+```bash
+# 获取表格块 ID（查找 block_type=31 的块）
+feishu-cli doc blocks DOC_ID
+
+# 插入行（-1 表示末尾）
+feishu-cli doc table insert-row DOC_ID TABLE_BLOCK_ID --index -1
+
+# 插入列
+feishu-cli doc table insert-column DOC_ID TABLE_BLOCK_ID --index 2
+
+# 删除行（左闭右开区间）
+feishu-cli doc table delete-rows DOC_ID TABLE_BLOCK_ID --start 1 --end 3
+
+# 删除列（左闭右开区间）
+feishu-cli doc table delete-columns DOC_ID TABLE_BLOCK_ID --start 0 --end 2
+
+# 合并单元格（左闭右开区间）
+feishu-cli doc table merge-cells DOC_ID TABLE_BLOCK_ID \
+  --row-start 0 --row-end 2 --col-start 0 --col-end 3
+
+# 取消合并
+feishu-cli doc table unmerge-cells DOC_ID TABLE_BLOCK_ID --row 0 --col 0
+```
+
+> **注意**：文档表格 API 限制单表最多 9 行 × 9 列。超出限制需使用电子表格（Sheet）。
+
 ### 批量更新块
 
 批量更新文档中的块内容：


### PR DESCRIPTION
## 背景

测试发现生成12行的表格会被拆分成两个表格，需要插入行已经合并单元格操作，sdk提供但feishu-cli未提供。
feishu-cli 文档内嵌表格此前只能通过 Markdown 导入创建，创建后无法调整行列或合并单元格。
所以需要添加插入、删除行、合并单元格的操作。

## 改动

### 1. 新增 `doc table` 子命令组

```bash
feishu-cli doc table insert-row DOC_ID TABLE_BLOCK_ID --index -1      # 插入行
feishu-cli doc table insert-column DOC_ID TABLE_BLOCK_ID --index -1   # 插入列
feishu-cli doc table delete-rows DOC_ID TABLE_BLOCK_ID --start 1 --end 3     # 删除行
feishu-cli doc table delete-columns DOC_ID TABLE_BLOCK_ID --start 0 --end 2  # 删除列
feishu-cli doc table merge-cells DOC_ID TABLE_BLOCK_ID \
  --row-start 0 --row-end 2 --col-start 0 --col-end 3  # 合并单元格
feishu-cli doc table unmerge-cells DOC_ID TABLE_BLOCK_ID --row 0 --col 0    # 取消合并
```

所有操作复用现有 `UpdateBlock` 封装，通过 `map[string]any` 构造请求体，调用 `DocumentBlock.Patch` API。

### 2. 索引语义统一

- 删除和合并操作统一使用**左闭右开区间**，符合 Go 切片惯例
- `--index -1` 表示插入到末尾，与飞书 API 保持一致

### 3. 代码影响范围

| 文件 | 变更 |
|------|------|
| `internal/client/docx.go` | 新增 `InsertTableRow`、`InsertTableColumn`、`DeleteTableRows`、`DeleteTableColumns`、`MergeTableCells`、`UnmergeTableCells` 6 个函数 |
| `cmd/doc_table.go` | 新增表格子命令组定义 |
| `cmd/doc_table_*.go` | 新增 6 个子命令文件 |
| `cmd/doc.go` | Long help 新增 table 子命令说明 |
| `skills/feishu-cli-toolkit/SKILL.md` | 模块速查表新增 §1.5 文档表格，章节新增详细说明 |
| `skills/feishu-cli-write/SKILL.md` | 高级操作新增表格操作章节 |

## 测试

- `go build` 构建成功
- `feishu-cli doc table --help` 帮助信息正确显示
- `feishu-cli doc table insert-row --help` 子命令参数正确

## 兼容性

- 所有命令和函数均为新增，无现有行为变更
- `internal/client/docx.go` 新增的 6 个函数为内部 API，不影响外部调用

## 注意事项

文档表格 API 限制单表最多 9 行 × 9 列，超出限制需使用电子表格（Sheet）。已在帮助文档和 skills 中说明。
```