### PR TITLE
优化嵌入在文档里的电子表格导出

### DIFF
--- a/internal/converter/block_html_tags_test.go
+++ b/internal/converter/block_html_tags_test.go
@@ -333,7 +333,7 @@ func TestExportSheetWithRowsCols(t *testing.T) {
 		t.Fatalf("Convert() error = %v", err)
 	}
 	got = strings.TrimSpace(got)
-	want := `<sheet token="sheet_xyz" rows="5" cols="8"/>`
+	want := `<sheet token="sheet" id="xyz" rows="5" cols="8"/>`
 	if got != want {
 		t.Errorf("got:\n%s\nwant:\n%s", got, want)
 	}

--- a/internal/converter/block_html_tags_test.go
+++ b/internal/converter/block_html_tags_test.go
@@ -138,21 +138,41 @@ func TestImportSheetDefault(t *testing.T) {
 }
 
 func TestImportSheetWithAttrs(t *testing.T) {
-	md := "<sheet rows=\"5\" cols=\"8\" token=\"sheet_xyz\"/>\n"
-	conv := NewMarkdownToBlock([]byte(md), ConvertOptions{}, "")
-	result, err := conv.ConvertWithTableData()
-	if err != nil {
-		t.Fatalf("error = %v", err)
+	tests := []struct {
+		name      string
+		md        string
+		wantToken string
+	}{
+		{
+			name:      "legacy combined token",
+			md:        "<sheet rows=\"5\" cols=\"8\" token=\"sheet_xyz\"/>\n",
+			wantToken: "sheet_xyz",
+		},
+		{
+			name:      "split token and id",
+			md:        "<sheet rows=\"5\" cols=\"8\" token=\"sheet\" id=\"xyz\"/>\n",
+			wantToken: "sheet_xyz",
+		},
 	}
-	block := result.BlockNodes[0].Block
-	if *block.Sheet.RowSize != 5 {
-		t.Errorf("expected RowSize=5, got %d", *block.Sheet.RowSize)
-	}
-	if *block.Sheet.ColumnSize != 8 {
-		t.Errorf("expected ColumnSize=8, got %d", *block.Sheet.ColumnSize)
-	}
-	if *block.Sheet.Token != "sheet_xyz" {
-		t.Errorf("expected token 'sheet_xyz', got %q", *block.Sheet.Token)
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			conv := NewMarkdownToBlock([]byte(tt.md), ConvertOptions{}, "")
+			result, err := conv.ConvertWithTableData()
+			if err != nil {
+				t.Fatalf("error = %v", err)
+			}
+			block := result.BlockNodes[0].Block
+			if *block.Sheet.RowSize != 5 {
+				t.Errorf("expected RowSize=5, got %d", *block.Sheet.RowSize)
+			}
+			if *block.Sheet.ColumnSize != 8 {
+				t.Errorf("expected ColumnSize=8, got %d", *block.Sheet.ColumnSize)
+			}
+			if *block.Sheet.Token != tt.wantToken {
+				t.Errorf("expected token %q, got %q", tt.wantToken, *block.Sheet.Token)
+			}
+		})
 	}
 }
 

--- a/internal/converter/block_to_markdown.go
+++ b/internal/converter/block_to_markdown.go
@@ -1079,7 +1079,13 @@ func (c *BlockToMarkdown) convertSheet(block *larkdocx.Block) (string, error) {
 
 	var attrs []string
 	if block.Sheet.Token != nil && *block.Sheet.Token != "" {
-		attrs = append(attrs, fmt.Sprintf("token=\"%s\"", *block.Sheet.Token))
+		token := *block.Sheet.Token
+		if idx := strings.Index(token, "_"); idx != -1 {
+			attrs = append(attrs, fmt.Sprintf("token=\"%s\"", token[:idx]))
+			attrs = append(attrs, fmt.Sprintf("id=\"%s\"", token[idx+1:]))
+		} else {
+			attrs = append(attrs, fmt.Sprintf("token=\"%s\"", token))
+		}
 	}
 	if block.Sheet.RowSize != nil && *block.Sheet.RowSize > 0 {
 		attrs = append(attrs, fmt.Sprintf("rows=\"%d\"", *block.Sheet.RowSize))

--- a/internal/converter/block_to_markdown_container_test.go
+++ b/internal/converter/block_to_markdown_container_test.go
@@ -1598,7 +1598,7 @@ func TestConvertSheet(t *testing.T) {
 		return
 	}
 	got = strings.TrimSpace(got)
-	want := `<sheet token="sheet_token456"/>`
+	want := `<sheet token="sheet" id="token456"/>`
 	if got != want {
 		t.Errorf("Convert() got:\n%s\n\nwant:\n%s", got, want)
 	}

--- a/internal/converter/markdown_to_block.go
+++ b/internal/converter/markdown_to_block.go
@@ -2414,9 +2414,14 @@ func (c *MarkdownToBlock) handleHTMLSheetBlock(tag *HTMLTag) []*BlockNode {
 		ColumnSize: &cols,
 	}
 
-	// 若有 token 属性，设置（用于 roundtrip）
+	// 若有 token/id 属性，设置（用于 roundtrip）
 	if token := tag.Attrs["token"]; token != "" {
-		sheet.Token = &token
+		if id := tag.Attrs["id"]; id != "" {
+			combined := token + "_" + id
+			sheet.Token = &combined
+		} else {
+			sheet.Token = &token
+		}
 	}
 
 	return []*BlockNode{{Block: &larkdocx.Block{


### PR DESCRIPTION
| 原始 | 现在 |
|--------|--------|
|`<sheet token="spreadsheetToken_sheetId"  />` | `<sheet token="spreadsheetToken"  id="sheet_id" />` | 

当电子表格嵌入在文档中，此时通过 block 获取到的 `sheet.token` 的格式为  `spreadsheetToken_sheetId`

为了方便 AI 能够正确解析表格内容，需要显示拆分来让 ai 能够通过正确的参数来获取