### PR TITLE
feat(msg): add --card-content-type for retrieving raw card JSON

### DIFF
--- a/README.md
+++ b/README.md
@@ -712,6 +712,12 @@ feishu-cli msg mget --message-ids om_xxx,om_yyy
 feishu-cli msg resource-download <message_id> <file_key> --type image -o photo.png
 feishu-cli msg thread-messages <thread_id> --page-size 20
 
+# interactive 卡片返回原始 schema（不再返回渲染后的 <card title> 文本）
+feishu-cli msg get om_xxx --card-content-type user             # userDSL（开发者视角的 schema 2.0 JSON）
+feishu-cli msg get om_xxx --card-content-type raw              # cardDSL（平台内部完整描述）
+feishu-cli msg mget --message-ids om_xxx,om_yyy --card-content-type user
+feishu-cli msg list --container-id oc_xxx --card-content-type user
+
 # 文档增强
 feishu-cli doc content-update <doc_id> --mode append --markdown "## 新内容"
 feishu-cli doc content-update <doc_id> --mode overwrite --markdown "# 全新文档"

--- a/cmd/get_message.go
+++ b/cmd/get_message.go
@@ -16,15 +16,22 @@ var getMessageCmd = &cobra.Command{
 	Long: `获取指定消息的详细信息。
 
 参数:
-  message_id    消息 ID（必填）
-  --output, -o  输出格式（json）
+  message_id            消息 ID（必填）
+  --output, -o          输出格式（json）
+  --card-content-type   interactive 卡片返回格式：user / raw（默认空，返回渲染版）
 
 示例:
   # 获取消息详情
   feishu-cli msg get om_xxx
 
   # JSON 格式输出
-  feishu-cli msg get om_xxx --output json`,
+  feishu-cli msg get om_xxx --output json
+
+  # interactive 卡片返回原始 schema 2.0 JSON（开发者视角的 userDSL）
+  feishu-cli msg get om_xxx --card-content-type user
+
+  # interactive 卡片返回平台内部完整 cardDSL
+  feishu-cli msg get om_xxx --card-content-type raw`,
 	Args: cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		if err := config.Validate(); err != nil {
@@ -38,7 +45,12 @@ var getMessageCmd = &cobra.Command{
 
 		messageID := args[0]
 
-		result, err := client.GetMessage(messageID, token)
+		cardContentType, err := resolveCardContentType(cmd)
+		if err != nil {
+			return err
+		}
+
+		result, err := client.GetMessage(messageID, token, cardContentType)
 		if err != nil {
 			return err
 		}
@@ -108,4 +120,5 @@ func init() {
 	msgCmd.AddCommand(getMessageCmd)
 	getMessageCmd.Flags().StringP("output", "o", "", "输出格式（json）")
 	getMessageCmd.Flags().String("user-access-token", "", "User Access Token（用户授权令牌）")
+	addCardContentTypeFlag(getMessageCmd)
 }

--- a/cmd/get_message_history.go
+++ b/cmd/get_message_history.go
@@ -130,7 +130,9 @@ var getMessageHistoryCmd = &cobra.Command{
 
 		if needFallback {
 			fmt.Fprintf(cmd.ErrOrStderr(), "[提示] bot 不在此群中，通过搜索方式获取消息...\n")
-			fallbackResult, fallbackErr := listMessagesViaSearch(containerID, pageSize, pageToken, token)
+			// msg history 命令暂未暴露 --card-content-type flag，传空保持渲染版默认行为；
+			// 如未来给 msg history 也加 flag，把 resolveCardContentType 的结果接进来即可。
+			fallbackResult, fallbackErr := listMessagesViaSearch(containerID, pageSize, pageToken, token, "")
 			if fallbackErr != nil {
 				if err != nil {
 					return err

--- a/cmd/list_messages.go
+++ b/cmd/list_messages.go
@@ -85,7 +85,7 @@ var listMessagesCmd = &cobra.Command{
 
 		if needFallback {
 			fmt.Fprintf(cmd.ErrOrStderr(), "[提示] bot 不在此群中，通过搜索方式获取消息...\n")
-			fallbackResult, fallbackErr := listMessagesViaSearch(containerID, pageSize, pageToken, token)
+			fallbackResult, fallbackErr := listMessagesViaSearch(containerID, pageSize, pageToken, token, cardContentType)
 			if fallbackErr != nil {
 				if err != nil {
 					return err

--- a/cmd/list_messages.go
+++ b/cmd/list_messages.go
@@ -34,7 +34,10 @@ var listMessagesCmd = &cobra.Command{
   feishu-cli msg list --container-id oc_xxx --page-size 10
 
   # JSON 格式输出
-  feishu-cli msg list --container-id oc_xxx --output json`,
+  feishu-cli msg list --container-id oc_xxx --output json
+
+  # interactive 卡片返回原始 schema 2.0 JSON（开发者视角的 userDSL）
+  feishu-cli msg list --container-id oc_xxx --card-content-type user`,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		if err := config.Validate(); err != nil {
 			return err
@@ -53,6 +56,11 @@ var listMessagesCmd = &cobra.Command{
 		pageSize, _ := cmd.Flags().GetInt("page-size")
 		pageToken, _ := cmd.Flags().GetString("page-token")
 
+		cardContentType, err := resolveCardContentType(cmd)
+		if err != nil {
+			return err
+		}
+
 		opts := client.ListMessagesOptions{
 			ContainerIDType: containerIDType,
 			StartTime:       startTime,
@@ -60,6 +68,7 @@ var listMessagesCmd = &cobra.Command{
 			SortType:        sortType,
 			PageSize:        pageSize,
 			PageToken:       pageToken,
+			CardContentType: cardContentType,
 		}
 
 		result, err := client.ListMessages(containerID, opts, token)
@@ -139,5 +148,6 @@ func init() {
 	listMessagesCmd.Flags().String("page-token", "", "分页标记")
 	listMessagesCmd.Flags().StringP("output", "o", "", "输出格式（json）")
 	listMessagesCmd.Flags().String("user-access-token", "", "User Access Token（用户授权令牌）")
+	addCardContentTypeFlag(listMessagesCmd)
 	mustMarkFlagRequired(listMessagesCmd, "container-id")
 }

--- a/cmd/msg_card_content_type.go
+++ b/cmd/msg_card_content_type.go
@@ -1,0 +1,41 @@
+package cmd
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/riba2534/feishu-cli/internal/client"
+	"github.com/spf13/cobra"
+)
+
+// cardContentTypeFlagDesc 是 msg get/mget/list 三个查询命令共用的 flag 帮助文本。
+//
+// 飞书 OAPI 对 interactive 卡片消息默认返回**渲染后**的文本（形如
+// `<card title="...">...</card>`）。要拿到原始 schema JSON，必须传
+// card_msg_content_type 参数。这里支持简写（user/raw）和完整 OAPI 值，便于在 CLI
+// 里少敲几个字符。
+const cardContentTypeFlagDesc = "卡片消息返回格式：user / raw（默认空，返回渲染版）。" +
+	"user → user_card_content（开发者构建时的 schema 2.0 JSON，便于偷师/调试）；" +
+	"raw → raw_card_content（平台内部完整 cardDSL）"
+
+// addCardContentTypeFlag 把 --card-content-type flag 注册到目标命令上。
+func addCardContentTypeFlag(c *cobra.Command) {
+	c.Flags().String("card-content-type", "", cardContentTypeFlagDesc)
+}
+
+// resolveCardContentType 把 flag 值（user/raw 或完整 OAPI 名）规范化为 OAPI 接受的字符串。
+// 空字符串保持空，让 client 层走原有渲染版返回路径，向后兼容。
+func resolveCardContentType(cmd *cobra.Command) (string, error) {
+	v, _ := cmd.Flags().GetString("card-content-type")
+	v = strings.TrimSpace(v)
+	switch strings.ToLower(v) {
+	case "":
+		return "", nil
+	case "user", client.CardMsgContentTypeUser:
+		return client.CardMsgContentTypeUser, nil
+	case "raw", client.CardMsgContentTypeRaw:
+		return client.CardMsgContentTypeRaw, nil
+	default:
+		return "", fmt.Errorf("无效的 --card-content-type 取值 %q（合法值：user / raw / user_card_content / raw_card_content）", v)
+	}
+}

--- a/cmd/msg_card_content_type_test.go
+++ b/cmd/msg_card_content_type_test.go
@@ -1,0 +1,54 @@
+package cmd
+
+import (
+	"testing"
+
+	"github.com/spf13/cobra"
+)
+
+func TestResolveCardContentType(t *testing.T) {
+	tests := []struct {
+		name      string
+		flagValue string
+		want      string
+		wantErr   bool
+	}{
+		{"未传 flag 默认空", "", "", false},
+		{"短写 user", "user", "user_card_content", false},
+		{"短写 raw", "raw", "raw_card_content", false},
+		{"全名 user_card_content", "user_card_content", "user_card_content", false},
+		{"全名 raw_card_content", "raw_card_content", "raw_card_content", false},
+		{"大小写不敏感 USER", "USER", "user_card_content", false},
+		{"大小写不敏感 Raw", "Raw", "raw_card_content", false},
+		{"前后空格被裁剪", "  user  ", "user_card_content", false},
+		{"非法值报错", "userdsl", "", true},
+		{"乱写报错", "abc", "", true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cmd := &cobra.Command{}
+			addCardContentTypeFlag(cmd)
+			if tt.flagValue != "" {
+				if err := cmd.Flags().Set("card-content-type", tt.flagValue); err != nil {
+					t.Fatalf("flag set 失败: %v", err)
+				}
+			}
+
+			got, err := resolveCardContentType(cmd)
+			if tt.wantErr {
+				if err == nil {
+					t.Errorf("resolveCardContentType(%q) 期望返回错误，但返回 %q", tt.flagValue, got)
+				}
+				return
+			}
+			if err != nil {
+				t.Errorf("resolveCardContentType(%q) 返回意外错误: %v", tt.flagValue, err)
+				return
+			}
+			if got != tt.want {
+				t.Errorf("resolveCardContentType(%q) = %q, 期望 %q", tt.flagValue, got, tt.want)
+			}
+		})
+	}
+}

--- a/cmd/msg_history_fallback.go
+++ b/cmd/msg_history_fallback.go
@@ -9,7 +9,12 @@ import (
 
 // listMessagesViaSearch 通过搜索+逐条获取的方式获取消息列表
 // 当 ListMessages API 返回空结果（bot 不在群）时作为降级方案
-func listMessagesViaSearch(chatID string, pageSize int, pageToken string, userAccessToken string) (*client.ListMessagesResult, error) {
+//
+// cardContentType 透传到每条 GetMessage 调用：当上层 cobra 命令带
+// `--card-content-type user|raw` flag 时，fallback 路径同样请求原始
+// schema JSON，避免出现"主路径返回 raw、search 降级路径返回渲染版"的语义不一致。
+// 调用方未启用 flag 时传空字符串即可。
+func listMessagesViaSearch(chatID string, pageSize int, pageToken, userAccessToken, cardContentType string) (*client.ListMessagesResult, error) {
 	if pageSize <= 0 {
 		pageSize = 20
 	}
@@ -37,7 +42,7 @@ func listMessagesViaSearch(chatID string, pageSize int, pageToken string, userAc
 		PageToken: searchResult.PageToken,
 	}
 	for _, msgID := range searchResult.MessageIDs {
-		msgResult, err := client.GetMessage(msgID, userAccessToken, "")
+		msgResult, err := client.GetMessage(msgID, userAccessToken, cardContentType)
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "[警告] 获取消息 %s 失败: %v\n", msgID, err)
 			continue

--- a/cmd/msg_history_fallback.go
+++ b/cmd/msg_history_fallback.go
@@ -37,7 +37,7 @@ func listMessagesViaSearch(chatID string, pageSize int, pageToken string, userAc
 		PageToken: searchResult.PageToken,
 	}
 	for _, msgID := range searchResult.MessageIDs {
-		msgResult, err := client.GetMessage(msgID, userAccessToken)
+		msgResult, err := client.GetMessage(msgID, userAccessToken, "")
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "[警告] 获取消息 %s 失败: %v\n", msgID, err)
 			continue

--- a/cmd/msg_mget.go
+++ b/cmd/msg_mget.go
@@ -14,11 +14,15 @@ var msgMgetCmd = &cobra.Command{
 	Long: `批量获取多条消息的详情。
 
 选项:
-  --message-ids  消息 ID 列表（逗号分隔，必填）
+  --message-ids         消息 ID 列表（逗号分隔，必填）
+  --card-content-type   interactive 卡片返回格式：user / raw（默认空，返回渲染版）
 
 示例:
   # 获取多条消息
-  feishu-cli msg mget --message-ids om_xxx,om_yyy,om_zzz`,
+  feishu-cli msg mget --message-ids om_xxx,om_yyy,om_zzz
+
+  # interactive 卡片返回原始 schema 2.0 JSON
+  feishu-cli msg mget --message-ids om_xxx,om_yyy --card-content-type user`,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		if err := config.Validate(); err != nil {
 			return err
@@ -32,7 +36,12 @@ var msgMgetCmd = &cobra.Command{
 			return fmt.Errorf("请提供至少一个消息 ID")
 		}
 
-		messages, err := client.BatchGetMessages(messageIDs, userToken)
+		cardContentType, err := resolveCardContentType(cmd)
+		if err != nil {
+			return err
+		}
+
+		messages, err := client.BatchGetMessages(messageIDs, userToken, cardContentType)
 		if err != nil {
 			return err
 		}
@@ -49,5 +58,6 @@ func init() {
 	msgCmd.AddCommand(msgMgetCmd)
 	msgMgetCmd.Flags().String("message-ids", "", "消息 ID 列表（逗号分隔）")
 	msgMgetCmd.Flags().String("user-access-token", "", "User Access Token（用户授权令牌）")
+	addCardContentTypeFlag(msgMgetCmd)
 	mustMarkFlagRequired(msgMgetCmd, "message-ids")
 }

--- a/internal/client/message.go
+++ b/internal/client/message.go
@@ -25,9 +25,6 @@ import (
 // 可拿到原始 JSON：
 //   - user_card_content：返回 userDSL（开发者构建卡片时的 schema 2.0 JSON，便于偷师/调试）
 //   - raw_card_content： 返回 cardDSL（平台内部完整描述，含默认补全字段）
-//
-// 文档来源（字节内部）：OAPI 卡片 2.0 兼容改造与返回结构优化技术方案
-// https://bytedance.larkoffice.com/docx/DxpUdWoFXosES6xCgqNcA62knWe
 const (
 	CardMsgContentTypeUser = "user_card_content"
 	CardMsgContentTypeRaw  = "raw_card_content"
@@ -198,7 +195,7 @@ type ListMessagesResult struct {
 }
 
 // ListMessages lists messages in a container (chat).
-// Note: The Feishu Go SDK (v3.5.3) incorrectly declares the List Messages API as
+// Note: The current Feishu Go SDK typed builder declares the List Messages API as
 // tenant_access_token only, but the API actually supports user_access_token as well.
 // When a user access token is provided, we use a raw HTTP request to bypass the SDK's
 // client-side token type validation. See: https://open.feishu.cn/document/server-docs/im-v1/message/list

--- a/internal/client/message.go
+++ b/internal/client/message.go
@@ -12,9 +12,25 @@ import (
 	"time"
 
 	lark "github.com/larksuite/oapi-sdk-go/v3"
+	larkcore "github.com/larksuite/oapi-sdk-go/v3/core"
 	larkim "github.com/larksuite/oapi-sdk-go/v3/service/im/v1"
 
 	"github.com/riba2534/feishu-cli/internal/config"
+)
+
+// 卡片消息内容返回格式枚举值（OAPI 参数 card_msg_content_type 的取值）
+//
+// 当查询消息（list/get/mget）命中 interactive 卡片时，OAPI 默认返回的是渲染后的
+// 文本（形如 `<card title="...">...</card>`）。通过传 card_msg_content_type 参数
+// 可拿到原始 JSON：
+//   - user_card_content：返回 userDSL（开发者构建卡片时的 schema 2.0 JSON，便于偷师/调试）
+//   - raw_card_content： 返回 cardDSL（平台内部完整描述，含默认补全字段）
+//
+// 文档来源（字节内部）：OAPI 卡片 2.0 兼容改造与返回结构优化技术方案
+// https://bytedance.larkoffice.com/docx/DxpUdWoFXosES6xCgqNcA62knWe
+const (
+	CardMsgContentTypeUser = "user_card_content"
+	CardMsgContentTypeRaw  = "raw_card_content"
 )
 
 // SendMessage sends a message to a user or chat
@@ -169,6 +185,9 @@ type ListMessagesOptions struct {
 	SortType        string
 	PageSize        int
 	PageToken       string
+	// CardContentType 控制 interactive 卡片的返回格式（取值 user_card_content / raw_card_content / 空）。
+	// 详见 CardMsgContentTypeUser/CardMsgContentTypeRaw 注释。
+	CardContentType string
 }
 
 // ListMessagesResult contains the result of listing messages
@@ -183,10 +202,18 @@ type ListMessagesResult struct {
 // tenant_access_token only, but the API actually supports user_access_token as well.
 // When a user access token is provided, we use a raw HTTP request to bypass the SDK's
 // client-side token type validation. See: https://open.feishu.cn/document/server-docs/im-v1/message/list
+//
+// 当 opts.CardContentType 非空时，SDK builder 不识别该字段，统一走 raw HTTP / SDK raw request
+// 路径，把 card_msg_content_type 加到 query params。
 func ListMessages(containerID string, opts ListMessagesOptions, userAccessToken string) (*ListMessagesResult, error) {
 	// When user access token is provided, use raw HTTP to bypass SDK token type restriction
 	if userAccessToken != "" {
 		return listMessagesWithUserToken(containerID, opts, userAccessToken)
+	}
+
+	// 当 SDK builder 不支持的参数（card_msg_content_type）需要传时，走 SDK raw request。
+	if opts.CardContentType != "" {
+		return listMessagesViaRawRequest(containerID, opts, "")
 	}
 
 	client, err := GetClient()
@@ -220,6 +247,71 @@ func ListMessages(containerID string, opts ListMessagesOptions, userAccessToken 
 	}
 
 	if !resp.Success() {
+		return nil, fmt.Errorf("获取消息列表失败: code=%d, msg=%s", resp.Code, resp.Msg)
+	}
+
+	return &ListMessagesResult{
+		Items:     resp.Data.Items,
+		PageToken: StringVal(resp.Data.PageToken),
+		HasMore:   BoolVal(resp.Data.HasMore),
+	}, nil
+}
+
+// listMessagesViaRawRequest calls /im/v1/messages via SDK raw request so that
+// query params (e.g. card_msg_content_type) unsupported by the typed SDK builder
+// can still be sent. tenant_access_token is auto-managed by the SDK; pass an
+// empty userAccessToken for tenant mode.
+func listMessagesViaRawRequest(containerID string, opts ListMessagesOptions, userAccessToken string) (*ListMessagesResult, error) {
+	cli, err := GetClient()
+	if err != nil {
+		return nil, err
+	}
+
+	req := &larkcore.ApiReq{
+		HttpMethod:  http.MethodGet,
+		ApiPath:     "/open-apis/im/v1/messages",
+		QueryParams: larkcore.QueryParams{},
+		SupportedAccessTokenTypes: []larkcore.AccessTokenType{
+			larkcore.AccessTokenTypeTenant,
+			larkcore.AccessTokenTypeUser,
+		},
+	}
+	if opts.ContainerIDType != "" {
+		req.QueryParams.Set("container_id_type", opts.ContainerIDType)
+	}
+	req.QueryParams.Set("container_id", containerID)
+	if opts.StartTime != "" {
+		req.QueryParams.Set("start_time", opts.StartTime)
+	}
+	if opts.EndTime != "" {
+		req.QueryParams.Set("end_time", opts.EndTime)
+	}
+	if opts.SortType != "" {
+		req.QueryParams.Set("sort_type", opts.SortType)
+	}
+	if opts.PageSize > 0 {
+		req.QueryParams.Set("page_size", strconv.Itoa(opts.PageSize))
+	}
+	if opts.PageToken != "" {
+		req.QueryParams.Set("page_token", opts.PageToken)
+	}
+	if opts.CardContentType != "" {
+		req.QueryParams.Set("card_msg_content_type", opts.CardContentType)
+	}
+
+	apiResp, err := cli.Do(Context(), req, UserTokenOption(userAccessToken)...)
+	if err != nil {
+		return nil, fmt.Errorf("获取消息列表失败: %w", err)
+	}
+	if apiResp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("获取消息列表失败: HTTP %d, body: %s", apiResp.StatusCode, string(apiResp.RawBody))
+	}
+
+	var resp listMessagesRawResponse
+	if err := json.Unmarshal(apiResp.RawBody, &resp); err != nil {
+		return nil, fmt.Errorf("获取消息列表失败: 解析响应失败: %w", err)
+	}
+	if resp.Code != 0 {
 		return nil, fmt.Errorf("获取消息列表失败: code=%d, msg=%s", resp.Code, resp.Msg)
 	}
 
@@ -267,6 +359,9 @@ func listMessagesWithUserToken(containerID string, opts ListMessagesOptions, use
 	}
 	if opts.PageToken != "" {
 		params.Set("page_token", opts.PageToken)
+	}
+	if opts.CardContentType != "" {
+		params.Set("card_msg_content_type", opts.CardContentType)
 	}
 
 	reqURL := fmt.Sprintf("%s/open-apis/im/v1/messages?%s", baseURL, params.Encode())
@@ -439,13 +534,21 @@ type GetMessageResult struct {
 	Message *larkim.Message
 }
 
-// GetMessage gets a message by message ID
+// GetMessage gets a message by message ID.
+//
 // Note: The SDK incorrectly declares this API as tenant_access_token only,
 // but it actually supports user_access_token. When a user token is provided,
 // we use raw HTTP to bypass the SDK's client-side token type validation.
-func GetMessage(messageID string, userAccessToken string) (*GetMessageResult, error) {
+//
+// 当 cardContentType 非空时（user_card_content / raw_card_content），SDK builder 不识别该
+// 字段，统一走 raw 路径把 card_msg_content_type 加到 query params。
+func GetMessage(messageID, userAccessToken, cardContentType string) (*GetMessageResult, error) {
 	if userAccessToken != "" {
-		return getMessageWithUserToken(messageID, userAccessToken)
+		return getMessageWithUserToken(messageID, userAccessToken, cardContentType)
+	}
+
+	if cardContentType != "" {
+		return getMessageViaRawRequest(messageID, cardContentType, "")
 	}
 
 	client, err := GetClient()
@@ -477,7 +580,9 @@ func GetMessage(messageID string, userAccessToken string) (*GetMessageResult, er
 
 // getMessageWithUserToken calls the Get Message API via raw HTTP,
 // bypassing the SDK's token type validation.
-func getMessageWithUserToken(messageID string, userAccessToken string) (*GetMessageResult, error) {
+//
+// cardContentType 透传到 query params；空字符串则不传，保持向后兼容。
+func getMessageWithUserToken(messageID, userAccessToken, cardContentType string) (*GetMessageResult, error) {
 	cfg := config.Get()
 	baseURL := cfg.BaseURL
 	if baseURL == "" {
@@ -485,6 +590,11 @@ func getMessageWithUserToken(messageID string, userAccessToken string) (*GetMess
 	}
 
 	reqURL := fmt.Sprintf("%s/open-apis/im/v1/messages/%s", baseURL, messageID)
+	if cardContentType != "" {
+		params := url.Values{}
+		params.Set("card_msg_content_type", cardContentType)
+		reqURL = reqURL + "?" + params.Encode()
+	}
 	req, err := http.NewRequest(http.MethodGet, reqURL, nil)
 	if err != nil {
 		return nil, fmt.Errorf("获取消息详情失败: %w", err)
@@ -516,6 +626,52 @@ func getMessageWithUserToken(messageID string, userAccessToken string) (*GetMess
 		return nil, fmt.Errorf("消息不存在")
 	}
 
+	return &GetMessageResult{
+		Message: resp.Data.Items[0],
+	}, nil
+}
+
+// getMessageViaRawRequest calls /im/v1/messages/:message_id via SDK raw request.
+// 用于 tenant 模式 + 需要传 SDK builder 不识别的字段（card_msg_content_type）的场景。
+func getMessageViaRawRequest(messageID, cardContentType, userAccessToken string) (*GetMessageResult, error) {
+	cli, err := GetClient()
+	if err != nil {
+		return nil, err
+	}
+
+	req := &larkcore.ApiReq{
+		HttpMethod:  http.MethodGet,
+		ApiPath:     "/open-apis/im/v1/messages/:message_id",
+		PathParams:  larkcore.PathParams{},
+		QueryParams: larkcore.QueryParams{},
+		SupportedAccessTokenTypes: []larkcore.AccessTokenType{
+			larkcore.AccessTokenTypeTenant,
+			larkcore.AccessTokenTypeUser,
+		},
+	}
+	req.PathParams.Set("message_id", messageID)
+	if cardContentType != "" {
+		req.QueryParams.Set("card_msg_content_type", cardContentType)
+	}
+
+	apiResp, err := cli.Do(Context(), req, UserTokenOption(userAccessToken)...)
+	if err != nil {
+		return nil, fmt.Errorf("获取消息详情失败: %w", err)
+	}
+	if apiResp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("获取消息详情失败: HTTP %d, body: %s", apiResp.StatusCode, string(apiResp.RawBody))
+	}
+
+	var resp listMessagesRawResponse
+	if err := json.Unmarshal(apiResp.RawBody, &resp); err != nil {
+		return nil, fmt.Errorf("获取消息详情失败: 解析响应失败: %w", err)
+	}
+	if resp.Code != 0 {
+		return nil, fmt.Errorf("获取消息详情失败: code=%d, msg=%s", resp.Code, resp.Msg)
+	}
+	if len(resp.Data.Items) == 0 {
+		return nil, fmt.Errorf("消息不存在")
+	}
 	return &GetMessageResult{
 		Message: resp.Data.Items[0],
 	}, nil
@@ -1063,10 +1219,12 @@ func DownloadMessageResource(messageID, fileKey, resourceType, outputPath, userA
 }
 
 // BatchGetMessages 批量获取消息详情（逐条调用 GetMessage）
-func BatchGetMessages(messageIDs []string, userAccessToken string) ([]*larkim.Message, error) {
+//
+// cardContentType 透传给每次 GetMessage 调用；空字符串则维持原渲染版返回。
+func BatchGetMessages(messageIDs []string, userAccessToken, cardContentType string) ([]*larkim.Message, error) {
 	var results []*larkim.Message
 	for _, id := range messageIDs {
-		msgResult, err := GetMessage(id, userAccessToken)
+		msgResult, err := GetMessage(id, userAccessToken, cardContentType)
 		if err != nil {
 			return nil, fmt.Errorf("获取消息 %s 失败: %w", id, err)
 		}

--- a/internal/client/message_test.go
+++ b/internal/client/message_test.go
@@ -6,6 +6,7 @@ import (
 	"net/http/httptest"
 	"net/url"
 	"os"
+	"strings"
 	"testing"
 
 	"github.com/riba2534/feishu-cli/internal/config"
@@ -131,5 +132,105 @@ func TestGetMessageWithUserToken_ApiErrorPropagated(t *testing.T) {
 	_, err := getMessageWithUserToken("om_xxx", "u-test", CardMsgContentTypeUser)
 	if err == nil {
 		t.Fatal("API 返回 code != 0 应返回错误")
+	}
+}
+
+// tenantRouteHandler 封装 tenant 模式 stub：识别 SDK 自动发起的 tenant_access_token
+// 取 token 请求并回 fake token；其他路径转交给业务 handler。
+func tenantRouteHandler(t *testing.T, business http.HandlerFunc) http.HandlerFunc {
+	t.Helper()
+	return func(w http.ResponseWriter, r *http.Request) {
+		if strings.HasPrefix(r.URL.Path, "/open-apis/auth/v3/tenant_access_token/internal") {
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = fmt.Fprint(w, `{"code":0,"msg":"ok","tenant_access_token":"t-fake","expire":7200}`)
+			return
+		}
+		business(w, r)
+	}
+}
+
+// TestListMessagesTenantRaw_CardContentType 覆盖 tenant 模式（userAccessToken 为空）
+// 走 listMessagesViaRawRequest 的路径——CardContentType 非空时本应触发 raw HTTP 走 SDK
+// raw request，把 card_msg_content_type 写入 query params。
+func TestListMessagesTenantRaw_CardContentType(t *testing.T) {
+	const containerID = "oc_test_chat"
+
+	var capturedQuery url.Values
+	var capturedAuth string
+	var capturedPath string
+	business := func(w http.ResponseWriter, r *http.Request) {
+		capturedPath = r.URL.Path
+		capturedQuery = r.URL.Query()
+		capturedAuth = r.Header.Get("Authorization")
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = fmt.Fprint(w, `{"code":0,"msg":"success","data":{"items":[],"has_more":false,"page_token":""}}`)
+	}
+
+	_, cleanup := stubFeishuServer(t, tenantRouteHandler(t, business))
+	defer cleanup()
+
+	opts := ListMessagesOptions{
+		ContainerIDType: "chat",
+		PageSize:        10,
+		CardContentType: CardMsgContentTypeRaw,
+	}
+	if _, err := ListMessages(containerID, opts, ""); err != nil {
+		t.Fatalf("ListMessages tenant 模式返回错误: %v", err)
+	}
+
+	if capturedPath != "/open-apis/im/v1/messages" {
+		t.Errorf("请求 path: got %q, want %q", capturedPath, "/open-apis/im/v1/messages")
+	}
+	if got := capturedQuery.Get("card_msg_content_type"); got != CardMsgContentTypeRaw {
+		t.Errorf("card_msg_content_type query: got %q, want %q", got, CardMsgContentTypeRaw)
+	}
+	if got := capturedQuery.Get("container_id"); got != containerID {
+		t.Errorf("container_id query: got %q, want %q", got, containerID)
+	}
+	if got := capturedQuery.Get("container_id_type"); got != "chat" {
+		t.Errorf("container_id_type query: got %q, want %q", got, "chat")
+	}
+	// tenant 模式应使用 tenant token，前缀 "Bearer t-" 来自 stub fake token
+	if !strings.HasPrefix(capturedAuth, "Bearer t-") {
+		t.Errorf("tenant 模式应使用 tenant_access_token，Authorization=%q", capturedAuth)
+	}
+}
+
+// TestGetMessageTenantRaw_CardContentType 覆盖 tenant 模式
+// 走 getMessageViaRawRequest 的路径。
+func TestGetMessageTenantRaw_CardContentType(t *testing.T) {
+	const messageID = "om_x100b512ca9a404b8b2432e156aa8895"
+
+	var capturedQuery url.Values
+	var capturedAuth string
+	var capturedPath string
+	business := func(w http.ResponseWriter, r *http.Request) {
+		capturedPath = r.URL.Path
+		capturedQuery = r.URL.Query()
+		capturedAuth = r.Header.Get("Authorization")
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = fmt.Fprintf(w, `{"code":0,"msg":"success","data":{"items":[{"message_id":"%s","msg_type":"interactive","body":{"content":"{}"}}]}}`, messageID)
+	}
+
+	_, cleanup := stubFeishuServer(t, tenantRouteHandler(t, business))
+	defer cleanup()
+
+	result, err := GetMessage(messageID, "", CardMsgContentTypeUser)
+	if err != nil {
+		t.Fatalf("GetMessage tenant 模式返回错误: %v", err)
+	}
+	if result == nil || result.Message == nil {
+		t.Fatalf("返回结果为空")
+	}
+
+	expectedPath := "/open-apis/im/v1/messages/" + messageID
+	if capturedPath != expectedPath {
+		t.Errorf("请求 path: got %q, want %q", capturedPath, expectedPath)
+	}
+	if got := capturedQuery.Get("card_msg_content_type"); got != CardMsgContentTypeUser {
+		t.Errorf("card_msg_content_type query: got %q, want %q", got, CardMsgContentTypeUser)
+	}
+	if !strings.HasPrefix(capturedAuth, "Bearer t-") {
+		t.Errorf("tenant 模式应使用 tenant_access_token，Authorization=%q", capturedAuth)
 	}
 }

--- a/internal/client/message_test.go
+++ b/internal/client/message_test.go
@@ -1,0 +1,135 @@
+package client
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"os"
+	"testing"
+
+	"github.com/riba2534/feishu-cli/internal/config"
+)
+
+// stubFeishuServer 起一个本地 httptest server 替代真实飞书 OAPI；
+// 通过 base_url 配置注入到 cli。
+func stubFeishuServer(t *testing.T, handler http.HandlerFunc) (string, func()) {
+	t.Helper()
+	srv := httptest.NewServer(handler)
+
+	resetClient()
+	resetConfig()
+
+	tmpDir := t.TempDir()
+	configFile := tmpDir + "/config.yaml"
+	content := fmt.Sprintf(`app_id: "test_app_id"
+app_secret: "test_app_secret"
+base_url: "%s"
+`, srv.URL)
+	if err := os.WriteFile(configFile, []byte(content), 0o600); err != nil {
+		t.Fatalf("写测试配置失败: %v", err)
+	}
+	if err := config.Init(configFile); err != nil {
+		t.Fatalf("初始化测试配置失败: %v", err)
+	}
+
+	return srv.URL, srv.Close
+}
+
+func TestGetMessageWithUserToken_CardContentType(t *testing.T) {
+	tests := []struct {
+		name             string
+		cardContentType  string
+		expectedQueryArg string
+	}{
+		{"空 → 不传 query", "", ""},
+		{"user_card_content", CardMsgContentTypeUser, "user_card_content"},
+		{"raw_card_content", CardMsgContentTypeRaw, "raw_card_content"},
+	}
+
+	const messageID = "om_x100b512ca9a404b8b2432e156aa8895"
+	const userToken = "u-test-token"
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var capturedQuery url.Values
+			var capturedAuth string
+			handler := func(w http.ResponseWriter, r *http.Request) {
+				capturedQuery = r.URL.Query()
+				capturedAuth = r.Header.Get("Authorization")
+				expectedPath := "/open-apis/im/v1/messages/" + messageID
+				if r.URL.Path != expectedPath {
+					t.Errorf("path 不符: got %q, want %q", r.URL.Path, expectedPath)
+				}
+				w.Header().Set("Content-Type", "application/json")
+				_, _ = fmt.Fprintf(w, `{"code":0,"msg":"success","data":{"items":[{"message_id":"%s","msg_type":"interactive","body":{"content":"{}"}}]}}`, messageID)
+			}
+
+			_, cleanup := stubFeishuServer(t, handler)
+			defer cleanup()
+
+			result, err := getMessageWithUserToken(messageID, userToken, tt.cardContentType)
+			if err != nil {
+				t.Fatalf("getMessageWithUserToken 返回错误: %v", err)
+			}
+			if result == nil || result.Message == nil {
+				t.Fatalf("返回结果为空")
+			}
+			if got := capturedQuery.Get("card_msg_content_type"); got != tt.expectedQueryArg {
+				t.Errorf("card_msg_content_type query: got %q, want %q", got, tt.expectedQueryArg)
+			}
+			if capturedAuth != "Bearer "+userToken {
+				t.Errorf("Authorization header: got %q, want %q", capturedAuth, "Bearer "+userToken)
+			}
+		})
+	}
+}
+
+func TestListMessagesWithUserToken_CardContentType(t *testing.T) {
+	const containerID = "oc_test_chat"
+	const userToken = "u-test-token"
+
+	var capturedQuery url.Values
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		capturedQuery = r.URL.Query()
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = fmt.Fprint(w, `{"code":0,"msg":"success","data":{"items":[],"has_more":false,"page_token":""}}`)
+	}
+
+	_, cleanup := stubFeishuServer(t, handler)
+	defer cleanup()
+
+	opts := ListMessagesOptions{
+		ContainerIDType: "chat",
+		PageSize:        10,
+		CardContentType: CardMsgContentTypeUser,
+	}
+	if _, err := ListMessages(containerID, opts, userToken); err != nil {
+		t.Fatalf("ListMessages 返回错误: %v", err)
+	}
+
+	if got := capturedQuery.Get("card_msg_content_type"); got != CardMsgContentTypeUser {
+		t.Errorf("card_msg_content_type query: got %q, want %q", got, CardMsgContentTypeUser)
+	}
+	if got := capturedQuery.Get("container_id"); got != containerID {
+		t.Errorf("container_id query: got %q, want %q", got, containerID)
+	}
+	if got := capturedQuery.Get("container_id_type"); got != "chat" {
+		t.Errorf("container_id_type query: got %q, want %q", got, "chat")
+	}
+}
+
+func TestGetMessageWithUserToken_ApiErrorPropagated(t *testing.T) {
+	handler := func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = fmt.Fprint(w, `{"code":230002,"msg":"permission denied","data":{}}`)
+	}
+
+	_, cleanup := stubFeishuServer(t, handler)
+	defer cleanup()
+
+	_, err := getMessageWithUserToken("om_xxx", "u-test", CardMsgContentTypeUser)
+	if err == nil {
+		t.Fatal("API 返回 code != 0 应返回错误")
+	}
+}

--- a/skills/feishu-cli-chat/SKILL.md
+++ b/skills/feishu-cli-chat/SKILL.md
@@ -393,7 +393,7 @@ feishu-cli msg get om_xxx --card-content-type user -o json
 feishu-cli msg get om_xxx --card-content-type raw -o json
 ```
 
-> **`--card-content-type user|raw`** 同样适用于 `msg list` 和 `msg mget`，仅对 interactive 卡片生效，其他 msg_type 不受影响。`user` = userDSL（schema 2.0），`raw` = cardDSL（含默认补全字段）。
+> **`--card-content-type`** 接受 `user` / `user_card_content`（userDSL）/ `raw` / `raw_card_content`（cardDSL）/ 空（默认渲染版），短别名与完整 OAPI 名等价。同样适用于 `msg list` 和 `msg mget`，仅对 interactive 卡片生效，其他 msg_type 不受影响。`user_card_content` = userDSL（开发者构建卡片时的 schema 2.0 JSON）；`raw_card_content` = cardDSL（平台内部完整描述，含默认补全字段）。
 
 ### 查看消息已读情况
 

--- a/skills/feishu-cli-chat/SKILL.md
+++ b/skills/feishu-cli-chat/SKILL.md
@@ -385,7 +385,15 @@ feishu-cli chat delete oc_xxx
 
 ```bash
 feishu-cli msg get om_xxx -o json
+
+# interactive 卡片拿到原始 schema 2.0 JSON（开发者视角的 userDSL，便于偷师/调试）
+feishu-cli msg get om_xxx --card-content-type user -o json
+
+# 返回平台内部完整 cardDSL（含默认补全字段）
+feishu-cli msg get om_xxx --card-content-type raw -o json
 ```
+
+> **`--card-content-type user|raw`** 同样适用于 `msg list` 和 `msg mget`，仅对 interactive 卡片生效，其他 msg_type 不受影响。`user` = userDSL（schema 2.0），`raw` = cardDSL（含默认补全字段）。
 
 ### 查看消息已读情况
 

--- a/skills/feishu-cli-msg/SKILL.md
+++ b/skills/feishu-cli-msg/SKILL.md
@@ -638,11 +638,20 @@ feishu-cli msg forward <message_id> \
 
 ```bash
 feishu-cli msg mget --message-ids om_xxx,om_yyy,om_zzz
+
+# interactive 卡片返回原始 schema 2.0 JSON（开发者视角的 userDSL，便于偷师）
+feishu-cli msg mget --message-ids om_xxx,om_yyy --card-content-type user
+
+# 返回平台内部完整 cardDSL（含默认补全字段，调试用）
+feishu-cli msg mget --message-ids om_xxx,om_yyy --card-content-type raw
 ```
 
 | 参数 | 说明 | 默认值 |
 |------|------|--------|
 | `--message-ids` | 消息 ID 列表（逗号分隔） | 必填 |
+| `--card-content-type` | interactive 卡片返回格式：`user`（userDSL）/ `raw`（cardDSL）/ 空（默认渲染版） | 空 |
+
+> **`--card-content-type` 同样适用于 `msg get` 和 `msg list`**：仅对 interactive 卡片消息生效，其他 msg_type 不受影响。`user` 拿到的是开发者构建卡片时的 schema 2.0 JSON，`raw` 是平台补齐默认字段后的完整描述。
 
 ## 下载消息资源
 

--- a/skills/feishu-cli-msg/SKILL.md
+++ b/skills/feishu-cli-msg/SKILL.md
@@ -649,9 +649,9 @@ feishu-cli msg mget --message-ids om_xxx,om_yyy --card-content-type raw
 | 参数 | 说明 | 默认值 |
 |------|------|--------|
 | `--message-ids` | 消息 ID 列表（逗号分隔） | 必填 |
-| `--card-content-type` | interactive 卡片返回格式：`user`（userDSL）/ `raw`（cardDSL）/ 空（默认渲染版） | 空 |
+| `--card-content-type` | interactive 卡片返回格式：`user` / `user_card_content`（userDSL）/ `raw` / `raw_card_content`（cardDSL）/ 空（默认渲染版） | 空 |
 
-> **`--card-content-type` 同样适用于 `msg get` 和 `msg list`**：仅对 interactive 卡片消息生效，其他 msg_type 不受影响。`user` 拿到的是开发者构建卡片时的 schema 2.0 JSON，`raw` 是平台补齐默认字段后的完整描述。
+> **`--card-content-type` 同样适用于 `msg get` 和 `msg list`**：仅对 interactive 卡片消息生效，其他 msg_type 不受影响。短别名 `user` / `raw` 与完整 OAPI 名 `user_card_content` / `raw_card_content` 等价，CLI 都接受。`user_card_content` = userDSL（开发者构建卡片时的 schema 2.0 JSON）；`raw_card_content` = cardDSL（平台内部完整描述，含默认补全字段）。
 
 ## 下载消息资源
 


### PR DESCRIPTION
## 背景

`feishu-cli msg {get,mget,list}` 默认对 interactive 卡片消息返回**渲染后**的文本——形如：

```
<card title="🚀 Claude Opus 4.7">...纯文本展开...</card>
```

如果用户想拿到**原始 schema 2.0 JSON**（用于：偷师生产卡片结构 / 调试自家卡片渲染 / 给 LLM 喂 schema 上下文 / 重发同款卡片），目前 cli 拿不到。

OAPI 实际上支持 `card_msg_content_type` 查询参数：
- `user_card_content` → 返回 **userDSL**（开发者构建卡片时填的 schema 2.0 JSON）
- `raw_card_content` → 返回 **cardDSL**（平台内部完整描述，含 element_id 等默认补全）

但 Feishu Go SDK（v3.4.19）的 typed builder（`NewGetMessageReqBuilder` / `NewListMessageReqBuilder`）还没暴露这个字段。

## 改动

给 `msg get` / `msg mget` / `msg list` 都加上 `--card-content-type` flag：

```bash
# userDSL（开发者视角的 schema 2.0 JSON）
feishu-cli msg get om_xxx --card-content-type user

# cardDSL（平台内部完整描述）
feishu-cli msg get om_xxx --card-content-type raw

# 批量
feishu-cli msg mget --message-ids om_xxx,om_yyy --card-content-type user

# 群消息流
feishu-cli msg list --container-id oc_xxx --card-content-type user
```

flag 值同时接受短写（`user` / `raw`）和完整 OAPI 名（`user_card_content` / `raw_card_content`）。**默认空 → 完全维持现有行为**，向后兼容。

## 实现

由于 SDK 的 typed builder 不识别 `card_msg_content_type`，新增的路径走 SDK raw request：
- **tenant token 模式**：通过 SDK 的 \`client.Do(ctx, &larkcore.ApiReq{...})\` 走 raw request，复用 SDK 的 token 管理
- **user token 模式**：沿用项目里已有的 raw HTTP 路径，把参数加到 query string

向后兼容：
- 当 \`--card-content-type\` 未传 / 为空时，SDK typed builder 路径完全不动
- 现有 \`GetMessage(messageID, userToken)\` 改为 \`GetMessage(messageID, userToken, cardContentType)\`，所有调用点跟着更新（仅 \`internal/\` 包，不是公开 SDK）

## 测试

- \`cmd/msg_card_content_type_test.go\`：纯函数测试 \`resolveCardContentType\`，覆盖空值 / 短写 / 全名 / 大小写 / 前后空格 / 非法值
- \`internal/client/message_test.go\`：httptest 起本地 stub server 验证：
  - \`GetMessage\` / \`ListMessages\` 在 \`CardContentType\` 非空时把 \`card_msg_content_type\` 加进 query string
  - 空字符串时不传该参数（向后兼容）
  - API 返回非零 code 时错误能正确传播

\`go test ./...\` 全过；\`go vet ./...\` 无输出。

## 参考

参数语义来自字节跳动内部技术方案文档「OAPI 卡片 2.0 兼容改造与返回结构优化技术方案」（lark 内部 docx）。该文档同时规划了 \`im.message.receive_v1\` 事件 \`event.message.user_card_content\` 字段（订阅实时新卡），本 PR 仅覆盖查询接口（get/mget/list）。