### PR TITLE
fix: 支持带文档上下文下载内嵌素材

### DIFF
--- a/README.md
+++ b/README.md
@@ -718,6 +718,7 @@ feishu-cli doc content-update <doc_id> --mode overwrite --markdown "# 全新文�
 feishu-cli doc content-update <doc_id> --mode replace_range --selection-by-title "## 旧章节" --markdown "## 新章节"
 feishu-cli doc media-insert <doc_id> --file photo.png --type image --align center
 feishu-cli doc media-download <file_token> -o image.png
+feishu-cli doc media-download <file_token> --doc-token DOC_TOKEN --doc-type docx -o image.png
 
 # 电子表格导出
 feishu-cli sheet export <token> -o output.xlsx

--- a/cmd/doc_media_download.go
+++ b/cmd/doc_media_download.go
@@ -12,17 +12,26 @@ import (
 var docMediaDownloadCmd = &cobra.Command{
 	Use:   "media-download <token>",
 	Short: "下载文档中的素材（图片/文件/画板缩略图）",
-	Long: `下载文档中嵌入的图��、文件或画板缩略图。
+	Long: `下载文档中嵌入的图片、文件或画板缩略图。
 
 参数:
   token       素材文件 token 或画板 ID
   --type      素材类型（media/whiteboard，默认 media）
   --output    输出文件路径（默认使用 token 作为文件名）
+  --doc-token 素材所属文档 token（文档内嵌图片需要）
+  --doc-type  素材所属文档类型（默认 docx）
+  --extra     原始 extra JSON（优先于 --doc-token/--doc-type）
   --timeout   下载超时时间（默认 5m，大文件可设置更长如 30m、1h）
 
 示例:
   # 下载图片素材
   feishu-cli doc media-download boxcnXXX -o image.png
+
+  # 下载文档内嵌图片
+  feishu-cli doc media-download boxcnXXX --doc-token DOC_TOKEN --doc-type docx -o image.png
+
+  # 手动指定素材下载 extra
+  feishu-cli doc media-download boxcnXXX --extra '{"doc_token":"DOC_TOKEN","doc_type":"docx"}' -o image.png
 
   # 下载画板缩略图
   feishu-cli doc media-download XXX --type whiteboard -o board.png
@@ -38,6 +47,9 @@ var docMediaDownloadCmd = &cobra.Command{
 		token := args[0]
 		mediaType, _ := cmd.Flags().GetString("type")
 		output, _ := cmd.Flags().GetString("output")
+		docToken, _ := cmd.Flags().GetString("doc-token")
+		docType, _ := cmd.Flags().GetString("doc-type")
+		extra, _ := cmd.Flags().GetString("extra")
 		timeoutStr, _ := cmd.Flags().GetString("timeout")
 		userAccessToken := resolveOptionalUserTokenWithFallback(cmd)
 
@@ -69,6 +81,9 @@ var docMediaDownloadCmd = &cobra.Command{
 			// 下载媒体文件（图片/附件）
 			opts := client.DownloadMediaOptions{
 				UserAccessToken: userAccessToken,
+				DocToken:        docToken,
+				DocType:         docType,
+				Extra:           extra,
 				Timeout:         timeout,
 			}
 
@@ -96,6 +111,9 @@ func init() {
 	docCmd.AddCommand(docMediaDownloadCmd)
 	docMediaDownloadCmd.Flags().String("type", "media", "素材类型（media/whiteboard）")
 	docMediaDownloadCmd.Flags().StringP("output", "o", "", "输出文件路径")
+	docMediaDownloadCmd.Flags().String("doc-token", "", "素材所属文档 token（用于下载文档内嵌图片）")
+	docMediaDownloadCmd.Flags().String("doc-type", "docx", "素材所属文档类型（默认 docx）")
+	docMediaDownloadCmd.Flags().String("extra", "", "素材下载 extra JSON（优先于 --doc-token/--doc-type）")
 	docMediaDownloadCmd.Flags().String("user-access-token", "", "User Access Token（可选；默认优先使用 auth login 登录态，失败时回退 App Token）")
 	docMediaDownloadCmd.Flags().String("timeout", "", "下载超时时间（默认 5m，示例: 10m, 30m, 1h）")
 }

--- a/cmd/doc_media_download_test.go
+++ b/cmd/doc_media_download_test.go
@@ -1,0 +1,19 @@
+package cmd
+
+import "testing"
+
+func TestDocMediaDownloadContextFlags(t *testing.T) {
+	for _, name := range []string{"doc-token", "doc-type", "extra"} {
+		if docMediaDownloadCmd.Flags().Lookup(name) == nil {
+			t.Fatalf("doc media-download missing --%s flag", name)
+		}
+	}
+
+	docType, err := docMediaDownloadCmd.Flags().GetString("doc-type")
+	if err != nil {
+		t.Fatalf("get doc-type flag: %v", err)
+	}
+	if docType != "docx" {
+		t.Fatalf("doc-type default = %q, want docx", docType)
+	}
+}

--- a/internal/client/drive.go
+++ b/internal/client/drive.go
@@ -142,7 +142,27 @@ func UploadMediaWithExtra(filePath, parentType, parentNode, fileName, extra stri
 type DownloadMediaOptions struct {
 	UserAccessToken string        // User Access Token（可选）
 	DocToken        string        // 文档 Token（文档内嵌图片下载时需要）
+	DocType         string        // 文档类型（默认 docx）
+	Extra           string        // 原始 extra JSON，设置后优先于 DocToken/DocType
 	Timeout         time.Duration // 自定义超时时间（0 表示使用默认 5 分钟）
+}
+
+func buildDownloadMediaExtra(opts DownloadMediaOptions) string {
+	if opts.Extra != "" {
+		return opts.Extra
+	}
+	if opts.DocToken == "" {
+		return ""
+	}
+	docType := opts.DocType
+	if docType == "" {
+		docType = "docx"
+	}
+	extraJSON, _ := json.Marshal(map[string]string{
+		"doc_token": opts.DocToken,
+		"doc_type":  docType,
+	})
+	return string(extraJSON)
 }
 
 // DownloadMedia downloads a file from Feishu drive
@@ -162,9 +182,8 @@ func DownloadMedia(fileToken string, outputPath string, opts ...DownloadMediaOpt
 	var reqOpts []larkcore.RequestOptionFunc
 	if len(opts) > 0 {
 		reqOpts = UserTokenOption(opts[0].UserAccessToken)
-		if opts[0].DocToken != "" {
-			extraJSON, _ := json.Marshal(map[string]string{"doc_token": opts[0].DocToken, "obj_type": "docx"})
-			reqBuilder = reqBuilder.Extra(string(extraJSON))
+		if extra := buildDownloadMediaExtra(opts[0]); extra != "" {
+			reqBuilder = reqBuilder.Extra(extra)
 		}
 	}
 
@@ -198,9 +217,8 @@ func GetMediaTempURL(fileToken string, opts ...DownloadMediaOptions) (string, er
 	var reqOpts []larkcore.RequestOptionFunc
 	if len(opts) > 0 {
 		reqOpts = UserTokenOption(opts[0].UserAccessToken)
-		if opts[0].DocToken != "" {
-			extraJSON, _ := json.Marshal(map[string]string{"doc_token": opts[0].DocToken, "obj_type": "docx"})
-			reqBuilder = reqBuilder.Extra(string(extraJSON))
+		if extra := buildDownloadMediaExtra(opts[0]); extra != "" {
+			reqBuilder = reqBuilder.Extra(extra)
 		}
 	}
 

--- a/internal/client/drive_media_test.go
+++ b/internal/client/drive_media_test.go
@@ -1,0 +1,44 @@
+package client
+
+import "testing"
+
+func TestBuildDownloadMediaExtra(t *testing.T) {
+	tests := []struct {
+		name string
+		opts DownloadMediaOptions
+		want string
+	}{
+		{
+			name: "empty options",
+			opts: DownloadMediaOptions{},
+			want: "",
+		},
+		{
+			name: "doc token defaults to docx",
+			opts: DownloadMediaOptions{DocToken: "doc_token_123"},
+			want: `{"doc_token":"doc_token_123","doc_type":"docx"}`,
+		},
+		{
+			name: "doc type can be overridden",
+			opts: DownloadMediaOptions{DocToken: "doc_token_123", DocType: "doc"},
+			want: `{"doc_token":"doc_token_123","doc_type":"doc"}`,
+		},
+		{
+			name: "raw extra wins",
+			opts: DownloadMediaOptions{
+				DocToken: "doc_token_123",
+				DocType:  "docx",
+				Extra:    `{"doc_token":"override","doc_type":"docx"}`,
+			},
+			want: `{"doc_token":"override","doc_type":"docx"}`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := buildDownloadMediaExtra(tt.opts); got != tt.want {
+				t.Fatalf("buildDownloadMediaExtra() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}

--- a/skills/feishu-cli-export/SKILL.md
+++ b/skills/feishu-cli-export/SKILL.md
@@ -364,6 +364,12 @@ feishu-cli doc import-file ~/Documents/report.docx --type docx --name "季度报
 # 下载图片素材
 feishu-cli doc media-download <file_token> -o /tmp/image.png
 
+# 下载文档内嵌图片（表格单元格等场景）
+feishu-cli doc media-download <file_token> --doc-token DOC_TOKEN --doc-type docx -o /tmp/image.png
+
+# 手动指定素材下载 extra
+feishu-cli doc media-download <file_token> --extra '{"doc_token":"DOC_TOKEN","doc_type":"docx"}' -o /tmp/image.png
+
 # 下载文件素材
 feishu-cli doc media-download <file_token> -o /tmp/attachment.pdf
 
@@ -387,6 +393,9 @@ feishu-cli doc media-download <whiteboard_token> --type whiteboard -o /tmp/board
 | `<token>` | 素材 Token 或画板 Token | 必填 |
 | `--type` | 素材类型 `media`/`whiteboard` | `media` |
 | `-o, --output` | 输出文件路径 | — |
+| `--doc-token` | 素材所属文档 token（文档内嵌图片需要） | — |
+| `--doc-type` | 素材所属文档类型 | `docx` |
+| `--extra` | 原始素材下载 extra JSON，优先于 `--doc-token/--doc-type` | — |
 | `--timeout` | 下载超时时间（Go duration 格式，如 `10m`、`30m`、`1h`） | `5m` |
 
 ### 两种下载模式的区别


### PR DESCRIPTION
## 背景

导出新版文档或知识库文档时，图片块拿到的是素材 token。有些文档内嵌图片仅靠素材 token 不够，需要在素材下载接口里额外带上所属文档上下文。

这个 PR 解决的是 feishu-cli 在这类场景下“有 token 但命令行无法正确带上下文下载”的问题。

之前的问题主要有两个：

- `doc media-download` 没有 `--doc-token` / `--doc-type` / `--extra` 参数，用户从导出的 Markdown 里拿到 `<image token="..."/>` 后，没法用 CLI 手动补充文档上下文下载。
- 客户端代码虽然已有 `DocToken`，但生成的 `extra` 是 `{"doc_token":"...","obj_type":"docx"}`；下载素材时应使用 `doc_type`，否则文档内嵌素材下载会缺少正确上下文。

## 例子

假设导出的 Markdown 中出现了这样的图片：

```md
<image token="img_xxx"/>
```

这不是标准 Markdown 图片语法，普通 Markdown 下载器不会自动处理。正确做法是用素材 token 下载，同时告诉接口它属于哪篇 docx：

```bash
feishu-cli doc media-download img_xxx \
  --doc-token DOC_TOKEN \
  --doc-type docx \
  -o image.png
```

等价于给素材下载接口传：

```json
{"doc_token":"DOC_TOKEN","doc_type":"docx"}
```

如果调用方已经知道更特殊的 `extra` 结构，也可以直接传原始 JSON：

```bash
feishu-cli doc media-download img_xxx \
  --extra '{"doc_token":"DOC_TOKEN","doc_type":"docx"}' \
  -o image.png
```

## 修改内容

- `DownloadMediaOptions` 新增 `DocType` 和 `Extra`。
- 新增 `buildDownloadMediaExtra`，统一为素材下载和临时下载链接生成 `extra`。
- 将文档上下文里的字段从 `obj_type` 改为 `doc_type`。
- `Extra` 原样优先于 `DocToken/DocType`，方便兼容高级权限或后续特殊场景。
- `doc media-download` 新增：
  - `--doc-token`
  - `--doc-type`，默认 `docx`
  - `--extra`
- README 和 `feishu-cli-export` skill 文档补充对应用法。
- 增加回归测试覆盖 extra 构造和 CLI flag 注册。

## 验证

- `go test ./...`
- `go vet ./...`
- `go build -o /tmp/feishu-cli-pr-check .`
- `go run . doc media-download --help`
- `git diff --check`

另外做过一次真实文档验证：在文档素材下载权限已开通的情况下，`wiki export --download-images` 可以成功下载文档里的画板缩略图和多张图片。

## 注意

如果接口仍返回 403，通常是文档/素材下载权限问题：调用身份需要有目标文档资源权限，并且文档权限设置里允许创建副本、打印和下载。这个 PR 补齐的是 CLI 传下载上下文的能力，不会绕过飞书侧的权限控制。
