### PR TITLE
feat(auth): auto-refresh on stale --user-access-token + add `auth refresh` subcommand

### DIFF
--- a/cmd/auth.go
+++ b/cmd/auth.go
@@ -18,6 +18,7 @@ var authCmd = &cobra.Command{
   feishu-cli auth login --json                     # AI Agent 推荐：JSON 事件流输出
   feishu-cli auth check --scope "search:docs:read" # 检查当前 token 是否包含所需 scope
   feishu-cli auth status --verify -o json          # 查看并在线校验授权状态
+  feishu-cli auth refresh                          # 强制刷新 access_token
   feishu-cli auth logout                           # 退出登录`,
 }
 

--- a/cmd/auth_refresh.go
+++ b/cmd/auth_refresh.go
@@ -1,0 +1,59 @@
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/riba2534/feishu-cli/internal/auth"
+	"github.com/riba2534/feishu-cli/internal/config"
+	"github.com/spf13/cobra"
+)
+
+var authRefreshCmd = &cobra.Command{
+	Use:   "refresh",
+	Short: "强制刷新 access_token（用 refresh_token）",
+	Long: `用 ~/.feishu-cli/token.json 中的 refresh_token 调用飞书 OAuth v2 token 端点，
+强制获取新的 access_token，并写回 token.json。
+
+通常情况下不需要手动调用——当 access_token 过期时，所有读取 token.json 的命令
+（如 wiki/doc/search 等）会自动触发刷新。本子命令用于:
+  - 长时间运行的脚本前主动续期，避免中途过期
+  - 排查 token 状态时手动验证 refresh_token 是否仍有效
+  - 强制让 token.json 立即更新到最新状态
+
+示例:
+  feishu-cli auth refresh                    # 文本输出
+  feishu-cli auth refresh -o json            # JSON 输出（自动化场景）
+
+退出码:
+  0 - 成功
+  1 - 失败（refresh_token 过期、网络错误等）`,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		cfg := config.Get()
+		newToken, err := auth.ForceRefreshLocalToken(cfg.AppID, cfg.AppSecret, cfg.BaseURL)
+		if err != nil {
+			return err
+		}
+
+		output, _ := cmd.Flags().GetString("output")
+		if output == "json" {
+			return printJSON(map[string]any{
+				"status":             "ok",
+				"access_token":       auth.MaskToken(newToken.AccessToken),
+				"expires_at":         newToken.ExpiresAt.Format("2006-01-02 15:04:05"),
+				"refresh_expires_at": newToken.RefreshExpiresAt.Format("2006-01-02 15:04:05"),
+				"scope":              newToken.Scope,
+			})
+		}
+
+		fmt.Println("✓ Access Token 已刷新")
+		fmt.Printf("  Access Token:   %s\n", auth.MaskToken(newToken.AccessToken))
+		fmt.Printf("  有效期至:        %s\n", newToken.ExpiresAt.Format("2006-01-02 15:04:05"))
+		fmt.Printf("  Refresh 有效期:  %s\n", newToken.RefreshExpiresAt.Format("2006-01-02 15:04:05"))
+		return nil
+	},
+}
+
+func init() {
+	authRefreshCmd.Flags().StringP("output", "o", "", "输出格式（json）")
+	authCmd.AddCommand(authRefreshCmd)
+}

--- a/cmd/auth_refresh.go
+++ b/cmd/auth_refresh.go
@@ -28,6 +28,10 @@ var authRefreshCmd = &cobra.Command{
   0 - 成功
   1 - 失败（refresh_token 过期、网络错误等）`,
 	RunE: func(cmd *cobra.Command, args []string) error {
+		if err := config.Validate(); err != nil {
+			return err
+		}
+
 		cfg := config.Get()
 		newToken, err := auth.ForceRefreshLocalToken(cfg.AppID, cfg.AppSecret, cfg.BaseURL)
 		if err != nil {
@@ -36,19 +40,26 @@ var authRefreshCmd = &cobra.Command{
 
 		output, _ := cmd.Flags().GetString("output")
 		if output == "json" {
-			return printJSON(map[string]any{
-				"status":             "ok",
-				"access_token":       auth.MaskToken(newToken.AccessToken),
-				"expires_at":         newToken.ExpiresAt.Format("2006-01-02 15:04:05"),
-				"refresh_expires_at": newToken.RefreshExpiresAt.Format("2006-01-02 15:04:05"),
-				"scope":              newToken.Scope,
-			})
+			result := map[string]any{
+				"status":       "ok",
+				"access_token": auth.MaskToken(newToken.AccessToken),
+				"expires_at":   newToken.ExpiresAt.Format("2006-01-02 15:04:05"),
+				"scope":        newToken.Scope,
+			}
+			if !newToken.RefreshExpiresAt.IsZero() {
+				result["refresh_expires_at"] = newToken.RefreshExpiresAt.Format("2006-01-02 15:04:05")
+			}
+			return printJSON(result)
 		}
 
 		fmt.Println("✓ Access Token 已刷新")
 		fmt.Printf("  Access Token:   %s\n", auth.MaskToken(newToken.AccessToken))
 		fmt.Printf("  有效期至:        %s\n", newToken.ExpiresAt.Format("2006-01-02 15:04:05"))
-		fmt.Printf("  Refresh 有效期:  %s\n", newToken.RefreshExpiresAt.Format("2006-01-02 15:04:05"))
+		if !newToken.RefreshExpiresAt.IsZero() {
+			fmt.Printf("  Refresh 有效期:  %s\n", newToken.RefreshExpiresAt.Format("2006-01-02 15:04:05"))
+		} else {
+			fmt.Println("  Refresh 有效期:  未知")
+		}
 		return nil
 	},
 }

--- a/internal/auth/resolve.go
+++ b/internal/auth/resolve.go
@@ -14,18 +14,27 @@ func logf(format string, a ...any) {
 //
 // 优先级:
 //  1. flagValue（--user-access-token 参数）
-//  2. FEISHU_USER_ACCESS_TOKEN 环境变量
+//     - 若 flagValue 等于 token.json 中已过期的 access_token 且 refresh_token 仍有效，
+//       自动刷新并返回新 access_token（写回 token.json）。常见场景：脚本从 token.json
+//       读取 access_token 后传入 --user-access-token，本质是延伸本机身份。
+//  2. FEISHU_USER_ACCESS_TOKEN 环境变量（同样支持本机身份延伸时的自动刷新）
 //  3. token.json（access_token 有效直接返回；过期则用 refresh_token 刷新）
 //  4. configValue（config.yaml 静态配置）
 //  5. 全部为空 → 返回错误
 func ResolveUserAccessToken(flagValue, configValue, appID, appSecret, baseURL string) (string, error) {
 	// 1. 命令行参数
 	if flagValue != "" {
+		if refreshed, ok := refreshIfStaleLocalToken(flagValue, appID, appSecret, baseURL); ok {
+			return refreshed, nil
+		}
 		return flagValue, nil
 	}
 
 	// 2. 环境变量
 	if envToken := os.Getenv("FEISHU_USER_ACCESS_TOKEN"); envToken != "" {
+		if refreshed, ok := refreshIfStaleLocalToken(envToken, appID, appSecret, baseURL); ok {
+			return refreshed, nil
+		}
 		return envToken, nil
 	}
 
@@ -74,4 +83,77 @@ func ResolveUserAccessToken(flagValue, configValue, appID, appSecret, baseURL st
 		"  2. 命令行参数: --user-access-token <token>\n" +
 		"  3. 环境变量: export FEISHU_USER_ACCESS_TOKEN=<token>\n" +
 		"  4. 配置文件: user_access_token: <token>")
+}
+
+// refreshIfStaleLocalToken 当显式传入的 token 等于 token.json 里已过期的 access_token 时，
+// 触发自动刷新并写回 token.json。这是为了支持「脚本从 token.json 读 access_token 后传 flag」
+// 这种常见用法——既保留显式传入 token 的契约，又解决了过期场景。
+//
+// 返回值:
+//   - (newToken, true): 已成功刷新并保存
+//   - ("", false): 不匹配本地 token，或不需要刷新，调用方应使用原始 token
+func refreshIfStaleLocalToken(explicitToken, appID, appSecret, baseURL string) (string, bool) {
+	local, err := LoadToken()
+	if err != nil || local == nil {
+		return "", false
+	}
+	// 必须确认 explicitToken 就是 token.json 的 access_token，否则不能擅自 refresh
+	if local.AccessToken != explicitToken {
+		return "", false
+	}
+	// 已经有效，不需要刷新
+	if local.IsAccessTokenValid() {
+		return "", false
+	}
+	// access 过期但 refresh 失效，无能为力
+	if !local.IsRefreshTokenValid() {
+		return "", false
+	}
+	if baseURL == "" {
+		baseURL = "https://open.feishu.cn"
+	}
+	logf("[自动刷新] 显式传入的 access_token 已过期且匹配本地 token.json，正在刷新...")
+	newToken, refreshErr := RefreshAccessToken(local, appID, appSecret, baseURL)
+	if refreshErr != nil {
+		logf("[自动刷新] 刷新失败: %v", refreshErr)
+		return "", false
+	}
+	if saveErr := SaveToken(newToken); saveErr != nil {
+		logf("[自动刷新] Token 已刷新但保存失败: %v", saveErr)
+	} else {
+		logf("[自动刷新] 刷新成功，新 Token 有效期至 %s", newToken.ExpiresAt.Format("2006-01-02 15:04:05"))
+	}
+	return newToken.AccessToken, true
+}
+
+// ForceRefreshLocalToken 强制刷新 token.json 中的 access_token，
+// 即使当前 access_token 仍然有效。由 `auth refresh` 子命令调用。
+//
+// 失败原因可能是: token.json 不存在、refresh_token 已过期、网络/服务端错误。
+func ForceRefreshLocalToken(appID, appSecret, baseURL string) (*TokenStore, error) {
+	local, err := LoadToken()
+	if err != nil {
+		return nil, fmt.Errorf("读取 token.json 失败: %w", err)
+	}
+	if local == nil {
+		return nil, fmt.Errorf("未登录（token.json 不存在），请先 `feishu-cli auth login`")
+	}
+	if local.RefreshToken == "" {
+		return nil, fmt.Errorf("token.json 中缺少 refresh_token，请重新 `feishu-cli auth login`")
+	}
+	if !local.IsRefreshTokenValid() {
+		return nil, fmt.Errorf("refresh_token 已过期（%s），请重新 `feishu-cli auth login`",
+			local.RefreshExpiresAt.Format("2006-01-02 15:04:05"))
+	}
+	if baseURL == "" {
+		baseURL = "https://open.feishu.cn"
+	}
+	newToken, err := RefreshAccessToken(local, appID, appSecret, baseURL)
+	if err != nil {
+		return nil, err
+	}
+	if err := SaveToken(newToken); err != nil {
+		return nil, fmt.Errorf("刷新成功但写入 token.json 失败: %w", err)
+	}
+	return newToken, nil
 }

--- a/internal/auth/resolve_test.go
+++ b/internal/auth/resolve_test.go
@@ -1,6 +1,7 @@
 package auth
 
 import (
+	"net/http"
 	"os"
 	"path/filepath"
 	"testing"
@@ -115,5 +116,256 @@ func TestResolveUserAccessToken_Priority(t *testing.T) {
 	token, _ = ResolveUserAccessToken("", "config-token", "", "", "")
 	if token != "file-token" {
 		t.Errorf("got %q, want file-token", token)
+	}
+}
+
+// ----- refreshIfStaleLocalToken -----
+
+// TestRefreshIfStaleLocalToken_NotMatchingLocal: 显式 token 与本地 token.json 不一致时，
+// 应直接返回 ("", false)，调用方继续使用原始 token。
+func TestRefreshIfStaleLocalToken_NotMatchingLocal(t *testing.T) {
+	tmpDir := t.TempDir()
+	tokenPathFunc = func() (string, error) { return filepath.Join(tmpDir, "token.json"), nil }
+	defer func() { tokenPathFunc = originalTokenPath }()
+
+	// 本地 token 与传入的 explicit token 不一致
+	store := &TokenStore{
+		AccessToken:      "local-access",
+		RefreshToken:     "local-refresh",
+		ExpiresAt:        time.Now().Add(-1 * time.Hour), // 已过期
+		RefreshExpiresAt: time.Now().Add(24 * time.Hour),
+	}
+	if err := SaveToken(store); err != nil {
+		t.Fatalf("SaveToken error: %v", err)
+	}
+
+	got, ok := refreshIfStaleLocalToken("some-other-token", "aid", "sec", "https://example.com")
+	if ok {
+		t.Errorf("expected ok=false when explicit token doesn't match local, got ok=true (got=%q)", got)
+	}
+	if got != "" {
+		t.Errorf("expected empty string when not matching, got %q", got)
+	}
+}
+
+// TestRefreshIfStaleLocalToken_AccessStillValid: explicit token 与本地一致且尚未过期，
+// 不需要刷新，返回 ("", false) 让调用方使用原值。
+func TestRefreshIfStaleLocalToken_AccessStillValid(t *testing.T) {
+	tmpDir := t.TempDir()
+	tokenPathFunc = func() (string, error) { return filepath.Join(tmpDir, "token.json"), nil }
+	defer func() { tokenPathFunc = originalTokenPath }()
+
+	store := &TokenStore{
+		AccessToken:      "still-valid",
+		RefreshToken:     "rt",
+		ExpiresAt:        time.Now().Add(1 * time.Hour),
+		RefreshExpiresAt: time.Now().Add(24 * time.Hour),
+	}
+	if err := SaveToken(store); err != nil {
+		t.Fatalf("SaveToken error: %v", err)
+	}
+
+	got, ok := refreshIfStaleLocalToken("still-valid", "aid", "sec", "https://example.com")
+	if ok {
+		t.Errorf("expected ok=false when access token still valid, got ok=true (got=%q)", got)
+	}
+	if got != "" {
+		t.Errorf("expected empty string when not refreshing, got %q", got)
+	}
+}
+
+// TestRefreshIfStaleLocalToken_RefreshExpired: explicit token 匹配但 access 与 refresh 都失效，
+// 无能为力，返回 ("", false)。
+func TestRefreshIfStaleLocalToken_RefreshExpired(t *testing.T) {
+	tmpDir := t.TempDir()
+	tokenPathFunc = func() (string, error) { return filepath.Join(tmpDir, "token.json"), nil }
+	defer func() { tokenPathFunc = originalTokenPath }()
+
+	store := &TokenStore{
+		AccessToken:      "stale",
+		RefreshToken:     "rt",
+		ExpiresAt:        time.Now().Add(-1 * time.Hour),
+		RefreshExpiresAt: time.Now().Add(-1 * time.Hour),
+	}
+	if err := SaveToken(store); err != nil {
+		t.Fatalf("SaveToken error: %v", err)
+	}
+
+	got, ok := refreshIfStaleLocalToken("stale", "aid", "sec", "https://example.com")
+	if ok {
+		t.Errorf("expected ok=false when both tokens expired, got ok=true (got=%q)", got)
+	}
+}
+
+// TestRefreshIfStaleLocalToken_Success: explicit token 匹配本地过期 access，且 refresh 仍有效，
+// 走 RefreshAccessToken 并返回新 token。
+func TestRefreshIfStaleLocalToken_Success(t *testing.T) {
+	tmpDir := t.TempDir()
+	tokenPathFunc = func() (string, error) { return filepath.Join(tmpDir, "token.json"), nil }
+	defer func() { tokenPathFunc = originalTokenPath }()
+
+	store := &TokenStore{
+		AccessToken:      "stale-access",
+		RefreshToken:     "valid-refresh",
+		ExpiresAt:        time.Now().Add(-1 * time.Hour),
+		RefreshExpiresAt: time.Now().Add(24 * time.Hour),
+		Scope:            "old:scope",
+	}
+	if err := SaveToken(store); err != nil {
+		t.Fatalf("SaveToken error: %v", err)
+	}
+
+	srv, _ := newMockTokenServer(t, http.StatusOK, map[string]any{
+		"access_token":  "fresh-access",
+		"refresh_token": "fresh-refresh",
+		"expires_in":    7200,
+		"scope":         "old:scope",
+	})
+
+	got, ok := refreshIfStaleLocalToken("stale-access", "aid", "sec", srv.URL)
+	if !ok {
+		t.Fatalf("expected ok=true on successful refresh, got ok=false")
+	}
+	if got != "fresh-access" {
+		t.Errorf("expected fresh-access, got %q", got)
+	}
+
+	// 验证 token.json 已更新
+	updated, err := LoadToken()
+	if err != nil {
+		t.Fatalf("LoadToken error: %v", err)
+	}
+	if updated.AccessToken != "fresh-access" {
+		t.Errorf("token.json AccessToken got %q want fresh-access", updated.AccessToken)
+	}
+}
+
+// TestRefreshIfStaleLocalToken_RefreshEndpointFails: 刷新端点返回错误时，
+// 不更新 token.json，返回 ("", false) 让调用方降级使用原始 explicit token。
+func TestRefreshIfStaleLocalToken_RefreshEndpointFails(t *testing.T) {
+	tmpDir := t.TempDir()
+	tokenPathFunc = func() (string, error) { return filepath.Join(tmpDir, "token.json"), nil }
+	defer func() { tokenPathFunc = originalTokenPath }()
+
+	store := &TokenStore{
+		AccessToken:      "stale-access",
+		RefreshToken:     "valid-refresh",
+		ExpiresAt:        time.Now().Add(-1 * time.Hour),
+		RefreshExpiresAt: time.Now().Add(24 * time.Hour),
+	}
+	if err := SaveToken(store); err != nil {
+		t.Fatalf("SaveToken error: %v", err)
+	}
+
+	srv, _ := newMockTokenServer(t, http.StatusInternalServerError, map[string]any{
+		"error": "server_error",
+	})
+
+	got, ok := refreshIfStaleLocalToken("stale-access", "aid", "sec", srv.URL)
+	if ok {
+		t.Errorf("expected ok=false on refresh failure, got ok=true (got=%q)", got)
+	}
+	if got != "" {
+		t.Errorf("expected empty string on failure, got %q", got)
+	}
+
+	// 确认 token.json 未变更
+	unchanged, _ := LoadToken()
+	if unchanged.AccessToken != "stale-access" {
+		t.Errorf("expected token.json unchanged, got AccessToken=%q", unchanged.AccessToken)
+	}
+}
+
+// ----- ForceRefreshLocalToken -----
+
+// TestForceRefreshLocalToken_NoTokenFile: token.json 不存在时返回明确错误。
+func TestForceRefreshLocalToken_NoTokenFile(t *testing.T) {
+	tokenPathFunc = func() (string, error) { return filepath.Join(t.TempDir(), "nope.json"), nil }
+	defer func() { tokenPathFunc = originalTokenPath }()
+
+	_, err := ForceRefreshLocalToken("aid", "sec", "https://example.com")
+	if err == nil {
+		t.Fatal("expected error when token.json missing, got nil")
+	}
+}
+
+// TestForceRefreshLocalToken_NoRefreshToken: token.json 存在但缺 refresh_token。
+func TestForceRefreshLocalToken_NoRefreshToken(t *testing.T) {
+	tmpDir := t.TempDir()
+	tokenPathFunc = func() (string, error) { return filepath.Join(tmpDir, "token.json"), nil }
+	defer func() { tokenPathFunc = originalTokenPath }()
+
+	store := &TokenStore{
+		AccessToken: "only-access",
+		ExpiresAt:   time.Now().Add(1 * time.Hour),
+	}
+	if err := SaveToken(store); err != nil {
+		t.Fatalf("SaveToken error: %v", err)
+	}
+
+	_, err := ForceRefreshLocalToken("aid", "sec", "https://example.com")
+	if err == nil {
+		t.Fatal("expected error when refresh_token missing, got nil")
+	}
+}
+
+// TestForceRefreshLocalToken_RefreshExpired: refresh_token 已过期时返回错误。
+func TestForceRefreshLocalToken_RefreshExpired(t *testing.T) {
+	tmpDir := t.TempDir()
+	tokenPathFunc = func() (string, error) { return filepath.Join(tmpDir, "token.json"), nil }
+	defer func() { tokenPathFunc = originalTokenPath }()
+
+	store := &TokenStore{
+		AccessToken:      "any",
+		RefreshToken:     "rt",
+		ExpiresAt:        time.Now().Add(1 * time.Hour),
+		RefreshExpiresAt: time.Now().Add(-1 * time.Hour),
+	}
+	if err := SaveToken(store); err != nil {
+		t.Fatalf("SaveToken error: %v", err)
+	}
+
+	_, err := ForceRefreshLocalToken("aid", "sec", "https://example.com")
+	if err == nil {
+		t.Fatal("expected error when refresh_token expired, got nil")
+	}
+}
+
+// TestForceRefreshLocalToken_Success: 正常路径，调用 mock token server 完成刷新。
+func TestForceRefreshLocalToken_Success(t *testing.T) {
+	tmpDir := t.TempDir()
+	tokenPathFunc = func() (string, error) { return filepath.Join(tmpDir, "token.json"), nil }
+	defer func() { tokenPathFunc = originalTokenPath }()
+
+	store := &TokenStore{
+		AccessToken:      "old-access",
+		RefreshToken:     "valid-refresh",
+		ExpiresAt:        time.Now().Add(1 * time.Hour),
+		RefreshExpiresAt: time.Now().Add(24 * time.Hour),
+		Scope:            "scope",
+	}
+	if err := SaveToken(store); err != nil {
+		t.Fatalf("SaveToken error: %v", err)
+	}
+
+	srv, _ := newMockTokenServer(t, http.StatusOK, map[string]any{
+		"access_token":  "force-fresh-access",
+		"refresh_token": "force-fresh-refresh",
+		"expires_in":    7200,
+		"scope":         "scope",
+	})
+
+	got, err := ForceRefreshLocalToken("aid", "sec", srv.URL)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got.AccessToken != "force-fresh-access" {
+		t.Errorf("AccessToken got %q want force-fresh-access", got.AccessToken)
+	}
+
+	// token.json 应同步更新
+	updated, _ := LoadToken()
+	if updated.AccessToken != "force-fresh-access" {
+		t.Errorf("token.json AccessToken got %q want force-fresh-access", updated.AccessToken)
 	}
 }


### PR DESCRIPTION
## 问题

当 `--user-access-token` 传入一个已过期但本来该被自动刷新的 access_token 时，CLI 直接报错 `code=99991677, Authentication token expired`，而不是用 token.json 里仍然有效的 refresh_token 续期。

复现：

```bash
TOKEN=$(jq -r .access_token ~/.feishu-cli/token.json)
# 等 access_token 自然过期（默认 2 小时后）
feishu-cli wiki nodes <space-id> --user-access-token "$TOKEN"
# Error: 获取节点列表失败: code=99991677, msg=Authentication token expired.
```

`auth status` 显示 `needs_refresh` + Refresh Token 仍有 N 天有效期，但没有任何 CLI 入口能消费它——只能 `auth login` 重扫码。

## 根因

`internal/auth/resolve.go` 的 `ResolveUserAccessToken` 已经实现了完整的"access 过期 → 用 refresh 续期 → 写回 token.json"逻辑（line 41-58）。

但优先级链第一条短路：

```go
// 1. 命令行参数
if flagValue != "" {
    return flagValue, nil  // 直接返回，不检查是否过期
}
```

只要传了 `--user-access-token`，直接返回 flag 值，不走后面的 token.json 检查，所以 refresh 逻辑永远不被触发。

实际场景中（参考 `wiki create` / `doc import --document-id` 等命令），由于企业版 wiki space 不接受 app token，这些命令必须传 `--user-access-token`，于是脚本通常这么写：

```bash
TOKEN=$(jq -r .access_token ~/.feishu-cli/token.json)
feishu-cli wiki create --user-access-token "$TOKEN" ...
```

本质上是"延伸本机身份"——用户的意图是用 token.json 的身份，但 CLI 无法识别。

## 修复

### 1. flag/env 命中本机 token 时自动刷新

给 `ResolveUserAccessToken` 加 helper `refreshIfStaleLocalToken`：当显式传入的 token **等于** token.json 里那个 access_token 且已过期、refresh_token 仍有效时，自动 refresh + 写回 token.json，返回新 access_token。

不匹配 token.json 的 token（用户传了别处来的 token）保持原行为不动——尊重显式传入的契约。

```go
if flagValue != \"\" {
    if refreshed, ok := refreshIfStaleLocalToken(flagValue, appID, appSecret, baseURL); ok {
        return refreshed, nil
    }
    return flagValue, nil
}
```

环境变量 `FEISHU_USER_ACCESS_TOKEN` 同样支持。

### 2. 新增 \`auth refresh\` 子命令

强制刷新 token.json 中的 access_token，独立于自动刷新路径，用于：
- 长时间运行脚本前的主动续期
- 排查 refresh_token 是否仍有效
- 让 token.json 立即同步到最新状态

```bash
$ feishu-cli auth refresh
✓ Access Token 已刷新
  Access Token:   eyJhbG...P3-nvg
  有效期至:        2026-05-06 16:16:05
  Refresh 有效期:  2026-05-13 14:16:05

$ feishu-cli auth refresh -o json  # 自动化场景
```

## 测试

新增 helper 复用了现有的 `RefreshAccessToken` + `LoadToken` + `SaveToken`，所有 `internal/auth/...` 单测通过。

人工实测两条路径：

| 场景 | 操作 | 结果 |
|---|---|---|
| 手动触发 | 改 token.json 的 expires_at 为过去时间 → 跑 \`auth refresh\` | ✓ 输出新 token，token.json 已更新 |
| 自动触发 | 同上 → 跑 \`wiki nodes --user-access-token <过期 token>\` | ✓ stderr 打印 "[自动刷新] 显式传入的 access_token 已过期且匹配本地 token.json，正在刷新..." → 命令正常返回 |

## 兼容性

- 显式传入非本机 token（别处来的）：行为完全不变
- 不传任何 flag 走 token.json：行为不变（已有的自动刷新链）
- `auth refresh` 是新增子命令，不影响任何现有命令

## 类型

- 修复（用户报告的 token 过期 false-positive）
- 新功能（\`auth refresh\` 子命令）

🤖 Generated with [Claude Code](https://claude.com/claude-code)