### PR TITLE
fix(board): clone 默认跳过 svg/image 节点避免 HTTP 500 (WIP)

### DIFF
--- a/cmd/board_clone.go
+++ b/cmd/board_clone.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"encoding/json"
 	"fmt"
+	"os"
 	"time"
 
 	"github.com/riba2534/feishu-cli/internal/client"
@@ -83,7 +84,15 @@ var boardCloneCmd = &cobra.Command{
 			}
 		}
 		// 类型统计 + 分桶
+		// svg/image 节点默认自动跳过：飞书 OpenAPI 限制（详见 issue #124）——
+		//   svg 节点的 svg.code 字段经 GET board nodes 读出来是 null（write-only），
+		//   image 节点的 image_token 跨画板不允许复用，sanitize 后直接重发 POST 会触发
+		//   服务端 2891001 internal error。
+		// 绕路：image → `board image` 拿源板渲染 PNG + `upload-image`；
+		//      svg   → `board export-code` 拉源 SVG + `svg-import`。
+		// 用户显式 --filter-types 包含 svg/image 时尊重（明知风险强制走）。
 		typeStat := map[string]int{}
+		autoSkipped := map[string]int{}
 		var shapeNodes []map[string]any
 		var connectorNodes []map[string]any
 		for _, node := range apiResp.Data.Nodes {
@@ -92,25 +101,36 @@ var boardCloneCmd = &cobra.Command{
 			if len(filterSet) > 0 && !filterSet[t] {
 				continue
 			}
+			if len(filterSet) == 0 && (t == "svg" || t == "image") {
+				autoSkipped[t]++
+				continue
+			}
 			if t == "connector" {
 				connectorNodes = append(connectorNodes, node)
 			} else {
 				shapeNodes = append(shapeNodes, node)
 			}
 		}
+		if len(autoSkipped) > 0 {
+			fmt.Fprintf(os.Stderr,
+				"[warn] 跳过 %d 个 svg/image 节点（飞书 API 限制，详见 issue #124）：%v\n"+
+					"        绕路：image 用 `board image <src>` + `upload-image`；svg 用 `board export-code <src>` + `svg-import`\n",
+				autoSkipped["svg"]+autoSkipped["image"], autoSkipped)
+		}
 
 		if dryRun {
 			summary := map[string]any{
-				"source":          srcID,
-				"target":          dstID,
-				"total_nodes":     len(apiResp.Data.Nodes),
-				"shape_to_clone":  len(shapeNodes),
-				"conn_to_clone":   len(connectorNodes),
-				"type_breakdown":  typeStat,
-				"batch_size":      batchSize,
-				"interval_secs":   intervalDur.Seconds(),
-				"filter_types":    filterTypes,
-				"dry_run":         true,
+				"source":           srcID,
+				"target":           dstID,
+				"total_nodes":      len(apiResp.Data.Nodes),
+				"shape_to_clone":   len(shapeNodes),
+				"conn_to_clone":    len(connectorNodes),
+				"type_breakdown":   typeStat,
+				"batch_size":       batchSize,
+				"interval_secs":    intervalDur.Seconds(),
+				"filter_types":     filterTypes,
+				"auto_skipped":     autoSkipped,
+				"dry_run":          true,
 			}
 			if output == "json" {
 				return printJSON(summary)
@@ -191,12 +211,13 @@ var boardCloneCmd = &cobra.Command{
 		}
 
 		result := map[string]any{
-			"source":           srcID,
-			"target":           dstID,
-			"shape_created":    shapeCreated,
+			"source":            srcID,
+			"target":            dstID,
+			"shape_created":     shapeCreated,
 			"connector_created": connCreated,
 			"connector_skipped": connSkipped,
-			"type_breakdown":   typeStat,
+			"auto_skipped":      autoSkipped,
+			"type_breakdown":    typeStat,
 		}
 		if output == "json" {
 			return printJSON(result)


### PR DESCRIPTION
WIP draft，关联 #124。先把代码方向投出来，等 @riba2534 拍方案；如果觉得方向不对随时换。

## 改了什么

`board clone` 默认自动跳过 `type=svg` 和 `type=image` 节点 + stderr warning。

## 为什么（根因复述自 #124）

svg/image 节点经 `GET /open-apis/board/.../nodes` 读出来后，sanitize + `POST .../nodes` 重发会触发服务端 `2891001 server internal error`：

- **svg 节点**：`svg.code` 字段从 API 读出来是 `null`（write-only），重发缺关键 payload
- **image 节点**：`image_token` 是源画板素材空间内的引用，跨板不允许复用

isolate 验证：手动 `jq 'del(.id,.locked,.children,.parent_id)'` sanitize 后 `feishu-cli board create-notes $DST sanitized.json` 重发同样 HTTP 500，证明根因不在 clone 命令的连线重映射逻辑，是在 svg/image 节点的特殊 schema 要求 clone 没处理。

## 行为变化

| 用户调用 | 改前 | 改后 |
|---|---|---|
| `board clone $SRC $DST`（默认） | HTTP 500 整体失败 | 跳过 svg/image，clone composite_shape/text_shape/connector，stderr warning |
| `board clone $SRC $DST --filter-types composite_shape,text_shape` | 已 OK | 保持不变 |
| `board clone $SRC $DST --filter-types svg`（用户显式） | HTTP 500 | **尊重用户**，仍 HTTP 500（明知风险强制走） |
| `board clone $SRC $DST --dry-run` | summary 不报 skip | summary 多 `auto_skipped` 字段（`{svg:N, image:M}`） |

## stderr warning 样式

```
[warn] 跳过 2 个 svg/image 节点（飞书 API 限制，详见 issue #124）：map[image:1 svg:1]
        绕路：image 用 `board image <src>` + `upload-image`；svg 用 `board export-code <src>` + `svg-import`
```

## 实测

源板 `FTccwnkT0hgzhNbvYoGll1Pegtf`（1 svg + 1 image），目标空板 `SSrIwbt7xhVZwabQ818lRDSmg7d`：

```bash
# 默认行为
$ feishu-cli board clone $SRC $DST --user-access-token "$UAT" --dry-run -o json
[warn] 跳过 2 个 svg/image 节点（飞书 API 限制，详见 issue #124）：map[image:1 svg:1]
        绕路：image 用 `board image <src>` + `upload-image`；svg 用 `board export-code <src>` + `svg-import`
{
  "auto_skipped": { "image": 1, "svg": 1 },
  "shape_to_clone": 0,
  "type_breakdown": { "image": 1, "svg": 1 },
  ...
}

# 显式 --filter-types svg（尊重用户）
$ feishu-cli board clone $SRC $DST --user-access-token "$UAT" --filter-types svg --dry-run -o json
{
  "shape_to_clone": 1,  // svg 真的进了 shape 列表（用户明确要 clone svg）
  ...
}
```

## 可讨论方向

这版是 issue #124 里 **方案 A（skip + warning）** 的最小实现。如果你想要：

- **方案 B**（默认 hard error，需要 `--allow-skip svg,image` 才跳过）：我改一下
- **方案 C**（自动 download + re-upload；image 走 board image → upload-image；svg 走 board export-code → svg-import）：工程量大但功能完整，需要你拍是否值
- **不跳过、改成把 svg/image 节点的特殊处理 push 给飞书服务端报清楚的错**：可能要在 client 层 detect svg.code=null 提前 bail

按 #124 里你的偏好调整。

## test 缺位

cmd/board_clone.go 没有 `_test.go`（cmd 包大多无单测），这版没加 test。如果你要求加 unit test 我补一下（mock client.GetBoardNodes/CreateBoardNodes 验证 auto_skip 路径）。

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
