### PR TITLE
fix(msg): use optional user token for delete to allow bot self-recall

### DIFF
--- a/cmd/delete_message.go
+++ b/cmd/delete_message.go
@@ -33,10 +33,7 @@ var deleteMessageCmd = &cobra.Command{
 			return err
 		}
 
-		token, err := resolveRequiredUserToken(cmd)
-		if err != nil {
-			return err
-		}
+		token := resolveOptionalUserToken(cmd)
 
 		messageID := args[0]
 


### PR DESCRIPTION
## 问题

`feishu-cli msg delete <om_xxx>` 在 bot 24h 内撤回自己发到群里的消息时强报错：

```
Error: 删除消息失败: code=230026, msg=No permission to recall this message,
ext=User is NOT the group owner or group admin.
```

但同样的消息 ID 用 raw curl + `tenant_access_token` 直接成功：

```bash
curl -X DELETE "https://open.feishu.cn/open-apis/im/v1/messages/${MSG_ID}" \
  -H "Authorization: Bearer ${TENANT_TOKEN}"
# {"code":0,"data":{},"msg":"success"}
```

飞书 OpenAPI 本身允许 bot 用 app token 撤回自己发的消息（24h 内），但 user 视角下规则严格——必须是群主/管理员。

## 根因

[17e415c](https://github.com/riba2534/feishu-cli/commit/17e415c) 把 delete 命令的 token 选择从 `resolveOptionalUserToken` 改成 `resolveRequiredUserToken`，强制走 user_access_token，导致 bot 自撤这种本来 app token 可以做到的场景报 230026 false positive。

同模块的 `cmd/send_message.go:116` 和 `cmd/reply_msg.go:48` 仍然用 `resolveOptionalUserToken`，delete 是孤例。

## 修复

```diff
-		token, err := resolveRequiredUserToken(cmd)
-		if err != nil {
-			return err
-		}
+		token := resolveOptionalUserToken(cmd)
```

`internal/client/message.go::DeleteMessage()` 内部的 `UserTokenOption(token)` 在 token 为空时返回 nil，larksuite go SDK 自动 fallback 到 tenant_access_token，不需要其他改动。

显式传 `--user-access-token` 时仍然走 user 路径，行为兼容。

## 验证

修复后用同一群同一 bot 发消息 → 立即撤回成功：

```
$ feishu-cli msg send --receive-id-type chat_id --receive-id oc_xxx \
    --text "fix verify ..." --output json
{"message_id": "om_x100b503eefbb0cb4e1009aeb3099f4f"}

$ feishu-cli msg delete om_x100b503eefbb0cb4e1009aeb3099f4f
消息删除成功！
  消息 ID: om_x100b503eefbb0cb4e1009aeb3099f4f

$ feishu-cli msg get om_x100b503eefbb0cb4e1009aeb3099f4f --output json | jq '.message.deleted'
true
```

## 一致性论证

`msg` 模块下所有命令的 token 选择一览：

| 命令 | token 选择 | 行为 |
|------|------------|------|
| `msg send` | `resolveOptionalUserToken` | 默认 app token |
| `msg reply` | `resolveOptionalUserToken` | 默认 app token |
| `msg delete`（修复前）| `resolveRequiredUserToken` | 强制 user token，与 send/reply 不一致 |
| `msg delete`（修复后）| `resolveOptionalUserToken` | 默认 app token，对齐 send/reply |

bot 发出去的消息 bot 应当能撤回，这是和 send/reply 对称的能力，不应该比发消息更难。