### PR TITLE
feat(doc): 支持 video 标签导入导出

### DIFF
--- a/cmd/add_content.go
+++ b/cmd/add_content.go
@@ -275,7 +275,7 @@ func addContentMarkdown(documentID, blockID, contentData, basePath string, uploa
 	for idx, children := range nodeChildrenMap {
 		if idx < len(createdBlockIDs) {
 			parentID := createdBlockIDs[idx]
-			nestedCount, nestedErr := createNestedChildren(documentID, parentID, children, userAccessToken)
+			nestedCount, _, nestedErr := createNestedChildren(documentID, parentID, children, userAccessToken)
 			if nestedErr != nil {
 				fmt.Fprintf(os.Stderr, "[Warning] 嵌套子块创建失败: %v\n", nestedErr)
 			}

--- a/cmd/import_markdown.go
+++ b/cmd/import_markdown.go
@@ -446,10 +446,11 @@ var importMarkdownCmd = &cobra.Command{
 				time.Sleep(cooldown)
 			}
 			phase2Header := fmt.Sprintf("=== 阶段 2/3: 并发处理 (图表×%d, 表格×%d", diagramWorkers, tableWorkers)
-			if len(iTasks) > 0 {
+			if len(iTasks) > 0 && len(vTasks) > 0 {
+				phase2Header += fmt.Sprintf(", 图片+视频×%d", imageWorkers)
+			} else if len(iTasks) > 0 {
 				phase2Header += fmt.Sprintf(", 图片×%d", imageWorkers)
-			}
-			if len(vTasks) > 0 {
+			} else if len(vTasks) > 0 {
 				phase2Header += fmt.Sprintf(", 视频×%d", imageWorkers)
 			}
 			phase2Header += ") ==="
@@ -614,21 +615,16 @@ func phase1CreateBlocks(
 				continue
 			}
 
-			// 提取顶层块，记录带有嵌套子块的节点
+			// 提取顶层块，嵌套子块稍后按 BlockNode 树顺序创建
 			var topLevelBlocks []*larkdocx.Block
-			nodeChildrenMap := map[int][]*converter.BlockNode{} // 顶层索引 → 嵌套子节点
 
-			for i, node := range result.BlockNodes {
+			for _, node := range result.BlockNodes {
 				topLevelBlocks = append(topLevelBlocks, node.Block)
-				if len(node.Children) > 0 {
-					nodeChildrenMap[i] = node.Children
-				}
 			}
 
 			// 记录表格块和图片块的索引
 			var tableIndices []int
 			var imageIndices []int
-			var videoIndices []int
 			for i, block := range topLevelBlocks {
 				if block.BlockType != nil {
 					switch *block.BlockType {
@@ -636,10 +632,6 @@ func phase1CreateBlocks(
 						tableIndices = append(tableIndices, i)
 					case int(converter.BlockTypeImage):
 						imageIndices = append(imageIndices, i)
-					case int(converter.BlockTypeFile):
-						if block.File != nil && block.File.Name != nil && isVideoFilename(*block.File.Name) {
-							videoIndices = append(videoIndices, i)
-						}
 					}
 				}
 			}
@@ -672,19 +664,23 @@ func phase1CreateBlocks(
 				}
 			}
 
-			// 递归创建嵌套子块（如嵌套列表）
-			for idx, children := range nodeChildrenMap {
-				if idx < len(createdBlockIDs) {
-					parentID := createdBlockIDs[idx]
+			nestedCreatedByTop := map[int][]createdBlockNode{}
 
-					nestedCount, nestedErr := createNestedChildren(documentID, parentID, children, userAccessToken)
-					if nestedErr != nil {
-						if verbose {
-							syncPrintf("  ⚠ 段落 %d 嵌套子块创建失败: %v\n", segIdx+1, nestedErr)
-						}
-					}
-					stats.totalBlocks += nestedCount
+			// 递归创建嵌套子块（如嵌套列表）
+			for idx, node := range result.BlockNodes {
+				if idx >= len(createdBlockIDs) || len(node.Children) == 0 {
+					continue
 				}
+				parentID := createdBlockIDs[idx]
+
+				nestedCount, nestedCreated, nestedErr := createNestedChildren(documentID, parentID, node.Children, userAccessToken)
+				if nestedErr != nil {
+					if verbose {
+						syncPrintf("  ⚠ 段落 %d 嵌套子块创建失败: %v\n", segIdx+1, nestedErr)
+					}
+				}
+				stats.totalBlocks += nestedCount
+				nestedCreatedByTop[idx] = nestedCreated
 			}
 
 			// QuoteContainer / Callout：遍历所有顶层节点清理飞书 API 异步生成的空子块。
@@ -733,20 +729,7 @@ func phase1CreateBlocks(
 				imageSourceIdx++
 			}
 
-			videoSourceIdx := 0
-			for _, fileIdx := range videoIndices {
-				if fileIdx >= len(createdBlockIDs) || videoSourceIdx >= len(result.VideoSources) {
-					continue
-				}
-
-				vTasks = append(vTasks, videoTask{
-					index:       len(vTasks) + 1,
-					fileBlockID: createdBlockIDs[fileIdx],
-					source:      result.VideoSources[videoSourceIdx],
-					basePath:    basePath,
-				})
-				videoSourceIdx++
-			}
+			vTasks = appendVideoTasks(vTasks, result.BlockNodes, createdBlockIDs, nestedCreatedByTop, result.VideoSources, basePath)
 
 		} else if seg.kind == "equation" {
 			// 块级公式：飞书 API 不支持创建 Equation 块（type=16），
@@ -1113,6 +1096,8 @@ func processImageTask(documentID string, task imageTask, verbose bool, userAcces
 
 // processVideoTask 处理单个视频上传任务（File Block）
 func processVideoTask(documentID string, task videoTask, verbose bool, userAccessToken string) videoResult {
+	const maxRetries = 5
+
 	localPath, fileName, cleanup, err := resolveMediaSource(task.source, task.basePath, ".mp4")
 	if err != nil {
 		syncPrintf("  ✗ 视频 %d 解析失败 (%s): %v\n", task.index, task.source, err)
@@ -1120,11 +1105,29 @@ func processVideoTask(documentID string, task videoTask, verbose bool, userAcces
 	}
 	defer cleanup()
 
+	const maxVideoSize = 20 * 1024 * 1024
+	fi, err := os.Stat(localPath)
+	if err != nil {
+		syncPrintf("  ✗ 视频 %d 文件信息获取失败: %v\n", task.index, err)
+		return videoResult{task: task, success: false, err: err}
+	}
+	if fi.Size() > maxVideoSize {
+		err := fmt.Errorf("视频超过 20MB 限制 (%d MB)，当前上传通道暂不支持大文件分块上传", fi.Size()/(1024*1024))
+		syncPrintf("  ✗ 视频 %d: %v\n", task.index, err)
+		return videoResult{task: task, success: false, err: err}
+	}
+
 	extra := fmt.Sprintf(`{"drive_route_token":"%s"}`, documentID)
 	retryCfg := client.RetryConfig{
-		MaxRetries:       3,
-		MaxTotalAttempts: 6,
+		MaxRetries:       maxRetries,
+		MaxTotalAttempts: maxRetries + 3,
 		RetryOnRateLimit: true,
+		OnRetry: func(attempt int, err error, wait time.Duration) {
+			if verbose {
+				syncPrintf("  ⚠ 视频 %d 上传重试 %d/%d (等待 %.1fs): %v\n",
+					task.index, attempt, maxRetries, wait.Seconds(), err)
+			}
+		},
 	}
 
 	uploadResult := client.DoWithRetry(func() (string, http.Header, error) {
@@ -1213,20 +1216,11 @@ func resolveMediaSource(source, basePath, defaultExt string) (string, string, fu
 	return localPath, filepath.Base(localPath), noop, nil
 }
 
-func isVideoFilename(name string) bool {
-	switch strings.ToLower(filepath.Ext(name)) {
-	case ".mp4", ".mov", ".m4v", ".webm", ".avi", ".mkv":
-		return true
-	default:
-		return false
-	}
-}
-
 // createNestedChildren 递归创建嵌套子块（如嵌套列表的父子关系）
 // 返回创建的块总数和可能的错误
-func createNestedChildren(documentID string, parentBlockID string, children []*converter.BlockNode, userAccessToken string) (int, error) {
+func createNestedChildren(documentID string, parentBlockID string, children []*converter.BlockNode, userAccessToken string) (int, []createdBlockNode, error) {
 	if len(children) == 0 {
-		return 0, nil
+		return 0, nil, nil
 	}
 
 	var childBlocks []*larkdocx.Block
@@ -1237,6 +1231,7 @@ func createNestedChildren(documentID string, parentBlockID string, children []*c
 	const batchSize = 50
 	var createdBlockIDs []string
 	totalCreated := 0
+	var createdNodes []createdBlockNode
 
 	for i := 0; i < len(childBlocks); i += batchSize {
 		end := i + batchSize
@@ -1252,7 +1247,7 @@ func createNestedChildren(documentID string, parentBlockID string, children []*c
 			RetryOnRateLimit: true,
 		})
 		if result.Err != nil {
-			return totalCreated, fmt.Errorf("创建嵌套子块失败 (parent=%s): %w", parentBlockID, result.Err)
+			return totalCreated, createdNodes, fmt.Errorf("创建嵌套子块失败 (parent=%s): %w", parentBlockID, result.Err)
 		}
 		totalCreated += len(result.Value)
 
@@ -1269,11 +1264,13 @@ func createNestedChildren(documentID string, parentBlockID string, children []*c
 			continue
 		}
 		childID := createdBlockIDs[i]
+		createdNodes = append(createdNodes, createdBlockNode{node: child, blockID: childID})
 		if len(child.Children) > 0 {
-			nestedCount, err := createNestedChildren(documentID, childID, child.Children, userAccessToken)
+			nestedCount, nestedCreated, err := createNestedChildren(documentID, childID, child.Children, userAccessToken)
 			totalCreated += nestedCount
+			createdNodes = append(createdNodes, nestedCreated...)
 			if err != nil {
-				return totalCreated, err
+				return totalCreated, createdNodes, err
 			}
 		}
 		// QuoteContainer / Callout 嵌套场景：无论是否有子块，均清理 API 自动生成的空块
@@ -1282,7 +1279,58 @@ func createNestedChildren(documentID string, parentBlockID string, children []*c
 		}
 	}
 
-	return totalCreated, nil
+	return totalCreated, createdNodes, nil
+}
+
+type createdBlockNode struct {
+	node    *converter.BlockNode
+	blockID string
+}
+
+func appendVideoTasks(
+	tasks []videoTask,
+	topNodes []*converter.BlockNode,
+	topBlockIDs []string,
+	nestedCreatedByTop map[int][]createdBlockNode,
+	videoSources []string,
+	basePath string,
+) []videoTask {
+	sourceIdx := 0
+
+	appendIfVideo := func(node *converter.BlockNode, blockID string) {
+		if sourceIdx >= len(videoSources) || !isVideoBlockNode(node) {
+			return
+		}
+		tasks = append(tasks, videoTask{
+			index:       len(tasks) + 1,
+			fileBlockID: blockID,
+			source:      videoSources[sourceIdx],
+			basePath:    basePath,
+		})
+		sourceIdx++
+	}
+
+	for i, node := range topNodes {
+		if i >= len(topBlockIDs) {
+			break
+		}
+		appendIfVideo(node, topBlockIDs[i])
+		for _, nested := range nestedCreatedByTop[i] {
+			appendIfVideo(nested.node, nested.blockID)
+		}
+	}
+
+	return tasks
+}
+
+func isVideoBlockNode(node *converter.BlockNode) bool {
+	if node == nil || node.Block == nil || node.Block.BlockType == nil {
+		return false
+	}
+	if *node.Block.BlockType != int(converter.BlockTypeFile) || node.Block.File == nil || node.Block.File.Name == nil {
+		return false
+	}
+	return converter.IsVideoFilename(*node.Block.File.Name)
 }
 
 // phase3HandleFallbacks 处理失败的图表，降级为代码块

--- a/cmd/import_markdown.go
+++ b/cmd/import_markdown.go
@@ -251,6 +251,21 @@ type imageResult struct {
 	err     error
 }
 
+// videoTask 表示一个待上传的视频任务（底层使用 File Block）
+type videoTask struct {
+	index       int
+	fileBlockID string
+	source      string
+	basePath    string
+}
+
+// videoResult 表示视频上传结果
+type videoResult struct {
+	task    videoTask
+	success bool
+	err     error
+}
+
 // importStats 记录导入统计信息
 type importStats struct {
 	mu              sync.Mutex
@@ -267,6 +282,10 @@ type importStats struct {
 	imageSuccess    int
 	imageFailed     int
 	imageSkipped    int
+	videoTotal      int
+	videoSuccess    int
+	videoFailed     int
+	videoSkipped    int
 	fallbackSuccess int
 	fallbackFailed  int
 	phase1Duration  time.Duration
@@ -397,7 +416,7 @@ var importMarkdownCmd = &cobra.Command{
 		fmt.Println("=== 阶段 1/3: 创建文档块 ===")
 		phase1Start := time.Now()
 
-		dTasks, tTasks, iTasks, err := phase1CreateBlocks(documentID, segments, uploadImages, basePath, stats, verbose, userAccessToken)
+		dTasks, tTasks, iTasks, vTasks, err := phase1CreateBlocks(documentID, segments, uploadImages, basePath, stats, verbose, userAccessToken)
 		if err != nil {
 			return err
 		}
@@ -405,15 +424,19 @@ var importMarkdownCmd = &cobra.Command{
 		stats.phase1Duration = time.Since(phase1Start)
 		stats.tableTotal = len(tTasks)
 		stats.imageTotal = stats.imageSkipped + len(iTasks)
+		stats.videoTotal = stats.videoSkipped + len(vTasks)
 		phase1Summary := fmt.Sprintf("[阶段1] 完成 (%.1fs), 块: %d, 待填表格: %d, 待导入图表: %d",
 			stats.phase1Duration.Seconds(), stats.totalBlocks, len(tTasks), len(dTasks))
 		if len(iTasks) > 0 {
 			phase1Summary += fmt.Sprintf(", 待上传图片: %d", len(iTasks))
 		}
+		if len(vTasks) > 0 {
+			phase1Summary += fmt.Sprintf(", 待上传视频: %d", len(vTasks))
+		}
 		fmt.Println(phase1Summary + "\n")
 
 		// === 阶段 2/3: 并发处理 ===
-		if len(dTasks) > 0 || len(tTasks) > 0 || len(iTasks) > 0 {
+		if len(dTasks) > 0 || len(tTasks) > 0 || len(iTasks) > 0 || len(vTasks) > 0 {
 			// 阶段 1 大量 API 调用后等待配额恢复，避免阶段 2 立即触发频率限制
 			if stats.totalBlocks > 30 {
 				cooldown := 5 * time.Second
@@ -426,17 +449,24 @@ var importMarkdownCmd = &cobra.Command{
 			if len(iTasks) > 0 {
 				phase2Header += fmt.Sprintf(", 图片×%d", imageWorkers)
 			}
+			if len(vTasks) > 0 {
+				phase2Header += fmt.Sprintf(", 视频×%d", imageWorkers)
+			}
 			phase2Header += ") ==="
 			fmt.Println(phase2Header)
 			phase2Start := time.Now()
 
-			failedDiagrams := phase2ConcurrentProcess(documentID, dTasks, tTasks, iTasks, diagramWorkers, tableWorkers, imageWorkers, diagramRetries, stats, verbose, userAccessToken)
+			failedDiagrams := phase2ConcurrentProcess(documentID, dTasks, tTasks, iTasks, vTasks, diagramWorkers, tableWorkers, imageWorkers, diagramRetries, stats, verbose, userAccessToken)
 
 			stats.phase2Duration = time.Since(phase2Start)
 			imageUploadTotal := stats.imageTotal - stats.imageSkipped
+			videoUploadTotal := stats.videoTotal - stats.videoSkipped
 			var imageInfo string
 			if imageUploadTotal > 0 {
 				imageInfo = fmt.Sprintf(", 图片: %d/%d", stats.imageSuccess, imageUploadTotal)
+			}
+			if videoUploadTotal > 0 {
+				imageInfo += fmt.Sprintf(", 视频: %d/%d", stats.videoSuccess, videoUploadTotal)
 			}
 			fmt.Printf("[阶段2] 完成 (%.1fs), 图表: %d/%d, 表格: %d/%d%s\n\n",
 				stats.phase2Duration.Seconds(),
@@ -479,6 +509,10 @@ var importMarkdownCmd = &cobra.Command{
 				"image_success":    stats.imageSuccess,
 				"image_failed":     stats.imageFailed,
 				"image_skipped":    stats.imageSkipped,
+				"video_total":      stats.videoTotal,
+				"video_success":    stats.videoSuccess,
+				"video_failed":     stats.videoFailed,
+				"video_skipped":    stats.videoSkipped,
 				"duration_seconds": totalDuration.Seconds(),
 				"phase1_seconds":   stats.phase1Duration.Seconds(),
 				"phase2_seconds":   stats.phase2Duration.Seconds(),
@@ -501,6 +535,19 @@ var importMarkdownCmd = &cobra.Command{
 						stats.imageSuccess, stats.imageTotal, stats.imageSkipped)
 				} else {
 					fmt.Printf("  图片: %d/%d 成功\n", stats.imageSuccess, stats.imageTotal)
+				}
+			}
+			if stats.videoTotal > 0 {
+				if stats.videoSkipped == stats.videoTotal {
+					fmt.Printf("  视频: %d 个 (已创建占位块，资源需手动处理)\n", stats.videoSkipped)
+				} else if stats.videoFailed > 0 {
+					fmt.Printf("  视频: %d/%d 成功 (%d 跳过, %d 失败)\n",
+						stats.videoSuccess, stats.videoTotal, stats.videoSkipped, stats.videoFailed)
+				} else if stats.videoSkipped > 0 {
+					fmt.Printf("  视频: %d/%d 成功 (%d 跳过)\n",
+						stats.videoSuccess, stats.videoTotal, stats.videoSkipped)
+				} else {
+					fmt.Printf("  视频: %d/%d 成功\n", stats.videoSuccess, stats.videoTotal)
 				}
 			}
 			if stats.tableTotal > 0 {
@@ -535,10 +582,11 @@ func phase1CreateBlocks(
 	stats *importStats,
 	verbose bool,
 	userAccessToken string,
-) ([]diagramTask, []tableTask, []imageTask, error) {
+) ([]diagramTask, []tableTask, []imageTask, []videoTask, error) {
 	var dTasks []diagramTask
 	var tTasks []tableTask
 	var iTasks []imageTask
+	var vTasks []videoTask
 	diagramIdx := 0
 
 	for segIdx, seg := range segments {
@@ -555,11 +603,12 @@ func phase1CreateBlocks(
 			conv := converter.NewMarkdownToBlock([]byte(seg.content), options, basePath)
 			result, err := conv.ConvertWithTableData()
 			if err != nil {
-				return nil, nil, nil, fmt.Errorf("转换 Markdown 失败 (段落 %d): %w", segIdx+1, err)
+				return nil, nil, nil, nil, fmt.Errorf("转换 Markdown 失败 (段落 %d): %w", segIdx+1, err)
 			}
 
 			// 累加图片统计
 			stats.imageSkipped += result.ImageStats.Skipped
+			stats.videoSkipped += result.VideoStats.Skipped
 
 			if len(result.BlockNodes) == 0 {
 				continue
@@ -579,6 +628,7 @@ func phase1CreateBlocks(
 			// 记录表格块和图片块的索引
 			var tableIndices []int
 			var imageIndices []int
+			var videoIndices []int
 			for i, block := range topLevelBlocks {
 				if block.BlockType != nil {
 					switch *block.BlockType {
@@ -586,6 +636,10 @@ func phase1CreateBlocks(
 						tableIndices = append(tableIndices, i)
 					case int(converter.BlockTypeImage):
 						imageIndices = append(imageIndices, i)
+					case int(converter.BlockTypeFile):
+						if block.File != nil && block.File.Name != nil && isVideoFilename(*block.File.Name) {
+							videoIndices = append(videoIndices, i)
+						}
 					}
 				}
 			}
@@ -607,7 +661,7 @@ func phase1CreateBlocks(
 					RetryOnRateLimit: true,
 				})
 				if createResult.Err != nil {
-					return nil, nil, nil, fmt.Errorf("添加内容失败 (段落 %d): %w", segIdx+1, createResult.Err)
+					return nil, nil, nil, nil, fmt.Errorf("添加内容失败 (段落 %d): %w", segIdx+1, createResult.Err)
 				}
 				stats.totalBlocks += len(createResult.Value)
 
@@ -677,6 +731,21 @@ func phase1CreateBlocks(
 					basePath:     basePath,
 				})
 				imageSourceIdx++
+			}
+
+			videoSourceIdx := 0
+			for _, fileIdx := range videoIndices {
+				if fileIdx >= len(createdBlockIDs) || videoSourceIdx >= len(result.VideoSources) {
+					continue
+				}
+
+				vTasks = append(vTasks, videoTask{
+					index:       len(vTasks) + 1,
+					fileBlockID: createdBlockIDs[fileIdx],
+					source:      result.VideoSources[videoSourceIdx],
+					basePath:    basePath,
+				})
+				videoSourceIdx++
 			}
 
 		} else if seg.kind == "equation" {
@@ -761,7 +830,7 @@ func phase1CreateBlocks(
 		}
 	}
 
-	return dTasks, tTasks, iTasks, nil
+	return dTasks, tTasks, iTasks, vTasks, nil
 }
 
 // phase2ConcurrentProcess 并发处理图表导入、表格填充和图片上传
@@ -770,6 +839,7 @@ func phase2ConcurrentProcess(
 	dTasks []diagramTask,
 	tTasks []tableTask,
 	iTasks []imageTask,
+	vTasks []videoTask,
 	diagramWorkers int,
 	tableWorkers int,
 	imageWorkers int,
@@ -844,6 +914,28 @@ func phase2ConcurrentProcess(
 					stats.imageSuccess++
 				} else {
 					stats.imageFailed++
+				}
+				stats.mu.Unlock()
+			}(task)
+		}
+	}
+
+	if len(vTasks) > 0 {
+		videoSem := make(chan struct{}, imageWorkers)
+		for _, task := range vTasks {
+			wg.Add(1)
+			go func(t videoTask) {
+				defer wg.Done()
+				videoSem <- struct{}{}
+				defer func() { <-videoSem }()
+
+				result := processVideoTask(documentID, t, verbose, userAccessToken)
+
+				stats.mu.Lock()
+				if result.success {
+					stats.videoSuccess++
+				} else {
+					stats.videoFailed++
 				}
 				stats.mu.Unlock()
 			}(task)
@@ -1019,6 +1111,47 @@ func processImageTask(documentID string, task imageTask, verbose bool, userAcces
 	return imageResult{task: task, success: true}
 }
 
+// processVideoTask 处理单个视频上传任务（File Block）
+func processVideoTask(documentID string, task videoTask, verbose bool, userAccessToken string) videoResult {
+	localPath, fileName, cleanup, err := resolveMediaSource(task.source, task.basePath, ".mp4")
+	if err != nil {
+		syncPrintf("  ✗ 视频 %d 解析失败 (%s): %v\n", task.index, task.source, err)
+		return videoResult{task: task, success: false, err: err}
+	}
+	defer cleanup()
+
+	extra := fmt.Sprintf(`{"drive_route_token":"%s"}`, documentID)
+	retryCfg := client.RetryConfig{
+		MaxRetries:       3,
+		MaxTotalAttempts: 6,
+		RetryOnRateLimit: true,
+	}
+
+	uploadResult := client.DoWithRetry(func() (string, http.Header, error) {
+		return client.UploadMediaWithExtra(localPath, "docx_file", task.fileBlockID, fileName, extra, userAccessToken)
+	}, retryCfg)
+	if uploadResult.Err != nil {
+		syncPrintf("  ✗ 视频 %d 上传失败 (%s): %v\n", task.index, task.source, uploadResult.Err)
+		return videoResult{task: task, success: false, err: uploadResult.Err}
+	}
+
+	fileToken := uploadResult.Value
+	replaceResult := client.DoVoidWithRetry(func() (http.Header, error) {
+		return client.UpdateBlock(documentID, task.fileBlockID, map[string]any{
+			"replace_file": map[string]any{"token": fileToken},
+		}, userAccessToken)
+	}, retryCfg)
+	if replaceResult.Err != nil {
+		syncPrintf("  ✗ 视频 %d 绑定失败 (token=%s): %v\n", task.index, fileToken, replaceResult.Err)
+		return videoResult{task: task, success: false, err: replaceResult.Err}
+	}
+
+	if verbose {
+		syncPrintf("  ✓ 视频 %d 成功 (%s)\n", task.index, task.source)
+	}
+	return videoResult{task: task, success: true}
+}
+
 func validateWorkerCount(flagName string, value int) error {
 	if value <= 0 {
 		return fmt.Errorf("--%s 必须大于 0，当前值: %d", flagName, value)
@@ -1029,6 +1162,10 @@ func validateWorkerCount(flagName string, value int) error {
 // resolveImageSource 解析图片来源为本地文件路径。
 // 返回本地路径、上传文件名和清理函数（外部 URL 下载的临时文件需要清理）。
 func resolveImageSource(source, basePath string) (string, string, func(), error) {
+	return resolveMediaSource(source, basePath, ".png")
+}
+
+func resolveMediaSource(source, basePath, defaultExt string) (string, string, func(), error) {
 	noop := func() {}
 
 	// HTTP(S) URL → 下载到临时文件
@@ -1045,7 +1182,7 @@ func resolveImageSource(source, basePath string) (string, string, func(), error)
 
 		ext := filepath.Ext(fileName)
 		if ext == "" || len(ext) > 10 {
-			ext = ".png"
+			ext = defaultExt
 		}
 		tmpFile, err := os.CreateTemp("", "feishu-img-*"+ext)
 		if err != nil {
@@ -1074,6 +1211,15 @@ func resolveImageSource(source, basePath string) (string, string, func(), error)
 		return "", "", nil, fmt.Errorf("图片文件不存在: %s", localPath)
 	}
 	return localPath, filepath.Base(localPath), noop, nil
+}
+
+func isVideoFilename(name string) bool {
+	switch strings.ToLower(filepath.Ext(name)) {
+	case ".mp4", ".mov", ".m4v", ".webm", ".avi", ".mkv":
+		return true
+	default:
+		return false
+	}
 }
 
 // createNestedChildren 递归创建嵌套子块（如嵌套列表的父子关系）

--- a/cmd/import_markdown.go
+++ b/cmd/import_markdown.go
@@ -22,6 +22,10 @@ import (
 // printMu 保护并发 goroutine 的日志输出不交叉
 var printMu sync.Mutex
 
+// maxInlineVideoSize 视频通过 drive_media 接口直传的大小上限（字节）。
+// 飞书该接口暂不支持分块上传，超过此值的视频会被拒绝；后续支持分块上传后可放宽。
+const maxInlineVideoSize = 20 * 1024 * 1024
+
 // syncPrintf 线程安全的 Printf，用于并发阶段的日志输出
 func syncPrintf(format string, a ...any) {
 	printMu.Lock()
@@ -462,18 +466,18 @@ var importMarkdownCmd = &cobra.Command{
 			stats.phase2Duration = time.Since(phase2Start)
 			imageUploadTotal := stats.imageTotal - stats.imageSkipped
 			videoUploadTotal := stats.videoTotal - stats.videoSkipped
-			var imageInfo string
+			var mediaInfo string
 			if imageUploadTotal > 0 {
-				imageInfo = fmt.Sprintf(", 图片: %d/%d", stats.imageSuccess, imageUploadTotal)
+				mediaInfo = fmt.Sprintf(", 图片: %d/%d", stats.imageSuccess, imageUploadTotal)
 			}
 			if videoUploadTotal > 0 {
-				imageInfo += fmt.Sprintf(", 视频: %d/%d", stats.videoSuccess, videoUploadTotal)
+				mediaInfo += fmt.Sprintf(", 视频: %d/%d", stats.videoSuccess, videoUploadTotal)
 			}
 			fmt.Printf("[阶段2] 完成 (%.1fs), 图表: %d/%d, 表格: %d/%d%s\n\n",
 				stats.phase2Duration.Seconds(),
 				stats.diagramSuccess, stats.diagramTotal,
 				stats.tableSuccess, stats.tableTotal,
-				imageInfo)
+				mediaInfo)
 
 			// === 阶段 3/3: 降级处理 ===
 			if len(failedDiagrams) > 0 {
@@ -880,15 +884,21 @@ func phase2ConcurrentProcess(
 		}(task)
 	}
 
+	// 图片和视频共用一个媒体上传信号量（飞书 drive_media 上传 API 限制约 5 QPS，
+	// 必须把图片和视频放进同一个并发池，否则总并发会变为 imageWorkers*2，超出 QPS）
+	var mediaSem chan struct{}
+	if len(iTasks) > 0 || len(vTasks) > 0 {
+		mediaSem = make(chan struct{}, imageWorkers)
+	}
+
 	// 启动图片上传工作
 	if len(iTasks) > 0 {
-		imageSem := make(chan struct{}, imageWorkers)
 		for _, task := range iTasks {
 			wg.Add(1)
 			go func(t imageTask) {
 				defer wg.Done()
-				imageSem <- struct{}{}
-				defer func() { <-imageSem }()
+				mediaSem <- struct{}{}
+				defer func() { <-mediaSem }()
 
 				result := processImageTask(documentID, t, verbose, userAccessToken)
 
@@ -904,13 +914,12 @@ func phase2ConcurrentProcess(
 	}
 
 	if len(vTasks) > 0 {
-		videoSem := make(chan struct{}, imageWorkers)
 		for _, task := range vTasks {
 			wg.Add(1)
 			go func(t videoTask) {
 				defer wg.Done()
-				videoSem <- struct{}{}
-				defer func() { <-videoSem }()
+				mediaSem <- struct{}{}
+				defer func() { <-mediaSem }()
 
 				result := processVideoTask(documentID, t, verbose, userAccessToken)
 
@@ -1047,7 +1056,7 @@ func processImageTask(documentID string, task imageTask, verbose bool, userAcces
 		return imageResult{task: task, success: false, err: err}
 	}
 	if fi.Size() > maxImageSize {
-		err := fmt.Errorf("图片超过 20MB 限制 (%d MB)", fi.Size()/(1024*1024))
+		err := fmt.Errorf("图片超过 20MB 限制 (%.1f MB)", float64(fi.Size())/(1024*1024))
 		syncPrintf("  ✗ 图片 %d: %v\n", task.index, err)
 		return imageResult{task: task, success: false, err: err}
 	}
@@ -1098,23 +1107,34 @@ func processImageTask(documentID string, task imageTask, verbose bool, userAcces
 func processVideoTask(documentID string, task videoTask, verbose bool, userAccessToken string) videoResult {
 	const maxRetries = 5
 
+	failWith := func(reason string, err error) videoResult {
+		// 视频上传失败：把阶段 1 创建的空 File 块替换为可见占位 Text 块，避免文档里留孤儿
+		fileName := pathpkg.Base(task.source)
+		if fileName == "" || fileName == "." || fileName == "/" {
+			fileName = task.source
+		}
+		replaceFailedVideoBlock(documentID, task, fileName, reason, userAccessToken)
+		return videoResult{task: task, success: false, err: err}
+	}
+
 	localPath, fileName, cleanup, err := resolveMediaSource(task.source, task.basePath, ".mp4")
 	if err != nil {
 		syncPrintf("  ✗ 视频 %d 解析失败 (%s): %v\n", task.index, task.source, err)
-		return videoResult{task: task, success: false, err: err}
+		return failWith(fmt.Sprintf("解析失败: %v", err), err)
 	}
 	defer cleanup()
 
-	const maxVideoSize = 20 * 1024 * 1024
 	fi, err := os.Stat(localPath)
 	if err != nil {
 		syncPrintf("  ✗ 视频 %d 文件信息获取失败: %v\n", task.index, err)
-		return videoResult{task: task, success: false, err: err}
+		return failWith(fmt.Sprintf("文件信息获取失败: %v", err), err)
 	}
-	if fi.Size() > maxVideoSize {
-		err := fmt.Errorf("视频超过 20MB 限制 (%d MB)，当前上传通道暂不支持大文件分块上传", fi.Size()/(1024*1024))
+	if fi.Size() > maxInlineVideoSize {
+		sizeMB := float64(fi.Size()) / (1024 * 1024)
+		err := fmt.Errorf("视频超过 %.1f MB 限制 (当前 %.1f MB)，当前上传通道暂不支持大文件分块上传",
+			float64(maxInlineVideoSize)/(1024*1024), sizeMB)
 		syncPrintf("  ✗ 视频 %d: %v\n", task.index, err)
-		return videoResult{task: task, success: false, err: err}
+		return failWith(fmt.Sprintf("超过 %.1f MB 限制", float64(maxInlineVideoSize)/(1024*1024)), err)
 	}
 
 	extra := fmt.Sprintf(`{"drive_route_token":"%s"}`, documentID)
@@ -1135,7 +1155,7 @@ func processVideoTask(documentID string, task videoTask, verbose bool, userAcces
 	}, retryCfg)
 	if uploadResult.Err != nil {
 		syncPrintf("  ✗ 视频 %d 上传失败 (%s): %v\n", task.index, task.source, uploadResult.Err)
-		return videoResult{task: task, success: false, err: uploadResult.Err}
+		return failWith(fmt.Sprintf("上传失败: %v", uploadResult.Err), uploadResult.Err)
 	}
 
 	fileToken := uploadResult.Value
@@ -1146,13 +1166,60 @@ func processVideoTask(documentID string, task videoTask, verbose bool, userAcces
 	}, retryCfg)
 	if replaceResult.Err != nil {
 		syncPrintf("  ✗ 视频 %d 绑定失败 (token=%s): %v\n", task.index, fileToken, replaceResult.Err)
-		return videoResult{task: task, success: false, err: replaceResult.Err}
+		return failWith(fmt.Sprintf("绑定失败: %v", replaceResult.Err), replaceResult.Err)
 	}
 
 	if verbose {
 		syncPrintf("  ✓ 视频 %d 成功 (%s)\n", task.index, task.source)
 	}
 	return videoResult{task: task, success: true}
+}
+
+// replaceFailedVideoBlock 将上传失败的视频 File 块替换为可见的占位 Text 块，
+// 避免阶段 1 创建的空 File 块在文档中变成孤儿（用户看不到任何内容）。
+// 由于飞书 PatchBlock 不支持跨类型变更，这里采用"删除 + 同位置插入 Text"的策略，
+// 模式与 phase3HandleFallbacks 一致。占位失败仅记日志，不让整体导入崩溃。
+func replaceFailedVideoBlock(documentID string, task videoTask, fileName, reason, userAccessToken string) {
+	placeholder := fmt.Sprintf("[视频上传失败：%s (%s)]", fileName, reason)
+
+	// 1. 在文档顶层子块中找到该 File 块的索引
+	children, err := client.GetAllBlockChildren(documentID, documentID, userAccessToken)
+	if err != nil {
+		syncPrintf("  ⚠ 视频 %d 占位块创建失败（无法获取子块列表）: %v\n", task.index, err)
+		return
+	}
+	idx := -1
+	for i, child := range children {
+		if child.BlockId != nil && *child.BlockId == task.fileBlockID {
+			idx = i
+			break
+		}
+	}
+	if idx < 0 {
+		syncPrintf("  ⚠ 视频 %d 占位块创建跳过（File 块未在顶层找到，可能位于嵌套容器内）\n", task.index)
+		return
+	}
+
+	// 2. 删除空 File 块
+	if _, err := client.DeleteBlocks(documentID, documentID, idx, idx+1, userAccessToken); err != nil {
+		syncPrintf("  ⚠ 视频 %d 占位块创建失败（删除原 File 块失败）: %v\n", task.index, err)
+		return
+	}
+
+	// 3. 在原位置插入 Text 占位块
+	textBlockType := 2 // Text block
+	textBlock := &larkdocx.Block{
+		BlockType: &textBlockType,
+		Text: &larkdocx.Text{
+			Elements: []*larkdocx.TextElement{
+				{TextRun: &larkdocx.TextRun{Content: &placeholder}},
+			},
+		},
+	}
+	if _, _, err := client.CreateBlock(documentID, documentID, []*larkdocx.Block{textBlock}, idx, userAccessToken); err != nil {
+		syncPrintf("  ⚠ 视频 %d 占位块创建失败（插入 Text 块失败）: %v\n", task.index, err)
+		return
+	}
 }
 
 func validateWorkerCount(flagName string, value int) error {

--- a/cmd/import_markdown_test.go
+++ b/cmd/import_markdown_test.go
@@ -168,8 +168,8 @@ func TestProcessVideoTaskRejectsFilesOverUploadAllLimit(t *testing.T) {
 	if result.success {
 		t.Fatal("processVideoTask() success = true, want false")
 	}
-	if result.err == nil || !strings.Contains(result.err.Error(), "视频超过 20MB 限制") {
-		t.Fatalf("processVideoTask() err = %v, want 20MB limit error", result.err)
+	if result.err == nil || !strings.Contains(result.err.Error(), "视频超过") {
+		t.Fatalf("processVideoTask() err = %v, want video size limit error", result.err)
 	}
 }
 

--- a/cmd/import_markdown_test.go
+++ b/cmd/import_markdown_test.go
@@ -5,7 +5,11 @@ import (
 	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
+
+	larkdocx "github.com/larksuite/oapi-sdk-go/v3/service/docx/v1"
+	"github.com/riba2534/feishu-cli/internal/converter"
 )
 
 func TestValidateWorkerCount(t *testing.T) {
@@ -95,4 +99,91 @@ func TestResolveImageSourceHTTPURLWithoutPathName(t *testing.T) {
 	if filepath.Ext(localPath) != ".png" {
 		t.Fatalf("temp file ext = %q, want %q", filepath.Ext(localPath), ".png")
 	}
+}
+
+func TestAppendVideoTasksIncludesNestedVideosInTreeOrder(t *testing.T) {
+	topVideo := videoNode("top.mp4")
+	grid := &converter.BlockNode{
+		Block: blockWithType(converter.BlockTypeGrid),
+		Children: []*converter.BlockNode{
+			videoNode("nested-a.mp4"),
+			{
+				Block: blockWithType(converter.BlockTypeQuoteContainer),
+				Children: []*converter.BlockNode{
+					videoNode("nested-b.mp4"),
+				},
+			},
+		},
+	}
+
+	tasks := appendVideoTasks(nil,
+		[]*converter.BlockNode{topVideo, grid},
+		[]string{"top-id", "grid-id"},
+		map[int][]createdBlockNode{
+			1: {
+				{node: grid.Children[0], blockID: "nested-a-id"},
+				{node: grid.Children[1], blockID: "quote-id"},
+				{node: grid.Children[1].Children[0], blockID: "nested-b-id"},
+			},
+		},
+		[]string{"./top.mp4", "./nested-a.mp4", "./nested-b.mp4"},
+		"/tmp",
+	)
+
+	if len(tasks) != 3 {
+		t.Fatalf("len(tasks) = %d, want 3", len(tasks))
+	}
+	wantIDs := []string{"top-id", "nested-a-id", "nested-b-id"}
+	wantSources := []string{"./top.mp4", "./nested-a.mp4", "./nested-b.mp4"}
+	for i := range tasks {
+		if tasks[i].fileBlockID != wantIDs[i] || tasks[i].source != wantSources[i] {
+			t.Fatalf("task[%d] = {id:%q source:%q}, want {id:%q source:%q}",
+				i, tasks[i].fileBlockID, tasks[i].source, wantIDs[i], wantSources[i])
+		}
+	}
+}
+
+func TestProcessVideoTaskRejectsFilesOverUploadAllLimit(t *testing.T) {
+	baseDir := t.TempDir()
+	videoPath := filepath.Join(baseDir, "large.mp4")
+	f, err := os.Create(videoPath)
+	if err != nil {
+		t.Fatalf("create video: %v", err)
+	}
+	if err := f.Truncate(20*1024*1024 + 1); err != nil {
+		_ = f.Close()
+		t.Fatalf("truncate video: %v", err)
+	}
+	if err := f.Close(); err != nil {
+		t.Fatalf("close video: %v", err)
+	}
+
+	result := processVideoTask("doc-token", videoTask{
+		index:       1,
+		fileBlockID: "block-id",
+		source:      "large.mp4",
+		basePath:    baseDir,
+	}, false, "user-token")
+
+	if result.success {
+		t.Fatal("processVideoTask() success = true, want false")
+	}
+	if result.err == nil || !strings.Contains(result.err.Error(), "视频超过 20MB 限制") {
+		t.Fatalf("processVideoTask() err = %v, want 20MB limit error", result.err)
+	}
+}
+
+func videoNode(name string) *converter.BlockNode {
+	blockType := int(converter.BlockTypeFile)
+	return &converter.BlockNode{
+		Block: &larkdocx.Block{
+			BlockType: &blockType,
+			File:      &larkdocx.File{Name: &name},
+		},
+	}
+}
+
+func blockWithType(blockType converter.BlockType) *larkdocx.Block {
+	bt := int(blockType)
+	return &larkdocx.Block{BlockType: &bt}
 }

--- a/internal/converter/block_html_tags_test.go
+++ b/internal/converter/block_html_tags_test.go
@@ -249,6 +249,28 @@ func TestImportFileWithViewType(t *testing.T) {
 	}
 }
 
+func TestImportVideoWithLocalSrc(t *testing.T) {
+	md := "<video src=\"./demo.mp4\" controls></video>\n"
+	conv := NewMarkdownToBlock([]byte(md), ConvertOptions{UploadImages: true}, "")
+	result, err := conv.ConvertWithTableData()
+	if err != nil {
+		t.Fatalf("error = %v", err)
+	}
+	if len(result.BlockNodes) != 1 {
+		t.Fatalf("expected 1 block, got %d", len(result.BlockNodes))
+	}
+	block := result.BlockNodes[0].Block
+	if int(BlockType(*block.BlockType)) != int(BlockTypeFile) {
+		t.Fatalf("expected File block type (23), got %d", *block.BlockType)
+	}
+	if block.File == nil || block.File.Name == nil || *block.File.Name != "demo.mp4" {
+		t.Fatalf("expected file name demo.mp4, got %#v", block.File)
+	}
+	if len(result.VideoSources) != 1 || result.VideoSources[0] != "./demo.mp4" {
+		t.Fatalf("expected video source ./demo.mp4, got %#v", result.VideoSources)
+	}
+}
+
 // ===========================================================================
 // Phase 3: Block-level HTML Tag Export Tests
 // ===========================================================================

--- a/internal/converter/block_to_markdown.go
+++ b/internal/converter/block_to_markdown.go
@@ -1089,9 +1089,8 @@ func (c *BlockToMarkdown) convertVideoFile(token, name string, viewType *int) (s
 		attrs = append(attrs, fmt.Sprintf("src=\"feishu://media/%s\"", token))
 	}
 	attrs = appendVideoMetadata(attrs, name, viewType)
-	if len(attrs) == 1 {
-		return "", nil
-	}
+	// 即使没有 token 也输出最小占位标签，避免视频块在导出 Markdown 中被静默丢失。
+	// 与 appendVideoMetadata 现有风格一致，name 不做额外转义。
 	return fmt.Sprintf("<video %s></video>\n", strings.Join(attrs, " ")), nil
 }
 

--- a/internal/converter/block_to_markdown.go
+++ b/internal/converter/block_to_markdown.go
@@ -1024,12 +1024,25 @@ func (c *BlockToMarkdown) convertFile(block *larkdocx.Block) (string, error) {
 		return "", nil
 	}
 
-	var attrs []string
-	if block.File.Token != nil && *block.File.Token != "" {
-		attrs = append(attrs, fmt.Sprintf("token=\"%s\"", *block.File.Token))
+	token := ""
+	if block.File.Token != nil {
+		token = *block.File.Token
 	}
-	if block.File.Name != nil && *block.File.Name != "" {
-		attrs = append(attrs, fmt.Sprintf("name=\"%s\"", *block.File.Name))
+	name := ""
+	if block.File.Name != nil {
+		name = *block.File.Name
+	}
+
+	if isVideoFilename(name) {
+		return c.convertVideoFile(token, name, block.File.ViewType)
+	}
+
+	var attrs []string
+	if token != "" {
+		attrs = append(attrs, fmt.Sprintf("token=\"%s\"", token))
+	}
+	if name != "" {
+		attrs = append(attrs, fmt.Sprintf("name=\"%s\"", name))
 	}
 	if block.File.ViewType != nil && *block.File.ViewType > 0 {
 		attrs = append(attrs, fmt.Sprintf("view-type=\"%d\"", *block.File.ViewType))
@@ -1040,6 +1053,61 @@ func (c *BlockToMarkdown) convertFile(block *larkdocx.Block) (string, error) {
 	}
 
 	return fmt.Sprintf("<file %s/>\n", strings.Join(attrs, " ")), nil
+}
+
+func (c *BlockToMarkdown) convertVideoFile(token, name string, viewType *int) (string, error) {
+	attrs := []string{"controls"}
+
+	if token != "" && c.options.DownloadImages {
+		c.imageCount++
+		filename := name
+		if filename == "" {
+			filename = fmt.Sprintf("video_%d.mp4", c.imageCount)
+		}
+		if filepath.Ext(filename) == "" {
+			filename += ".mp4"
+		}
+
+		if err := os.MkdirAll(c.options.AssetsDir, 0755); err != nil {
+			return "", fmt.Errorf("创建资源目录失败: %w", err)
+		}
+
+		localPath := filepath.Join(c.options.AssetsDir, filename)
+		dlOpts := client.DownloadMediaOptions{UserAccessToken: c.options.UserAccessToken, DocToken: c.options.DocumentID}
+		if tmpURL, err := client.GetMediaTempURL(token, dlOpts); err == nil {
+			if dlErr := client.DownloadFromURL(tmpURL, localPath); dlErr == nil {
+				attrs = append(attrs, fmt.Sprintf("src=\"%s\"", localPath))
+				return fmt.Sprintf("<video %s></video>\n", strings.Join(attrs, " ")), nil
+			}
+		}
+		if err := client.DownloadMedia(token, localPath, dlOpts); err == nil {
+			attrs = append(attrs, fmt.Sprintf("src=\"%s\"", localPath))
+			return fmt.Sprintf("<video %s></video>\n", strings.Join(attrs, " ")), nil
+		}
+	}
+
+	if token != "" {
+		attrs = append(attrs, fmt.Sprintf("src=\"feishu://media/%s\"", token))
+	}
+	if name != "" {
+		attrs = append(attrs, fmt.Sprintf("data-name=\"%s\"", name))
+	}
+	if viewType != nil && *viewType > 0 {
+		attrs = append(attrs, fmt.Sprintf("data-view-type=\"%d\"", *viewType))
+	}
+	if len(attrs) == 1 {
+		return "", nil
+	}
+	return fmt.Sprintf("<video %s></video>\n", strings.Join(attrs, " ")), nil
+}
+
+func isVideoFilename(name string) bool {
+	switch strings.ToLower(filepath.Ext(name)) {
+	case ".mp4", ".mov", ".m4v", ".webm", ".avi", ".mkv":
+		return true
+	default:
+		return false
+	}
 }
 
 func (c *BlockToMarkdown) convertBitable(block *larkdocx.Block) (string, error) {

--- a/internal/converter/block_to_markdown.go
+++ b/internal/converter/block_to_markdown.go
@@ -23,6 +23,8 @@ type BlockToMarkdown struct {
 	childBlockIDs map[string]bool // 子块 ID 集合，这些块不应独立处理
 	options       ConvertOptions
 	imageCount    int
+	videoCount    int
+	videoFiles    map[string]bool
 	headingSeqs   []string                   // 标题自动编号状态，按深度索引（depth-1）
 	userCache     map[string]MentionUserInfo // 用户 ID → 信息缓存
 }
@@ -1033,7 +1035,7 @@ func (c *BlockToMarkdown) convertFile(block *larkdocx.Block) (string, error) {
 		name = *block.File.Name
 	}
 
-	if isVideoFilename(name) {
+	if IsVideoFilename(name) {
 		return c.convertVideoFile(token, name, block.File.ViewType)
 	}
 
@@ -1059,51 +1061,85 @@ func (c *BlockToMarkdown) convertVideoFile(token, name string, viewType *int) (s
 	attrs := []string{"controls"}
 
 	if token != "" && c.options.DownloadImages {
-		c.imageCount++
-		filename := name
-		if filename == "" {
-			filename = fmt.Sprintf("video_%d.mp4", c.imageCount)
-		}
-		if filepath.Ext(filename) == "" {
-			filename += ".mp4"
-		}
-
 		if err := os.MkdirAll(c.options.AssetsDir, 0755); err != nil {
 			return "", fmt.Errorf("创建资源目录失败: %w", err)
 		}
 
-		localPath := filepath.Join(c.options.AssetsDir, filename)
+		localPath := c.nextVideoAssetPath(name)
 		dlOpts := client.DownloadMediaOptions{UserAccessToken: c.options.UserAccessToken, DocToken: c.options.DocumentID}
 		if tmpURL, err := client.GetMediaTempURL(token, dlOpts); err == nil {
 			if dlErr := client.DownloadFromURL(tmpURL, localPath); dlErr == nil {
-				attrs = append(attrs, fmt.Sprintf("src=\"%s\"", localPath))
+				attrs = appendVideoMetadata(append(attrs, fmt.Sprintf("src=\"%s\"", localPath)), name, viewType)
 				return fmt.Sprintf("<video %s></video>\n", strings.Join(attrs, " ")), nil
+			} else if c.options.Debug {
+				fmt.Fprintf(os.Stderr, "[Debug] 视频下载失败 (URL方式): %v\n", dlErr)
 			}
+		} else if c.options.Debug {
+			fmt.Fprintf(os.Stderr, "[Debug] 获取视频临时URL失败: %v\n", err)
 		}
 		if err := client.DownloadMedia(token, localPath, dlOpts); err == nil {
-			attrs = append(attrs, fmt.Sprintf("src=\"%s\"", localPath))
+			attrs = appendVideoMetadata(append(attrs, fmt.Sprintf("src=\"%s\"", localPath)), name, viewType)
 			return fmt.Sprintf("<video %s></video>\n", strings.Join(attrs, " ")), nil
+		} else if c.options.Debug {
+			fmt.Fprintf(os.Stderr, "[Debug] 视频SDK下载失败: %v\n", err)
 		}
 	}
 
 	if token != "" {
 		attrs = append(attrs, fmt.Sprintf("src=\"feishu://media/%s\"", token))
 	}
-	if name != "" {
-		attrs = append(attrs, fmt.Sprintf("data-name=\"%s\"", name))
-	}
-	if viewType != nil && *viewType > 0 {
-		attrs = append(attrs, fmt.Sprintf("data-view-type=\"%d\"", *viewType))
-	}
+	attrs = appendVideoMetadata(attrs, name, viewType)
 	if len(attrs) == 1 {
 		return "", nil
 	}
 	return fmt.Sprintf("<video %s></video>\n", strings.Join(attrs, " ")), nil
 }
 
-func isVideoFilename(name string) bool {
+func appendVideoMetadata(attrs []string, name string, viewType *int) []string {
+	if name != "" {
+		attrs = append(attrs, fmt.Sprintf("data-name=\"%s\"", name))
+	}
+	if viewType != nil && *viewType > 0 {
+		attrs = append(attrs, fmt.Sprintf("data-view-type=\"%d\"", *viewType))
+	}
+	return attrs
+}
+
+func (c *BlockToMarkdown) nextVideoAssetPath(name string) string {
+	c.videoCount++
+	filename := name
+	if filename == "" {
+		filename = fmt.Sprintf("video_%d.mp4", c.videoCount)
+	}
+	if filepath.Ext(filename) == "" {
+		filename += ".mp4"
+	}
+	return filepath.Join(c.options.AssetsDir, c.reserveUniqueVideoFilename(filename))
+}
+
+func (c *BlockToMarkdown) reserveUniqueVideoFilename(filename string) string {
+	if c.videoFiles == nil {
+		c.videoFiles = make(map[string]bool)
+	}
+
+	ext := filepath.Ext(filename)
+	base := strings.TrimSuffix(filename, ext)
+	candidate := filename
+	for i := 2; ; i++ {
+		if !c.videoFiles[candidate] {
+			if _, err := os.Stat(filepath.Join(c.options.AssetsDir, candidate)); os.IsNotExist(err) {
+				c.videoFiles[candidate] = true
+				return candidate
+			}
+		}
+		candidate = fmt.Sprintf("%s_%d%s", base, i, ext)
+	}
+}
+
+// IsVideoFilename reports whether name uses an extension that should roundtrip as a video file.
+func IsVideoFilename(name string) bool {
 	switch strings.ToLower(filepath.Ext(name)) {
-	case ".mp4", ".mov", ".m4v", ".webm", ".avi", ".mkv":
+	case ".mp4", ".mov", ".m4v", ".webm", ".avi", ".mkv", ".flv", ".wmv", ".mpeg", ".mpg", ".3gp", ".ogv":
 		return true
 	default:
 		return false

--- a/internal/converter/block_to_markdown_container_test.go
+++ b/internal/converter/block_to_markdown_container_test.go
@@ -1538,6 +1538,20 @@ func TestConvertFile(t *testing.T) {
 			},
 			want: `<file token="file_abc123" name="document.pdf"/>`,
 		},
+		{
+			name: "video file exported as video tag",
+			blocks: []*larkdocx.Block{
+				{
+					BlockId:   strPtr("file2"),
+					BlockType: intPtr(int(BlockTypeFile)),
+					File: &larkdocx.File{
+						Token: strPtr("file_video_123"),
+						Name:  strPtr("demo.mp4"),
+					},
+				},
+			},
+			want: `<video controls src="feishu://media/file_video_123" data-name="demo.mp4"></video>`,
+		},
 	}
 
 	for _, tt := range tests {

--- a/internal/converter/block_to_markdown_container_test.go
+++ b/internal/converter/block_to_markdown_container_test.go
@@ -1,6 +1,8 @@
 package converter
 
 import (
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -1545,12 +1547,13 @@ func TestConvertFile(t *testing.T) {
 					BlockId:   strPtr("file2"),
 					BlockType: intPtr(int(BlockTypeFile)),
 					File: &larkdocx.File{
-						Token: strPtr("file_video_123"),
-						Name:  strPtr("demo.mp4"),
+						Token:    strPtr("file_video_123"),
+						Name:     strPtr("demo.mp4"),
+						ViewType: intPtr(1),
 					},
 				},
 			},
-			want: `<video controls src="feishu://media/file_video_123" data-name="demo.mp4"></video>`,
+			want: `<video controls src="feishu://media/file_video_123" data-name="demo.mp4" data-view-type="1"></video>`,
 		},
 	}
 
@@ -1567,6 +1570,81 @@ func TestConvertFile(t *testing.T) {
 				t.Errorf("Convert() got:\n%s\n\nwant:\n%s", got, tt.want)
 			}
 		})
+	}
+}
+
+func TestVideoAssetFilenamesUseIndependentCounterAndAvoidCollisions(t *testing.T) {
+	assetsDir := t.TempDir()
+	conv := NewBlockToMarkdown(nil, ConvertOptions{AssetsDir: assetsDir})
+
+	first := conv.nextVideoAssetPath("")
+	second := conv.nextVideoAssetPath("")
+	if filepath.Base(first) != "video_1.mp4" || filepath.Base(second) != "video_2.mp4" {
+		t.Fatalf("default video names = %q, %q; want video_1.mp4, video_2.mp4", filepath.Base(first), filepath.Base(second))
+	}
+
+	existing := filepath.Join(assetsDir, "demo.mp4")
+	if err := os.WriteFile(existing, []byte("reserved"), 0644); err != nil {
+		t.Fatalf("write existing video: %v", err)
+	}
+	third := conv.nextVideoAssetPath("demo.mp4")
+	fourth := conv.nextVideoAssetPath("demo.mp4")
+	if filepath.Base(third) != "demo_2.mp4" || filepath.Base(fourth) != "demo_3.mp4" {
+		t.Fatalf("deduped names = %q, %q; want demo_2.mp4, demo_3.mp4", filepath.Base(third), filepath.Base(fourth))
+	}
+}
+
+func TestIsVideoFilenameRecognizesCommonFormats(t *testing.T) {
+	for _, name := range []string{"a.mp4", "a.mov", "a.m4v", "a.webm", "a.avi", "a.mkv", "a.flv", "a.wmv", "a.mpeg", "a.mpg", "a.3gp", "a.ogv"} {
+		if !IsVideoFilename(name) {
+			t.Fatalf("IsVideoFilename(%q) = false, want true", name)
+		}
+	}
+	if IsVideoFilename("a.pdf") {
+		t.Fatal("IsVideoFilename(a.pdf) = true, want false")
+	}
+}
+
+func TestRoundtripVideoFilePreservesTokenNameAndViewType(t *testing.T) {
+	blocks := []*larkdocx.Block{
+		{
+			BlockId:   strPtr("video1"),
+			BlockType: intPtr(int(BlockTypeFile)),
+			File: &larkdocx.File{
+				Token:    strPtr("file_video_123"),
+				Name:     strPtr("demo.mp4"),
+				ViewType: intPtr(1),
+			},
+		},
+	}
+
+	exporter := NewBlockToMarkdown(blocks, ConvertOptions{})
+	md, err := exporter.Convert()
+	if err != nil {
+		t.Fatalf("export video: %v", err)
+	}
+
+	importer := NewMarkdownToBlock([]byte(md), ConvertOptions{UploadImages: true}, "")
+	result, err := importer.ConvertWithTableData()
+	if err != nil {
+		t.Fatalf("import video: %v", err)
+	}
+	if len(result.BlockNodes) != 1 {
+		t.Fatalf("len(BlockNodes) = %d, want 1", len(result.BlockNodes))
+	}
+
+	file := result.BlockNodes[0].Block.File
+	if file == nil {
+		t.Fatal("expected File block after roundtrip")
+	}
+	if file.Token == nil || *file.Token != "file_video_123" {
+		t.Fatalf("token = %#v, want file_video_123", file.Token)
+	}
+	if file.Name == nil || *file.Name != "demo.mp4" {
+		t.Fatalf("name = %#v, want demo.mp4", file.Name)
+	}
+	if file.ViewType == nil || *file.ViewType != 1 {
+		t.Fatalf("viewType = %#v, want 1", file.ViewType)
 	}
 }
 

--- a/internal/converter/markdown_to_block.go
+++ b/internal/converter/markdown_to_block.go
@@ -2503,9 +2503,35 @@ func (c *MarkdownToBlock) handleHTMLVideoBlock(tag *HTMLTag) []*BlockNode {
 		return nil
 	}
 
+	name := strings.TrimSpace(tag.Attrs["data-name"])
+	if name == "" {
+		name = strings.TrimSpace(tag.Attrs["name"])
+	}
+	viewType := parseHTMLIntAttrDefault(tag.Attrs["data-view-type"], 0)
+	if viewType <= 0 {
+		viewType = parseHTMLIntAttrDefault(tag.Attrs["view-type"], 2)
+	}
+	if viewType <= 0 {
+		viewType = 2
+	}
+
 	if strings.HasPrefix(src, "feishu://media/") {
-		c.videoStats.Skipped++
-		return []*BlockNode{{Block: c.createMediaPlaceholder("Video", src)}}
+		token := strings.TrimPrefix(src, "feishu://media/")
+		if token == "" {
+			return nil
+		}
+		blockType := int(BlockTypeFile)
+		file := &larkdocx.File{
+			Token:    &token,
+			ViewType: &viewType,
+		}
+		if name != "" {
+			file.Name = &name
+		}
+		return []*BlockNode{{Block: &larkdocx.Block{
+			BlockType: &blockType,
+			File:      file,
+		}}}
 	}
 
 	if !c.options.UploadImages {
@@ -2513,15 +2539,16 @@ func (c *MarkdownToBlock) handleHTMLVideoBlock(tag *HTMLTag) []*BlockNode {
 		return []*BlockNode{{Block: c.createMediaPlaceholder("Video", src)}}
 	}
 
-	name := filepath.Base(src)
 	if name == "." || name == string(filepath.Separator) || name == "" {
-		name = "video.mp4"
+		name = filepath.Base(src)
+		if name == "." || name == string(filepath.Separator) || name == "" {
+			name = "video.mp4"
+		}
 	}
 
 	c.videoStats.Total++
 	c.videoSources = append(c.videoSources, src)
 	blockType := int(BlockTypeFile)
-	viewType := 2
 	return []*BlockNode{{Block: &larkdocx.Block{
 		BlockType: &blockType,
 		File: &larkdocx.File{

--- a/internal/converter/markdown_to_block.go
+++ b/internal/converter/markdown_to_block.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"fmt"
 	"net/url"
+	"path/filepath"
 	"regexp"
 	"strings"
 
@@ -151,6 +152,8 @@ type MarkdownToBlock struct {
 	basePath     string // base path for resolving relative image paths
 	imageStats   ImageStats
 	imageSources []string // 记录每个 Image Block 对应的图片来源路径
+	videoStats   VideoStats
+	videoSources []string // 记录每个视频 File Block 对应的视频来源路径
 }
 
 // NewMarkdownToBlock creates a new converter
@@ -337,6 +340,8 @@ func (c *MarkdownToBlock) ConvertWithTableData() (*ConvertResult, error) {
 
 	result.ImageStats = c.imageStats
 	result.ImageSources = c.imageSources
+	result.VideoStats = c.videoStats
+	result.VideoSources = c.videoSources
 	return result, nil
 }
 
@@ -406,6 +411,9 @@ func (c *MarkdownToBlock) convertParagraph(node *ast.Paragraph) ([]*BlockNode, e
 
 	// 检查段落是否只包含一个 <image> HTML 标签
 	if block := c.tryConvertHTMLImageParagraph(node); block != nil {
+		return []*BlockNode{{Block: block}}, nil
+	}
+	if block := c.tryConvertHTMLVideoParagraph(node); block != nil {
 		return []*BlockNode{{Block: block}}, nil
 	}
 
@@ -2199,6 +2207,8 @@ func (c *MarkdownToBlock) handleBlockHTMLTag(tag *HTMLTag) []*BlockNode {
 		return c.handleHTMLBitableBlock(tag)
 	case "file":
 		return c.handleHTMLFileBlock(tag)
+	case "video":
+		return c.handleHTMLVideoBlock(tag)
 	}
 	return nil
 }
@@ -2384,6 +2394,9 @@ func (c *MarkdownToBlock) convertInnerMarkdown(markdown string) []*BlockNode {
 	c.imageStats.Total += inner.imageStats.Total
 	c.imageStats.Skipped += inner.imageStats.Skipped
 	c.imageSources = append(c.imageSources, inner.imageSources...)
+	c.videoStats.Total += inner.videoStats.Total
+	c.videoStats.Skipped += inner.videoStats.Skipped
+	c.videoSources = append(c.videoSources, inner.videoSources...)
 	return result.BlockNodes
 }
 
@@ -2483,6 +2496,41 @@ func (c *MarkdownToBlock) handleHTMLFileBlock(tag *HTMLTag) []*BlockNode {
 	}}}
 }
 
+// handleHTMLVideoBlock 处理 <video src="./demo.mp4" controls></video> → File Block (type=23)
+func (c *MarkdownToBlock) handleHTMLVideoBlock(tag *HTMLTag) []*BlockNode {
+	src := strings.TrimSpace(tag.Attrs["src"])
+	if src == "" {
+		return nil
+	}
+
+	if strings.HasPrefix(src, "feishu://media/") {
+		c.videoStats.Skipped++
+		return []*BlockNode{{Block: c.createMediaPlaceholder("Video", src)}}
+	}
+
+	if !c.options.UploadImages {
+		c.videoStats.Skipped++
+		return []*BlockNode{{Block: c.createMediaPlaceholder("Video", src)}}
+	}
+
+	name := filepath.Base(src)
+	if name == "." || name == string(filepath.Separator) || name == "" {
+		name = "video.mp4"
+	}
+
+	c.videoStats.Total++
+	c.videoSources = append(c.videoSources, src)
+	blockType := int(BlockTypeFile)
+	viewType := 2
+	return []*BlockNode{{Block: &larkdocx.Block{
+		BlockType: &blockType,
+		File: &larkdocx.File{
+			Name:     &name,
+			ViewType: &viewType,
+		},
+	}}}
+}
+
 // parseHTMLIntAttrDefault 解析 HTML 属性中的整数值，失败返回 defaultVal
 func parseHTMLIntAttrDefault(s string, defaultVal int) int {
 	if s == "" {
@@ -2532,6 +2580,56 @@ func (c *MarkdownToBlock) tryConvertHTMLImageParagraph(node *ast.Paragraph) *lar
 		return nodes[0].Block
 	}
 	return nil
+}
+
+// tryConvertHTMLVideoParagraph 检查段落是否只包含一个 <video> HTML 标签
+func (c *MarkdownToBlock) tryConvertHTMLVideoParagraph(node *ast.Paragraph) *larkdocx.Block {
+	var htmlBuf bytes.Buffer
+	onlyHTML := true
+	for child := node.FirstChild(); child != nil; child = child.NextSibling() {
+		if raw, ok := child.(*ast.RawHTML); ok {
+			for i := 0; i < raw.Segments.Len(); i++ {
+				seg := raw.Segments.At(i)
+				htmlBuf.Write(c.source[seg.Start:seg.Stop])
+			}
+		} else {
+			onlyHTML = false
+			break
+		}
+	}
+
+	if !onlyHTML || htmlBuf.Len() == 0 {
+		return nil
+	}
+
+	rawStr := strings.TrimSpace(htmlBuf.String())
+	if !IsHTMLTag(rawStr, "video") {
+		return nil
+	}
+
+	tag := ParseHTMLTag(rawStr)
+	if tag == nil {
+		return nil
+	}
+
+	nodes := c.handleHTMLVideoBlock(tag)
+	if len(nodes) > 0 {
+		return nodes[0].Block
+	}
+	return nil
+}
+
+func (c *MarkdownToBlock) createMediaPlaceholder(kind, ref string) *larkdocx.Block {
+	text := fmt.Sprintf("[%s: %s]", kind, ref)
+	blockType := int(BlockTypeText)
+	return &larkdocx.Block{
+		BlockType: &blockType,
+		Text: &larkdocx.Text{
+			Elements: []*larkdocx.TextElement{{
+				TextRun: &larkdocx.TextRun{Content: &text},
+			}},
+		},
+	}
 }
 
 // parseHTMLIntAttr 解析 HTML 属性中的整数值，失败返回 0

--- a/internal/converter/markdown_to_block_extended_test.go
+++ b/internal/converter/markdown_to_block_extended_test.go
@@ -1068,6 +1068,50 @@ func TestMarkdownToBlockImage(t *testing.T) {
 	}
 }
 
+func TestMarkdownToBlockVideo(t *testing.T) {
+	tests := []struct {
+		name     string
+		markdown string
+		options  ConvertOptions
+		checkFn  func(*testing.T, *ConvertResult)
+	}{
+		{
+			name:     "UploadImages=false 跳过 video",
+			markdown: "<video src=\"./demo.mp4\" controls></video>",
+			options:  ConvertOptions{UploadImages: false},
+			checkFn: func(t *testing.T, result *ConvertResult) {
+				if result.VideoStats.Skipped == 0 {
+					t.Error("expected video to be skipped")
+				}
+			},
+		},
+		{
+			name:     "本地路径 video 记录来源",
+			markdown: "<video src=\"./demo.mp4\" controls></video>",
+			options:  ConvertOptions{UploadImages: true},
+			checkFn: func(t *testing.T, result *ConvertResult) {
+				if result.VideoStats.Total != 1 {
+					t.Fatalf("expected 1 video total, got %d", result.VideoStats.Total)
+				}
+				if len(result.VideoSources) != 1 || result.VideoSources[0] != "./demo.mp4" {
+					t.Fatalf("unexpected video sources: %#v", result.VideoSources)
+				}
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			converter := NewMarkdownToBlock([]byte(tt.markdown), tt.options, "")
+			result, err := converter.ConvertWithTableData()
+			if err != nil {
+				t.Fatalf("ConvertWithTableData failed: %v", err)
+			}
+			tt.checkFn(t, result)
+		})
+	}
+}
+
 func TestMarkdownToBlockLargeTable(t *testing.T) {
 	// 构造超过 9 行的大表格
 	markdown := "| 列1 | 列2 |\n|-----|-----|\n"

--- a/internal/converter/markdown_to_block_extended_test.go
+++ b/internal/converter/markdown_to_block_extended_test.go
@@ -1087,7 +1087,7 @@ func TestMarkdownToBlockVideo(t *testing.T) {
 		},
 		{
 			name:     "本地路径 video 记录来源",
-			markdown: "<video src=\"./demo.mp4\" controls></video>",
+			markdown: "<video src=\"./demo.mp4\" controls data-name=\"original.mov\" data-view-type=\"1\"></video>",
 			options:  ConvertOptions{UploadImages: true},
 			checkFn: func(t *testing.T, result *ConvertResult) {
 				if result.VideoStats.Total != 1 {
@@ -1095,6 +1095,36 @@ func TestMarkdownToBlockVideo(t *testing.T) {
 				}
 				if len(result.VideoSources) != 1 || result.VideoSources[0] != "./demo.mp4" {
 					t.Fatalf("unexpected video sources: %#v", result.VideoSources)
+				}
+				file := result.BlockNodes[0].Block.File
+				if file == nil || file.Name == nil || *file.Name != "original.mov" {
+					t.Fatalf("expected video data-name to become file name, got %#v", file)
+				}
+				if file.ViewType == nil || *file.ViewType != 1 {
+					t.Fatalf("expected data-view-type=1, got %#v", file.ViewType)
+				}
+			},
+		},
+		{
+			name:     "feishu media video restores file block",
+			markdown: "<video controls src=\"feishu://media/file_video_123\" data-name=\"demo.mp4\" data-view-type=\"1\"></video>",
+			options:  ConvertOptions{UploadImages: true},
+			checkFn: func(t *testing.T, result *ConvertResult) {
+				if result.VideoStats.Skipped != 0 || len(result.VideoSources) != 0 {
+					t.Fatalf("feishu media token should not be counted as skipped upload, stats=%#v sources=%#v", result.VideoStats, result.VideoSources)
+				}
+				file := result.BlockNodes[0].Block.File
+				if file == nil {
+					t.Fatal("expected File block")
+				}
+				if file.Token == nil || *file.Token != "file_video_123" {
+					t.Fatalf("expected token file_video_123, got %#v", file.Token)
+				}
+				if file.Name == nil || *file.Name != "demo.mp4" {
+					t.Fatalf("expected name demo.mp4, got %#v", file.Name)
+				}
+				if file.ViewType == nil || *file.ViewType != 1 {
+					t.Fatalf("expected view type 1, got %#v", file.ViewType)
 				}
 			},
 		},

--- a/internal/converter/types.go
+++ b/internal/converter/types.go
@@ -111,6 +111,8 @@ type ConvertResult struct {
 	TableDatas   []*TableData // Table data in order of appearance, used for filling content
 	ImageStats   ImageStats   // 图片处理统计
 	ImageSources []string     // 每个 Image Block 对应的图片来源路径，与 BlockNodes 中的 Image Block 按序对应
+	VideoStats   VideoStats   // 视频处理统计
+	VideoSources []string     // 每个 Video(File) Block 对应的视频来源路径，与 BlockNodes 中的视频块按序对应
 }
 
 // ImageStats 记录图片处理统计
@@ -119,6 +121,14 @@ type ImageStats struct {
 	Success int // 上传成功数
 	Failed  int // 上传失败数
 	Skipped int // 跳过（feishu://media/ 引用或 upload-images=false）数
+}
+
+// VideoStats 记录视频处理统计
+type VideoStats struct {
+	Total   int // 需要上传/下载的视频总数
+	Success int // 成功数
+	Failed  int // 失败数
+	Skipped int // 跳过数
 }
 
 // MentionUserInfo 保存 @用户 的解析信息


### PR DESCRIPTION
## 背景

当前文档导出链路里，视频资源虽然能够作为文件资源被读到，但导出结果缺少明确的视频语义，导致 Markdown roundtrip 不够直观，也不利于后续继续渲染或复用。

本次改动的目标是：让文档中的视频在导出 Markdown 时，能够以 `video` 标签表达，并在开启资源下载时落到本地文件路径上。

## 本次改动

### 1. 导入侧支持 `video` 标签

- 在 Markdown 转块流程中新增对 `<video src="..."></video>` 的解析
- 支持把本地视频路径映射到文档资源上传流程
- 底层复用现有 `File Block` / `docx_file` 上传与绑定能力，不额外引入不可落地的原生视频块抽象

### 2. 导出侧识别视频文件并输出 `video` 标签

- 导出 Markdown 时识别视频文件块（如 `.mov` / `.mp4` 等）
- 优先将视频下载到本地资源目录
- 成功下载后输出 `<video controls src="本地路径"></video>`
- 下载失败时回退为 `feishu://media/...` 引用，保证信息不丢失且仍可 roundtrip

### 3. 补充测试与边界处理

- 增加视频导入、导出、roundtrip 相关测试
- 补齐内嵌 markdown（如 `grid/column`）场景下的视频统计与来源合并

## 行为对比

| 场景 | 修改前 | 修改后 |
| --- | --- | --- |
| 文档中包含视频资源 | 按普通文件处理 | 按视频语义处理 |
| 导出 Markdown 的标签形式 | `<file .../>` | `<video ...></video>` |
| 开启资源下载时 | 无法直接表达本地视频引用 | 下载到本地并输出 `<video controls src="./assets/xxx.mov"></video>` |
| 下载失败时 | 仅保留文件语义 | 回退为 `feishu://media/...` 的 `video` 标签引用 |

## 示例

### 修改前

```html
<file token="xxx" name="vscode-ls.mov"/>
```

### 修改后（下载成功）

```html
<video controls src="./assets/vscode-ls.mov"></video>
```

### 修改后（下载失败时回退）

```html
<video controls src="feishu://media/xxx" data-name="vscode-ls.mov"></video>
```

## 验证

已执行：

- `go test ./internal/converter ./cmd`

并使用实际知识库文档进行了导出验证，确认视频可以：

- 被识别为视频资源
- 下载到本地资源目录
- 导出为 `video` 标签并引用本地路径
