### PR TITLE
feat(wiki): 新增 export-tree 子命令递归导出整个知识库子树

### DIFF
--- a/cmd/export_wiki_tree.go
+++ b/cmd/export_wiki_tree.go
@@ -1,0 +1,397 @@
+package cmd
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/riba2534/feishu-cli/internal/client"
+	"github.com/riba2534/feishu-cli/internal/config"
+	"github.com/spf13/cobra"
+)
+
+var exportWikiTreeCmd = &cobra.Command{
+	Use:   "export-tree <node_token|url>",
+	Short: "递归导出整个知识库子树为本地目录",
+	Long: `以指定节点为根，递归遍历整个知识库子树，按 wiki 目录结构镜像到本地。
+
+输出布局:
+  ./<output-dir>/<根节点标题>.md                     # 根节点本身
+  ./<output-dir>/<子目录>/<子目录>.md                # 有子节点的节点：自身放在同名目录里
+  ./<output-dir>/<子目录>/<叶子节点>.md              # 叶子节点直接放在父目录
+
+支持的节点类型（默认仅 docx + sheet，与 wiki export 一致）:
+  docx      新版文档（完整支持）
+  sheet     电子表格（读取数据转为 Markdown 表格）
+  其它类型（doc / bitable / mindnote / file / slides）会被跳过并计入 unsupported。
+
+示例:
+  # 导出整棵子树到当前目录
+  feishu-cli wiki export-tree LHAswV4ahiqVM4kwtbZcHhvynth
+
+  # 指定输出目录
+  feishu-cli wiki export-tree LHAswV4ahiqVM4kwtbZcHhvynth -o ./backup
+
+  # 通过 URL 导出
+  feishu-cli wiki export-tree https://xxx.feishu.cn/wiki/LHAswV4ahiqVM4kwtbZcHhvynth -o ./backup
+
+  # 限制深度（避免拉超大子树）
+  feishu-cli wiki export-tree <token> -o ./backup --max-depth 3
+
+  # 只导 docx，跳过 sheet
+  feishu-cli wiki export-tree <token> -o ./backup --include-types docx
+
+  # 增量同步：已存在的 md 跳过
+  feishu-cli wiki export-tree <token> -o ./backup --skip-existing
+
+  # 单文档失败时立即中断（默认 continue）
+  feishu-cli wiki export-tree <token> -o ./backup --continue-on-error=false
+
+  # 同时下载图片到 assets 目录
+  feishu-cli wiki export-tree <token> -o ./backup --download-images --assets-dir ./backup/assets`,
+	Args: cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		if err := config.Validate(); err != nil {
+			return err
+		}
+
+		rootToken, err := extractWikiToken(args[0])
+		if err != nil {
+			return err
+		}
+
+		outputDir, _ := cmd.Flags().GetString("output-dir")
+		if outputDir == "" {
+			outputDir = "./"
+		}
+		if err := validateOutputPath(outputDir, ""); err != nil {
+			return fmt.Errorf("输出目录不安全: %w", err)
+		}
+
+		maxDepth, _ := cmd.Flags().GetInt("max-depth")
+		includeTypes, _ := cmd.Flags().GetStringSlice("include-types")
+		skipExisting, _ := cmd.Flags().GetBool("skip-existing")
+		continueOnError, _ := cmd.Flags().GetBool("continue-on-error")
+
+		userAccessToken := resolveOptionalUserTokenWithFallback(cmd)
+
+		// 1. 取根节点信息（自动得到 SpaceID，无需用户传）
+		fmt.Printf("正在解析根节点: %s\n", rootToken)
+		root, err := client.GetWikiNode(rootToken, userAccessToken)
+		if err != nil {
+			return err
+		}
+		fmt.Printf("根节点标题: %s\n", root.Title)
+		fmt.Printf("知识空间 ID: %s\n", root.SpaceID)
+
+		// 2. 收集整棵树（决定每个节点的本地输出路径）
+		fmt.Println("正在收集子树结构...")
+		jobs, err := collectWikiTree(root, outputDir, maxDepth, userAccessToken)
+		if err != nil {
+			return fmt.Errorf("收集子树失败: %w", err)
+		}
+		fmt.Printf("共发现 %d 个节点，开始导出\n\n", len(jobs))
+
+		// 3. 逐个导出
+		stats := newTreeStats(len(jobs))
+		for i, job := range jobs {
+			progress := fmt.Sprintf("[%d/%d]", i+1, len(jobs))
+			rel, _ := filepath.Rel(outputDir, job.OutputPath)
+			if rel == "" {
+				rel = job.OutputPath
+			}
+
+			// 类型过滤
+			if !isExportableWikiType(job.Node.ObjType, includeTypes) {
+				fmt.Printf("%s ⊘ %s  (skip: 不在 --include-types 列表，obj_type=%s)\n", progress, rel, job.Node.ObjType)
+				stats.Unsupported++
+				continue
+			}
+
+			// skip-existing
+			if skipExisting && fileExistsAndNonEmpty(job.OutputPath) {
+				fmt.Printf("%s ⏭  %s  (已存在，跳过)\n", progress, rel)
+				stats.Skipped++
+				continue
+			}
+
+			// 确保父目录存在
+			if err := os.MkdirAll(filepath.Dir(job.OutputPath), 0700); err != nil {
+				stats.Failed++
+				stats.Failures = append(stats.Failures, treeFailure{
+					NodeToken: job.Node.NodeToken,
+					Title:     job.Node.Title,
+					Path:      rel,
+					Error:     fmt.Sprintf("创建目录失败: %v", err),
+				})
+				fmt.Printf("%s ✗ %s  (创建目录失败: %v)\n", progress, rel, err)
+				if !continueOnError {
+					return fmt.Errorf("创建目录失败: %w", err)
+				}
+				continue
+			}
+
+			// 导出
+			markdown, err := exportWikiNodeMarkdown(job.Node, userAccessToken, cmd)
+			if err != nil {
+				stats.Failed++
+				stats.Failures = append(stats.Failures, treeFailure{
+					NodeToken: job.Node.NodeToken,
+					Title:     job.Node.Title,
+					Path:      rel,
+					Error:     err.Error(),
+				})
+				fmt.Printf("%s ✗ %s  (导出失败: %v)\n", progress, rel, err)
+				if !continueOnError {
+					return fmt.Errorf("%s 导出失败: %w", job.Node.Title, err)
+				}
+				continue
+			}
+
+			if err := os.WriteFile(job.OutputPath, []byte(markdown), 0600); err != nil {
+				stats.Failed++
+				stats.Failures = append(stats.Failures, treeFailure{
+					NodeToken: job.Node.NodeToken,
+					Title:     job.Node.Title,
+					Path:      rel,
+					Error:     fmt.Sprintf("写入文件失败: %v", err),
+				})
+				fmt.Printf("%s ✗ %s  (写入失败: %v)\n", progress, rel, err)
+				if !continueOnError {
+					return fmt.Errorf("写入文件失败: %w", err)
+				}
+				continue
+			}
+
+			stats.Success++
+			fmt.Printf("%s ✓ %s\n", progress, rel)
+		}
+
+		// 4. 总结
+		printTreeSummary(stats, outputDir)
+		return nil
+	},
+}
+
+// treeJob 一次「需要导出的节点 + 它的本地路径」的待办。
+type treeJob struct {
+	Node       *client.WikiNode
+	OutputPath string
+}
+
+// treeFailure 描述一个失败的导出任务，用于最后汇总。
+type treeFailure struct {
+	NodeToken string `json:"node_token"`
+	Title     string `json:"title"`
+	Path      string `json:"path"`
+	Error     string `json:"error"`
+}
+
+// treeStats 跟踪导出统计。
+type treeStats struct {
+	Total       int
+	Success     int
+	Skipped     int
+	Unsupported int
+	Failed      int
+	Failures    []treeFailure
+}
+
+func newTreeStats(total int) *treeStats {
+	return &treeStats{Total: total}
+}
+
+// collectWikiTree 以 root 为起点递归列出所有节点，决定每个节点的本地路径。
+//
+// 输出布局规则：
+//   - 根节点：写到 outputDir/<sanitizedRootTitle>.md
+//   - 有子节点的节点：自身写到 outputDir/.../<title>/<title>.md（即放在同名子目录中）
+//   - 叶子节点：写到 outputDir/.../<title>.md
+//
+// 同父下出现重名子节点时，第 2 个及以后追加 _<token[:6]> 防止路径碰撞。
+func collectWikiTree(root *client.WikiNode, outputDir string, maxDepth int, userAccessToken string) ([]treeJob, error) {
+	var jobs []treeJob
+
+	rootName := sanitizeWikiTitle(root.Title)
+	if root.HasChild {
+		// 根节点本身 + 它的子节点都挂在 outputDir 下，不为根再单独建一级目录
+		// 这样 outputDir 直接就是「根节点对应的目录」，避免出现 ./out/<root>/<root>.md 这种深一层
+		// 用户可以通过 -o 决定根目录的位置和名字。
+		jobs = append(jobs, treeJob{Node: root, OutputPath: filepath.Join(outputDir, rootName+".md")})
+		if err := walkChildren(root, outputDir, 1, maxDepth, userAccessToken, &jobs); err != nil {
+			return nil, err
+		}
+	} else {
+		jobs = append(jobs, treeJob{Node: root, OutputPath: filepath.Join(outputDir, rootName+".md")})
+	}
+
+	return jobs, nil
+}
+
+// walkChildren 递归处理 parent 节点的所有子节点，把它们的路径计算好后塞进 jobs。
+func walkChildren(parent *client.WikiNode, parentDir string, depth, maxDepth int, userAccessToken string, jobs *[]treeJob) error {
+	if maxDepth > 0 && depth > maxDepth {
+		return nil
+	}
+
+	children, err := listAllWikiChildren(parent.SpaceID, parent.NodeToken, userAccessToken)
+	if err != nil {
+		return fmt.Errorf("列出 %q 的子节点失败: %w", parent.Title, err)
+	}
+
+	usedNames := make(map[string]bool)
+	for _, child := range children {
+		baseName := sanitizeWikiTitle(child.Title)
+		uniqueName := dedupeSiblingName(baseName, child.NodeToken, usedNames)
+		usedNames[uniqueName] = true
+
+		if child.HasChild {
+			mirrorDir := filepath.Join(parentDir, uniqueName)
+			*jobs = append(*jobs, treeJob{
+				Node:       child,
+				OutputPath: filepath.Join(mirrorDir, uniqueName+".md"),
+			})
+			if err := walkChildren(child, mirrorDir, depth+1, maxDepth, userAccessToken, jobs); err != nil {
+				return err
+			}
+		} else {
+			*jobs = append(*jobs, treeJob{
+				Node:       child,
+				OutputPath: filepath.Join(parentDir, uniqueName+".md"),
+			})
+		}
+	}
+	return nil
+}
+
+// listAllWikiChildren 翻页列出某个父节点下的全部直接子节点。
+func listAllWikiChildren(spaceID, parentToken, userAccessToken string) ([]*client.WikiNode, error) {
+	var all []*client.WikiNode
+	pageToken := ""
+	for {
+		nodes, next, hasMore, err := client.ListWikiNodes(spaceID, parentToken, 50, pageToken, userAccessToken)
+		if err != nil {
+			return nil, err
+		}
+		all = append(all, nodes...)
+		if !hasMore || next == "" {
+			break
+		}
+		pageToken = next
+	}
+	return all, nil
+}
+
+// sanitizeWikiTitle 把 wiki 节点标题转成可作为文件/目录名的安全字符串。
+// 复用 cmd/utils.go 里的 safeOutputPath（只做字符替换 + 长度截断），
+// 然后处理空标题 / 单点目录等极端情况。
+func sanitizeWikiTitle(title string) string {
+	cleaned := safeOutputPath(strings.TrimSpace(title), "")
+	cleaned = strings.Trim(cleaned, ". ")
+	if cleaned == "" {
+		return "untitled"
+	}
+	return cleaned
+}
+
+// dedupeSiblingName 在同父目录下，如果 baseName 已被同级 sibling 用过，
+// 追加 _<token[:6]> 后缀避免文件/目录碰撞。
+func dedupeSiblingName(baseName, token string, used map[string]bool) string {
+	if !used[baseName] {
+		return baseName
+	}
+	suffix := token
+	if len(suffix) > 6 {
+		suffix = suffix[:6]
+	}
+	candidate := baseName + "_" + suffix
+	// 万一连带 token 后缀都撞了（极小概率），再追加序号
+	for i := 2; used[candidate]; i++ {
+		candidate = fmt.Sprintf("%s_%s_%d", baseName, suffix, i)
+	}
+	return candidate
+}
+
+// isExportableWikiType 判断节点类型是否在用户指定的导出白名单内。
+// 同时排除掉当前 wiki export 不支持转 Markdown 的类型（doc/bitable/mindnote/file/slides）。
+func isExportableWikiType(objType string, allowed []string) bool {
+	switch objType {
+	case "docx", "sheet":
+	default:
+		return false
+	}
+	if len(allowed) == 0 {
+		return true
+	}
+	for _, t := range allowed {
+		if strings.EqualFold(strings.TrimSpace(t), objType) {
+			return true
+		}
+	}
+	return false
+}
+
+// fileExistsAndNonEmpty 判断指定路径是否已经是非空文件，用于 --skip-existing。
+func fileExistsAndNonEmpty(path string) bool {
+	info, err := os.Stat(path)
+	if err != nil {
+		return false
+	}
+	return !info.IsDir() && info.Size() > 0
+}
+
+// exportWikiNodeMarkdown 复用现有 export_wiki.go 里的转换逻辑，根据 obj_type 分发。
+func exportWikiNodeMarkdown(node *client.WikiNode, userAccessToken string, cmd *cobra.Command) (string, error) {
+	switch node.ObjType {
+	case "docx":
+		return exportDocxToMarkdown(node.ObjToken, userAccessToken, cmd)
+	case "sheet":
+		return exportSheetToMarkdown(node.ObjToken, node.Title, userAccessToken)
+	default:
+		return "", fmt.Errorf("不支持的节点类型: %s", node.ObjType)
+	}
+}
+
+// printTreeSummary 在导出结束后打印总结，便于用户一眼看清结果。
+func printTreeSummary(stats *treeStats, outputDir string) {
+	fmt.Println()
+	fmt.Println("=== 导出完成 ===")
+	fmt.Printf("  输出目录: %s\n", outputDir)
+	fmt.Printf("  总节点:   %d\n", stats.Total)
+	fmt.Printf("  成功:     %d\n", stats.Success)
+	if stats.Skipped > 0 {
+		fmt.Printf("  跳过(已存在): %d\n", stats.Skipped)
+	}
+	if stats.Unsupported > 0 {
+		fmt.Printf("  跳过(不支持): %d\n", stats.Unsupported)
+	}
+	if stats.Failed > 0 {
+		fmt.Printf("  失败:     %d\n", stats.Failed)
+		fmt.Println()
+		fmt.Println("失败明细:")
+		for _, f := range stats.Failures {
+			fmt.Printf("  - [%s] %s\n    %s\n", f.NodeToken, f.Path, truncate(f.Error, 200))
+		}
+	}
+}
+
+// truncate 截断长字符串用于错误展示。
+func truncate(s string, n int) string {
+	if len(s) <= n {
+		return s
+	}
+	return s[:n] + "…"
+}
+
+func init() {
+	wikiCmd.AddCommand(exportWikiTreeCmd)
+	exportWikiTreeCmd.Flags().StringP("output-dir", "o", "./", "输出根目录")
+	exportWikiTreeCmd.Flags().Int("max-depth", 10, "最大递归深度（0 表示无限）")
+	exportWikiTreeCmd.Flags().StringSlice("include-types", []string{"docx", "sheet"}, "要导出的 obj_type，逗号分隔（仅 docx/sheet 实际支持转 Markdown，其它类型即使列出也会被跳过）")
+	exportWikiTreeCmd.Flags().Bool("download-images", false, "下载图片到本地目录（透传给底层 export）")
+	exportWikiTreeCmd.Flags().String("assets-dir", "./assets", "图片下载目录（透传给底层 export）")
+	exportWikiTreeCmd.Flags().Bool("skip-existing", false, "已存在且非空的 md 跳过（适合增量同步）")
+	exportWikiTreeCmd.Flags().Bool("continue-on-error", true, "单个节点导出失败时是否继续后续节点")
+	exportWikiTreeCmd.Flags().String("user-access-token", "", "User Access Token（可选；默认优先使用 auth login 登录态，失败时回退 App Token）")
+}

--- a/cmd/export_wiki_tree_test.go
+++ b/cmd/export_wiki_tree_test.go
@@ -1,0 +1,179 @@
+package cmd
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestSanitizeWikiTitle(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  string
+	}{
+		{"normal", "Hello World", "Hello World"},
+		{"chinese", "学习计划", "学习计划"},
+		{"slash", "a/b/c", "a_b_c"},
+		{"backslash", `a\b\c`, "a_b_c"},
+		{"colon", "a:b", "a_b"},
+		{"asterisk", "a*b", "a_b"},
+		{"question", "a?b", "a_b"},
+		{"quote", `a"b`, "a_b"},
+		{"angle brackets", "a<b>c", "a_b_c"},
+		{"pipe", "a|b", "a_b"},
+		{"all special", `a/\:*?"<>|b`, "a_________b"},
+		{"empty", "", "untitled"},
+		{"only spaces", "   ", "untitled"},
+		{"only dots", "...", "untitled"},
+		{"trailing dots and spaces", "  hello.  ", "hello"},
+		{"emoji preserved", "Go 学习指引 ⭐", "Go 学习指引 ⭐"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := sanitizeWikiTitle(tt.input)
+			if got != tt.want {
+				t.Errorf("sanitizeWikiTitle(%q) = %q, want %q", tt.input, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestSanitizeWikiTitleLengthLimit(t *testing.T) {
+	// safeOutputPath 在 utils.go 里的硬上限是 200 字符
+	long := strings.Repeat("a", 250)
+	got := sanitizeWikiTitle(long)
+	if len(got) > 200 {
+		t.Errorf("sanitizeWikiTitle did not truncate to <=200, got len=%d", len(got))
+	}
+}
+
+func TestDedupeSiblingName(t *testing.T) {
+	used := map[string]bool{}
+
+	// 第一次出现：原名直接用
+	first := dedupeSiblingName("hello", "abcdef123456", used)
+	if first != "hello" {
+		t.Fatalf("first occurrence should keep original name, got %q", first)
+	}
+	used[first] = true
+
+	// 第二次同名：加 token 前 6 位
+	second := dedupeSiblingName("hello", "xyz789abc000", used)
+	wantSecond := "hello_xyz789"
+	if second != wantSecond {
+		t.Fatalf("second occurrence should append token prefix, got %q want %q", second, wantSecond)
+	}
+	used[second] = true
+
+	// 第三次同名同 token 前缀（构造极端碰撞）：加序号
+	third := dedupeSiblingName("hello", "xyz789other", used)
+	if third == "hello" || third == "hello_xyz789" {
+		t.Fatalf("third occurrence collided, got %q", third)
+	}
+	if !strings.HasPrefix(third, "hello_xyz789") {
+		t.Fatalf("third should still start with hello_xyz789, got %q", third)
+	}
+}
+
+func TestDedupeSiblingNameShortToken(t *testing.T) {
+	used := map[string]bool{"x": true}
+	got := dedupeSiblingName("x", "abc", used)
+	wantSuffix := "_abc"
+	if !strings.HasSuffix(got, wantSuffix) {
+		t.Fatalf("short token should be used as-is, got %q want suffix %q", got, wantSuffix)
+	}
+}
+
+func TestIsExportableWikiType(t *testing.T) {
+	tests := []struct {
+		name    string
+		objType string
+		allowed []string
+		want    bool
+	}{
+		{"docx default", "docx", []string{"docx", "sheet"}, true},
+		{"sheet default", "sheet", []string{"docx", "sheet"}, true},
+		{"bitable rejected", "bitable", []string{"docx", "sheet"}, false},
+		{"file rejected", "file", []string{"docx", "sheet"}, false},
+		{"mindnote rejected", "mindnote", []string{"docx", "sheet"}, false},
+		{"slides rejected", "slides", []string{"docx", "sheet"}, false},
+		{"doc rejected", "doc", []string{"docx", "sheet"}, false},
+		{"narrow to docx only", "sheet", []string{"docx"}, false},
+		{"narrow to docx only - docx ok", "docx", []string{"docx"}, true},
+		{"empty allowed list = all supported", "docx", nil, true},
+		{"empty allowed list = all supported sheet", "sheet", []string{}, true},
+		{"empty allowed still rejects unsupported", "bitable", nil, false},
+		{"case insensitive", "DOCX", []string{"docx"}, false}, // ObjType is always lowercase
+		{"whitespace in allowed", "docx", []string{"  docx  "}, true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := isExportableWikiType(tt.objType, tt.allowed)
+			if got != tt.want {
+				t.Errorf("isExportableWikiType(%q, %v) = %v, want %v", tt.objType, tt.allowed, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestFileExistsAndNonEmpty(t *testing.T) {
+	dir := t.TempDir()
+
+	t.Run("nonexistent", func(t *testing.T) {
+		if fileExistsAndNonEmpty(filepath.Join(dir, "nope.md")) {
+			t.Error("nonexistent file should return false")
+		}
+	})
+
+	t.Run("empty file", func(t *testing.T) {
+		p := filepath.Join(dir, "empty.md")
+		if err := os.WriteFile(p, []byte{}, 0600); err != nil {
+			t.Fatal(err)
+		}
+		if fileExistsAndNonEmpty(p) {
+			t.Error("empty file should return false")
+		}
+	})
+
+	t.Run("nonempty file", func(t *testing.T) {
+		p := filepath.Join(dir, "ok.md")
+		if err := os.WriteFile(p, []byte("hello"), 0600); err != nil {
+			t.Fatal(err)
+		}
+		if !fileExistsAndNonEmpty(p) {
+			t.Error("non-empty file should return true")
+		}
+	})
+
+	t.Run("directory returns false", func(t *testing.T) {
+		if fileExistsAndNonEmpty(dir) {
+			t.Error("directory should return false (not a file)")
+		}
+	})
+}
+
+func TestTruncate(t *testing.T) {
+	tests := []struct {
+		name string
+		s    string
+		n    int
+		want string
+	}{
+		{"shorter than limit", "hello", 10, "hello"},
+		{"exactly at limit", "hello", 5, "hello"},
+		{"longer than limit", "hello world", 5, "hello…"},
+		{"empty", "", 5, ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := truncate(tt.s, tt.n)
+			if got != tt.want {
+				t.Errorf("truncate(%q, %d) = %q, want %q", tt.s, tt.n, got, tt.want)
+			}
+		})
+	}
+}

--- a/cmd/wiki.go
+++ b/cmd/wiki.go
@@ -19,6 +19,7 @@ var wikiCmd = &cobra.Command{
   spaces        列出知识空间
   nodes         列出空间下的节点
   export        导出知识库文档为 Markdown
+  export-tree   递归导出整个知识库子树为本地目录
 
 知识库 URL 格式:
   https://xxx.feishu.cn/wiki/<node_token>
@@ -55,8 +56,11 @@ var wikiCmd = &cobra.Command{
   # 列出空间下的节点
   feishu-cli wiki nodes <space_id>
 
-  # 导出为 Markdown（仅支持 docx 类型）
-  feishu-cli wiki export <node_token> --output doc.md`,
+  # 导出为 Markdown（仅支持 docx / sheet 类型）
+  feishu-cli wiki export <node_token> --output doc.md
+
+  # 递归导出整个子树（按 wiki 目录结构镜像到本地）
+  feishu-cli wiki export-tree <node_token> --output-dir ./backup`,
 }
 
 func init() {


### PR DESCRIPTION
## 背景

当前 `feishu-cli wiki export` 一次只能导出单个 node。要把一整个 wiki
子树备份到本地，得先 `wiki nodes` 列出再脚本 for-loop 调 export，命令
行体验上缺一个开箱即用的递归入口。

## 改动

新增 `wiki export-tree` 子命令：以给定节点为根递归遍历子树，按 wiki
目录结构镜像到本地。

完全复用 `GetWikiNode` / `ListWikiNodes` / `wiki export` 的既有逻辑，
**不引入新的 client 抽象，不动 `internal/client/wiki.go`**：

| 文件 | 变更 |
|------|------|
| `cmd/export_wiki_tree.go` | 新增（397 行）：主命令 + walker + 类型过滤 / 同名 dedup / skip-existing / 失败汇总 |
| `cmd/export_wiki_tree_test.go` | 新增（179 行）：36 个表驱动单测 |
| `cmd/wiki.go` | +6 行：Long help 加 `export-tree` 章节 |

## 命令

```bash
# 导出整棵子树到当前目录
feishu-cli wiki export-tree LHAswV4ahiqVM4kwtbZcHhvynth

# 指定输出目录
feishu-cli wiki export-tree LHAswV4ahiqVM4kwtbZcHhvynth -o ./backup

# 限制深度（避免拉超大子树）
feishu-cli wiki export-tree <token> -o ./backup --max-depth 3

# 只导 docx，跳过 sheet
feishu-cli wiki export-tree <token> -o ./backup --include-types docx

# 增量同步：已存在的 md 跳过
feishu-cli wiki export-tree <token> -o ./backup --skip-existing

# 单文档失败立即中断（默认 continue）
feishu-cli wiki export-tree <token> -o ./backup --continue-on-error=false

# 同时下载图片
feishu-cli wiki export-tree <token> -o ./backup --download-images --assets-dir ./backup/assets
```

## 输出布局

```
./backup/
├── <根节点标题>.md                      ← 根节点本身
├── <叶子节点1>.md                       ← 叶子节点放在父目录
└── <子目录>/                            ← 有子节点的节点：自身放在同名目录里
    ├── <子目录>.md
    ├── <孙节点1>.md
    └── ...
```

同名兄弟节点自动 dedup：第 2+ 个追加 `_<token[:6]>` 后缀避免路径碰撞。

## 行为对比

| 场景 | 改前 | 改后 |
|---|---|---|
| 单页导出 | `wiki export <token> -o x.md` | （不变） |
| 整棵子树导出 | 用户自己写脚本 walk + for-loop | `wiki export-tree <token> -o ./out/` |
| 不支持的 obj_type（bitable / mindnote / file / slides）| `wiki export` 报错中断 | `wiki export-tree` 自动跳过 + 计数 + ⊘ 标记 |
| 单个文档失败 | 整体中断 | 默认继续，最后汇总失败明细 |
| 进度可见 | 用户脚本自己打 | `[N/M] ✓ <path>` per doc |
| 重复运行 | 完全重下 | `--skip-existing` 跳过已有 md |

## 测试

**单测覆盖（`cmd/export_wiki_tree_test.go`，36 个表驱动 case）：**

- `TestSanitizeWikiTitle` 16 个 case：特殊字符替换、空标题、emoji、长度截断
- `TestDedupeSiblingName` + ShortToken：同父同名 dedup、token 短于 6 字符
- `TestIsExportableWikiType` 14 个 case：默认白名单、用户窄化、空允许列表
- `TestFileExistsAndNonEmpty` 4 个 case：空文件 / 不存在 / 目录 / 非空文件
- `TestTruncate` 4 个 case

**烟囱测试（实际飞书 wiki，覆盖 5 个场景）：**

| # | 场景 | 结果 |
|---|---|---|
| 1 | 17 docx 子树全量导出 | 17/17 ✓ |
| 2 | 同命令 + `--skip-existing` 第二次跑 | 17 跳过，0 重下 ✓ |
| 3 | 多层子树 + `--max-depth 1` vs `10` | 8 节点 vs 27 节点 ✓ |
| 4 | 99 doc Redis 全套子树 | 99/99 ✓ |
| 5 | 113 节点含 zip/dmg/pdf 等 file 类型 | 72 docx 成功 + 41 file 自动跳过 ✓ |

**回归：** `go test ./...` 全 pass，`go vet ./...` 干净。
