### PR TITLE
fix(msg): read interactive card content by default

### DIFF
--- a/cmd/get_message.go
+++ b/cmd/get_message.go
@@ -18,7 +18,7 @@ var getMessageCmd = &cobra.Command{
 参数:
   message_id            消息 ID（必填）
   --output, -o          输出格式（json）
-  --card-content-type   interactive 卡片返回格式：user / raw（默认空，返回渲染版）
+  --card-content-type   interactive 卡片返回格式：user / raw / rendered（默认 user）
 
 示例:
   # 获取消息详情
@@ -27,11 +27,14 @@ var getMessageCmd = &cobra.Command{
   # JSON 格式输出
   feishu-cli msg get om_xxx --output json
 
-  # interactive 卡片返回原始 schema 2.0 JSON（开发者视角的 userDSL）
+  # interactive 卡片返回 schema 2.0 JSON，并额外提取 card_texts（默认）
   feishu-cli msg get om_xxx --card-content-type user
 
   # interactive 卡片返回平台内部完整 cardDSL
-  feishu-cli msg get om_xxx --card-content-type raw`,
+  feishu-cli msg get om_xxx --card-content-type raw
+
+  # 保留 OAPI 原始渲染版/降级版
+  feishu-cli msg get om_xxx --card-content-type rendered`,
 	Args: cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		if err := config.Validate(); err != nil {
@@ -68,8 +71,14 @@ var getMessageCmd = &cobra.Command{
 				"message":      msg,
 				"sender_names": senderNames,
 			}
+			if cardTexts := client.ExtractCardTexts(msg); len(cardTexts) > 0 {
+				enriched["card_texts"] = cardTexts
+			}
 			if len(result.SubMessages) > 0 {
 				enriched["sub_messages"] = result.SubMessages
+				if cardTextMap := client.ExtractCardTextMap(result.SubMessages); len(cardTextMap) > 0 {
+					enriched["sub_message_card_texts"] = cardTextMap
+				}
 			}
 			if err := printJSON(enriched); err != nil {
 				return err
@@ -117,6 +126,12 @@ var getMessageCmd = &cobra.Command{
 			}
 			if msg.Body != nil && msg.Body.Content != nil {
 				fmt.Printf("  消息内容: %s\n", *msg.Body.Content)
+			}
+			if cardTexts := client.ExtractCardTexts(msg); len(cardTexts) > 0 {
+				fmt.Printf("  卡片文本:\n")
+				for _, text := range cardTexts {
+					fmt.Printf("    %s\n", text)
+				}
 			}
 			if len(result.SubMessages) > 0 {
 				fmt.Printf("  嵌套子消息: %d 条（含递归展开，使用 --output json 查看完整内容）\n", len(result.SubMessages))

--- a/cmd/get_message_history.go
+++ b/cmd/get_message_history.go
@@ -26,6 +26,7 @@ var getMessageHistoryCmd = &cobra.Command{
   --page-size           分页大小 (1-50)，默认 50
   --page-token          分页标记
   --output, -o          输出格式 (json)
+  --card-content-type   interactive 卡片返回格式：user / raw / rendered（默认 user）
 
 示例:
   # 群聊
@@ -39,7 +40,10 @@ var getMessageHistoryCmd = &cobra.Command{
 
   # 指定时间范围 + 升序
   feishu-cli msg history --user-email user@example.com \
-    --start-time 1704067200 --sort-type ByCreateTimeAsc`,
+    --start-time 1704067200 --sort-type ByCreateTimeAsc
+
+  # 保留 OAPI 原始渲染版/降级版
+  feishu-cli msg history --container-id oc_xxx --card-content-type rendered -o json`,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		if err := config.Validate(); err != nil {
 			return err
@@ -60,6 +64,10 @@ var getMessageHistoryCmd = &cobra.Command{
 		pageSize, _ := cmd.Flags().GetInt("page-size")
 		pageToken, _ := cmd.Flags().GetString("page-token")
 		output, _ := cmd.Flags().GetString("output")
+		cardContentType, err := resolveCardContentType(cmd)
+		if err != nil {
+			return err
+		}
 
 		// 三种入口互斥，必须恰好一个
 		entryCount := 0
@@ -116,6 +124,7 @@ var getMessageHistoryCmd = &cobra.Command{
 			SortType:        sortType,
 			PageSize:        pageSize,
 			PageToken:       pageToken,
+			CardContentType: cardContentType,
 		}
 
 		result, err := client.ListMessages(containerID, opts, token)
@@ -132,9 +141,7 @@ var getMessageHistoryCmd = &cobra.Command{
 
 		if needFallback {
 			fmt.Fprintf(cmd.ErrOrStderr(), "[提示] bot 不在此群中，通过搜索方式获取消息...\n")
-			// msg history 命令暂未暴露 --card-content-type flag，传空保持渲染版默认行为；
-			// 如未来给 msg history 也加 flag，把 resolveCardContentType 的结果接进来即可。
-			fallbackResult, fallbackErr := listMessagesViaSearch(containerID, pageSize, pageToken, token, "")
+			fallbackResult, fallbackErr := listMessagesViaSearch(containerID, pageSize, pageToken, token, cardContentType)
 			if fallbackErr != nil {
 				if err != nil {
 					return err
@@ -159,8 +166,18 @@ var getMessageHistoryCmd = &cobra.Command{
 				"page_token":   result.PageToken,
 				"sender_names": senderNames,
 			}
+			if cardTextMap := client.ExtractCardTextMap(result.Items); len(cardTextMap) > 0 {
+				enriched["card_texts"] = cardTextMap
+			}
 			if len(result.MergeForwardSubMessages) > 0 {
 				enriched["merge_forward_sub_messages"] = result.MergeForwardSubMessages
+				var subMsgs []*larkim.Message
+				for _, subs := range result.MergeForwardSubMessages {
+					subMsgs = append(subMsgs, subs...)
+				}
+				if cardTextMap := client.ExtractCardTextMap(subMsgs); len(cardTextMap) > 0 {
+					enriched["merge_forward_card_texts"] = cardTextMap
+				}
 			}
 			if err := printJSON(enriched); err != nil {
 				return err
@@ -217,4 +234,5 @@ func init() {
 	getMessageHistoryCmd.Flags().String("page-token", "", "分页标记")
 	getMessageHistoryCmd.Flags().StringP("output", "o", "", "输出格式 (json)")
 	getMessageHistoryCmd.Flags().String("user-access-token", "", "User Access Token（用户授权令牌）")
+	addCardContentTypeFlag(getMessageHistoryCmd)
 }

--- a/cmd/list_messages.go
+++ b/cmd/list_messages.go
@@ -38,7 +38,7 @@ var listMessagesCmd = &cobra.Command{
   # JSON 格式输出
   feishu-cli msg list --container-id oc_xxx --output json
 
-  # interactive 卡片返回原始 schema 2.0 JSON（开发者视角的 userDSL）
+  # interactive 卡片返回 schema 2.0 JSON，并额外提取 card_texts（默认）
   feishu-cli msg list --container-id oc_xxx --card-content-type user`,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		if err := config.Validate(); err != nil {
@@ -111,8 +111,18 @@ var listMessagesCmd = &cobra.Command{
 				"has_more":     result.HasMore,
 				"sender_names": senderNames,
 			}
+			if cardTextMap := client.ExtractCardTextMap(result.Items); len(cardTextMap) > 0 {
+				payload["card_texts"] = cardTextMap
+			}
 			if len(result.MergeForwardSubMessages) > 0 {
 				payload["merge_forward_sub_messages"] = result.MergeForwardSubMessages
+				var subMsgs []*larkim.Message
+				for _, subs := range result.MergeForwardSubMessages {
+					subMsgs = append(subMsgs, subs...)
+				}
+				if cardTextMap := client.ExtractCardTextMap(subMsgs); len(cardTextMap) > 0 {
+					payload["merge_forward_card_texts"] = cardTextMap
+				}
 			}
 			if err := printJSON(payload); err != nil {
 				return err

--- a/cmd/msg_card_content_type.go
+++ b/cmd/msg_card_content_type.go
@@ -8,34 +8,37 @@ import (
 	"github.com/spf13/cobra"
 )
 
-// cardContentTypeFlagDesc 是 msg get/mget/list 三个查询命令共用的 flag 帮助文本。
+// cardContentTypeFlagDesc 是 msg get/mget/list/history 查询命令共用的 flag 帮助文本。
 //
-// 飞书 OAPI 对 interactive 卡片消息默认返回**渲染后**的文本（形如
-// `<card title="...">...</card>`）。要拿到原始 schema JSON，必须传
-// card_msg_content_type 参数。这里支持简写（user/raw）和完整 OAPI 值，便于在 CLI
-// 里少敲几个字符。
-const cardContentTypeFlagDesc = "卡片消息返回格式：user / raw（默认空，返回渲染版）。" +
-	"user → user_card_content（开发者构建时的 schema 2.0 JSON，便于偷师/调试）；" +
-	"raw → raw_card_content（平台内部完整 cardDSL）"
+// 飞书 OAPI 不传 card_msg_content_type 时，部分 interactive 卡片只返回“请升级客户端”
+// 的降级内容。CLI 默认请求 user_card_content，并额外提取 card_texts 方便阅读。
+const cardContentTypeFlagDesc = "卡片消息返回格式：user / raw / rendered（默认 user）。" +
+	"user → user_card_content（schema 2.0 JSON，CLI 会提取 card_texts）；" +
+	"raw → raw_card_content（平台内部完整 cardDSL）；" +
+	"rendered → 不传 card_msg_content_type，保留 OAPI 渲染版/降级版"
 
 // addCardContentTypeFlag 把 --card-content-type flag 注册到目标命令上。
 func addCardContentTypeFlag(c *cobra.Command) {
 	c.Flags().String("card-content-type", "", cardContentTypeFlagDesc)
 }
 
-// resolveCardContentType 把 flag 值（user/raw 或完整 OAPI 名）规范化为 OAPI 接受的字符串。
-// 空字符串保持空，让 client 层走原有渲染版返回路径，向后兼容。
+// resolveCardContentType 把 flag 值（user/raw/rendered 或完整 OAPI 名）规范化为 OAPI 接受的字符串。
+// 未显式传 flag 时默认 user_card_content，避免 interactive 卡片只返回“请升级客户端”。
+// 显式传 rendered/default/legacy 时保持空字符串，让 client 层走 OAPI 原有渲染版返回路径。
 func resolveCardContentType(cmd *cobra.Command) (string, error) {
 	v, _ := cmd.Flags().GetString("card-content-type")
 	v = strings.TrimSpace(v)
+	if !cmd.Flags().Changed("card-content-type") && v == "" {
+		return client.CardMsgContentTypeUser, nil
+	}
 	switch strings.ToLower(v) {
-	case "":
+	case "", "rendered", "default", "legacy":
 		return "", nil
 	case "user", client.CardMsgContentTypeUser:
 		return client.CardMsgContentTypeUser, nil
 	case "raw", client.CardMsgContentTypeRaw:
 		return client.CardMsgContentTypeRaw, nil
 	default:
-		return "", fmt.Errorf("无效的 --card-content-type 取值 %q（合法值：user / raw / user_card_content / raw_card_content）", v)
+		return "", fmt.Errorf("无效的 --card-content-type 取值 %q（合法值：user / raw / rendered / user_card_content / raw_card_content）", v)
 	}
 }

--- a/cmd/msg_card_content_type_test.go
+++ b/cmd/msg_card_content_type_test.go
@@ -10,26 +10,30 @@ func TestResolveCardContentType(t *testing.T) {
 	tests := []struct {
 		name      string
 		flagValue string
+		setFlag   bool
 		want      string
 		wantErr   bool
 	}{
-		{"未传 flag 默认空", "", "", false},
-		{"短写 user", "user", "user_card_content", false},
-		{"短写 raw", "raw", "raw_card_content", false},
-		{"全名 user_card_content", "user_card_content", "user_card_content", false},
-		{"全名 raw_card_content", "raw_card_content", "raw_card_content", false},
-		{"大小写不敏感 USER", "USER", "user_card_content", false},
-		{"大小写不敏感 Raw", "Raw", "raw_card_content", false},
-		{"前后空格被裁剪", "  user  ", "user_card_content", false},
-		{"非法值报错", "userdsl", "", true},
-		{"乱写报错", "abc", "", true},
+		{"未传 flag 默认 user", "", false, "user_card_content", false},
+		{"显式空值走渲染版", "", true, "", false},
+		{"短写 user", "user", true, "user_card_content", false},
+		{"短写 raw", "raw", true, "raw_card_content", false},
+		{"短写 rendered", "rendered", true, "", false},
+		{"旧行为别名 default", "default", true, "", false},
+		{"全名 user_card_content", "user_card_content", true, "user_card_content", false},
+		{"全名 raw_card_content", "raw_card_content", true, "raw_card_content", false},
+		{"大小写不敏感 USER", "USER", true, "user_card_content", false},
+		{"大小写不敏感 Raw", "Raw", true, "raw_card_content", false},
+		{"前后空格被裁剪", "  user  ", true, "user_card_content", false},
+		{"非法值报错", "userdsl", true, "", true},
+		{"乱写报错", "abc", true, "", true},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			cmd := &cobra.Command{}
 			addCardContentTypeFlag(cmd)
-			if tt.flagValue != "" {
+			if tt.setFlag {
 				if err := cmd.Flags().Set("card-content-type", tt.flagValue); err != nil {
 					t.Fatalf("flag set 失败: %v", err)
 				}

--- a/cmd/msg_history_fallback.go
+++ b/cmd/msg_history_fallback.go
@@ -4,16 +4,16 @@ import (
 	"fmt"
 	"os"
 
+	larkim "github.com/larksuite/oapi-sdk-go/v3/service/im/v1"
+
 	"github.com/riba2534/feishu-cli/internal/client"
 )
 
 // listMessagesViaSearch 通过搜索+逐条获取的方式获取消息列表
 // 当 ListMessages API 返回空结果（bot 不在群）时作为降级方案
 //
-// cardContentType 透传到每条 GetMessage 调用：当上层 cobra 命令带
-// `--card-content-type user|raw` flag 时，fallback 路径同样请求原始
-// schema JSON，避免出现"主路径返回 raw、search 降级路径返回渲染版"的语义不一致。
-// 调用方未启用 flag 时传空字符串即可。
+// cardContentType 透传到每条 GetMessage 调用，fallback 路径与主路径保持一致；
+// 例如默认的 user_card_content、显式 raw_card_content，或 rendered 旧行为对应的空字符串。
 func listMessagesViaSearch(chatID string, pageSize int, pageToken, userAccessToken, cardContentType string) (*client.ListMessagesResult, error) {
 	if pageSize <= 0 {
 		pageSize = 20
@@ -41,6 +41,7 @@ func listMessagesViaSearch(chatID string, pageSize int, pageToken, userAccessTok
 		HasMore:   searchResult.HasMore,
 		PageToken: searchResult.PageToken,
 	}
+	subMap := make(map[string][]*larkim.Message)
 	for _, msgID := range searchResult.MessageIDs {
 		msgResult, err := client.GetMessage(msgID, userAccessToken, cardContentType)
 		if err != nil {
@@ -48,6 +49,15 @@ func listMessagesViaSearch(chatID string, pageSize int, pageToken, userAccessTok
 			continue
 		}
 		result.Items = append(result.Items, msgResult.Message)
+		if msgResult.Message != nil && len(msgResult.SubMessages) > 0 {
+			containerID := client.StringVal(msgResult.Message.MessageId)
+			if containerID != "" {
+				subMap[containerID] = msgResult.SubMessages
+			}
+		}
+	}
+	if len(subMap) > 0 {
+		result.MergeForwardSubMessages = subMap
 	}
 
 	return result, nil

--- a/cmd/msg_history_fallback_test.go
+++ b/cmd/msg_history_fallback_test.go
@@ -1,0 +1,79 @@
+package cmd
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/riba2534/feishu-cli/internal/client"
+	"github.com/riba2534/feishu-cli/internal/config"
+	"github.com/spf13/viper"
+)
+
+func stubCmdFeishuServer(t *testing.T, handler http.HandlerFunc) func() {
+	t.Helper()
+	srv := httptest.NewServer(handler)
+
+	viper.Reset()
+	tmpDir := t.TempDir()
+	configFile := tmpDir + "/config.yaml"
+	content := fmt.Sprintf(`app_id: "test_app_id"
+app_secret: "test_app_secret"
+base_url: "%s"
+`, srv.URL)
+	if err := os.WriteFile(configFile, []byte(content), 0o600); err != nil {
+		t.Fatalf("写测试配置失败: %v", err)
+	}
+	if err := config.Init(configFile); err != nil {
+		t.Fatalf("初始化测试配置失败: %v", err)
+	}
+
+	return srv.Close
+}
+
+func TestListMessagesViaSearchKeepsMergeForwardSubMessages(t *testing.T) {
+	const (
+		chatID    = "oc_test_chat"
+		rootID    = "om_root"
+		subID     = "om_sub_card"
+		userToken = "u-test-token"
+	)
+
+	cleanup := stubCmdFeishuServer(t, func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch {
+		case r.URL.Path == "/open-apis/search/v2/message":
+			_, _ = fmt.Fprintf(w, `{"code":0,"msg":"success","data":{"items":["%s"],"has_more":false,"page_token":""}}`, rootID)
+		case r.URL.Path == "/open-apis/im/v1/messages/"+rootID:
+			got := r.URL.Query().Get("card_msg_content_type")
+			if got != client.CardMsgContentTypeUser && got != client.CardMsgContentTypeRaw {
+				t.Errorf("card_msg_content_type = %q, want %q or %q", got, client.CardMsgContentTypeUser, client.CardMsgContentTypeRaw)
+			}
+			_, _ = fmt.Fprintf(w, `{"code":0,"msg":"success","data":{"items":[
+				{"message_id":"%s","msg_type":"merge_forward","body":{"content":"placeholder"}},
+				{"message_id":"%s","msg_type":"interactive","upper_message_id":"%s","body":{"content":"{\"body\":{\"elements\":[{\"tag\":\"plain_text\",\"content\":\"fallback 子卡片\"}]}}"}}
+			]}}`, rootID, subID, rootID)
+		default:
+			http.Error(w, "unexpected path "+r.URL.Path, http.StatusNotFound)
+		}
+	})
+	defer cleanup()
+
+	result, err := listMessagesViaSearch(chatID, 10, "", userToken, client.CardMsgContentTypeUser)
+	if err != nil {
+		t.Fatalf("listMessagesViaSearch 返回错误: %v", err)
+	}
+	if len(result.Items) != 1 || client.StringVal(result.Items[0].MessageId) != rootID {
+		t.Fatalf("Items = %#v, want root message", result.Items)
+	}
+	subs := result.MergeForwardSubMessages[rootID]
+	if len(subs) != 1 || client.StringVal(subs[0].MessageId) != subID {
+		t.Fatalf("MergeForwardSubMessages[%s] = %#v, want sub message %s", rootID, subs, subID)
+	}
+	if texts := client.ExtractCardTexts(subs[0]); len(texts) != 1 || !strings.Contains(texts[0], "fallback 子卡片") {
+		t.Fatalf("sub card texts = %#v", texts)
+	}
+}

--- a/cmd/msg_mget.go
+++ b/cmd/msg_mget.go
@@ -17,13 +17,13 @@ var msgMgetCmd = &cobra.Command{
 
 选项:
   --message-ids         消息 ID 列表（逗号分隔，必填）
-  --card-content-type   interactive 卡片返回格式：user / raw（默认空，返回渲染版）
+  --card-content-type   interactive 卡片返回格式：user / raw / rendered（默认 user）
 
 示例:
   # 获取多条消息
   feishu-cli msg mget --message-ids om_xxx,om_yyy,om_zzz
 
-  # interactive 卡片返回原始 schema 2.0 JSON
+  # interactive 卡片返回 schema 2.0 JSON，并额外提取 card_texts（默认）
   feishu-cli msg mget --message-ids om_xxx,om_yyy --card-content-type user`,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		if err := config.Validate(); err != nil {
@@ -59,8 +59,18 @@ var msgMgetCmd = &cobra.Command{
 			"messages":     result.Messages,
 			"sender_names": senderNames,
 		}
+		if cardTextMap := client.ExtractCardTextMap(result.Messages); len(cardTextMap) > 0 {
+			out["card_texts"] = cardTextMap
+		}
 		if len(result.MergeForwardSubMessages) > 0 {
 			out["merge_forward_sub_messages"] = result.MergeForwardSubMessages
+			var subMsgs []*larkim.Message
+			for _, subs := range result.MergeForwardSubMessages {
+				subMsgs = append(subMsgs, subs...)
+			}
+			if cardTextMap := client.ExtractCardTextMap(subMsgs); len(cardTextMap) > 0 {
+				out["merge_forward_card_texts"] = cardTextMap
+			}
 		}
 		return printJSON(out)
 	},

--- a/internal/client/card_text.go
+++ b/internal/client/card_text.go
@@ -1,0 +1,133 @@
+package client
+
+import (
+	"encoding/json"
+	"fmt"
+	"sort"
+	"strings"
+
+	larkim "github.com/larksuite/oapi-sdk-go/v3/service/im/v1"
+)
+
+// ExtractCardTexts 从 interactive 卡片 body.content 中提取适合 CLI 阅读的文本。
+// 支持 user_card_content 的 schema 2.0 结构、raw_card_content 的 json_card 字段，
+// 以及 OAPI 默认渲染版的 post-like elements/content 结构。
+func ExtractCardTexts(msg *larkim.Message) []string {
+	if msg == nil || StringVal(msg.MsgType) != "interactive" || msg.Body == nil || msg.Body.Content == nil {
+		return nil
+	}
+	var root any
+	if err := json.Unmarshal([]byte(*msg.Body.Content), &root); err != nil {
+		text := strings.TrimSpace(*msg.Body.Content)
+		if text == "" {
+			return nil
+		}
+		return []string{text}
+	}
+	texts := collectCardTexts(root)
+	return compactCardTexts(texts)
+}
+
+// ExtractCardTextMap 以 message_id 为 key，批量提取 interactive 卡片文本。
+func ExtractCardTextMap(messages []*larkim.Message) map[string][]string {
+	out := make(map[string][]string)
+	for _, msg := range messages {
+		id := StringVal(msg.MessageId)
+		texts := ExtractCardTexts(msg)
+		if id != "" && len(texts) > 0 {
+			out[id] = texts
+		}
+	}
+	if len(out) == 0 {
+		return nil
+	}
+	return out
+}
+
+func collectCardTexts(v any) []string {
+	switch value := v.(type) {
+	case string:
+		var nested any
+		if json.Unmarshal([]byte(value), &nested) == nil {
+			return collectCardTexts(nested)
+		}
+		return []string{value}
+	case []any:
+		var texts []string
+		for _, item := range value {
+			texts = append(texts, collectCardTexts(item)...)
+		}
+		return texts
+	case map[string]any:
+		return collectCardTextsFromMap(value)
+	default:
+		return nil
+	}
+}
+
+func collectCardTextsFromMap(m map[string]any) []string {
+	var texts []string
+	hasDirectText := false
+	for _, key := range []string{"text", "content", "summary", "title", "subtitle"} {
+		if text, ok := m[key].(string); ok {
+			texts = append(texts, text)
+			hasDirectText = true
+		}
+	}
+	if !hasDirectText {
+		for _, key := range []string{"i18nContent", "i18n_content"} {
+			if i18n, ok := m[key].(map[string]any); ok {
+				texts = append(texts, collectI18nTexts(i18n)...)
+			}
+		}
+	}
+	if jsonCard, ok := m["json_card"].(string); ok {
+		texts = append(texts, collectCardTexts(jsonCard)...)
+	}
+	for _, key := range []string{
+		"body", "newBody", "header", "config", "summary", "elements", "items", "columns",
+		"content", "text", "fields", "options", "actions", "extra",
+	} {
+		child, ok := m[key]
+		if ok {
+			texts = append(texts, collectCardTexts(child)...)
+		}
+	}
+	if property, ok := m["property"].(map[string]any); ok {
+		texts = append(texts, collectCardTexts(property)...)
+	}
+	return texts
+}
+
+func collectI18nTexts(m map[string]any) []string {
+	for _, key := range []string{"zh_cn", "zh-CN", "zh_CN", "zh-hans", "en_us", "en-US", "en_US"} {
+		if text, ok := m[key].(string); ok {
+			return []string{text}
+		}
+	}
+	keys := make([]string, 0, len(m))
+	for key := range m {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	for _, key := range keys {
+		if text, ok := m[key].(string); ok {
+			return []string{fmt.Sprintf("%s: %s", key, text)}
+		}
+	}
+	return nil
+}
+
+func compactCardTexts(texts []string) []string {
+	seen := make(map[string]bool)
+	out := make([]string, 0, len(texts))
+	for _, text := range texts {
+		text = strings.TrimSpace(text)
+		if text == "" || seen[text] {
+			continue
+		}
+		seen[text] = true
+		out = append(out, text)
+	}
+	return out
+}

--- a/internal/client/card_text_test.go
+++ b/internal/client/card_text_test.go
@@ -1,0 +1,128 @@
+package client
+
+import (
+	"encoding/json"
+	"testing"
+
+	larkim "github.com/larksuite/oapi-sdk-go/v3/service/im/v1"
+)
+
+func TestExtractCardTexts_UserCardContent(t *testing.T) {
+	content := `{
+		"schema": "2.0",
+		"body": {
+			"elements": [
+				{"tag": "markdown", "content": "Review 已提交到 MR。"},
+				{"tag": "plain_text", "content": "需修复后合并"},
+				{"tag": "markdown", "content": "Review 已提交到 MR。"}
+			]
+		},
+		"config": {
+			"summary": {
+				"content": "Review 摘要"
+			}
+		}
+	}`
+	msg := interactiveMessage("om_card_user", content)
+
+	got := ExtractCardTexts(msg)
+	want := []string{"Review 已提交到 MR。", "需修复后合并", "Review 摘要"}
+	if !equalStringSlices(got, want) {
+		t.Fatalf("ExtractCardTexts() = %#v, want %#v", got, want)
+	}
+}
+
+func TestExtractCardTexts_RawCardContent(t *testing.T) {
+	raw := map[string]any{
+		"json_card": `{
+			"body": {
+				"elements": [
+					{"tag": "markdown", "property": {"content": "CI 全部通过"}},
+					{"tag": "plain_text", "property": {"content": "review_not_passed"}}
+				]
+			}
+		}`,
+		"card_schema": 2,
+	}
+	contentBytes, err := json.Marshal(raw)
+	if err != nil {
+		t.Fatalf("marshal raw card: %v", err)
+	}
+	msg := interactiveMessage("om_card_raw", string(contentBytes))
+
+	got := ExtractCardTexts(msg)
+	want := []string{"CI 全部通过", "review_not_passed"}
+	if !equalStringSlices(got, want) {
+		t.Fatalf("ExtractCardTexts() = %#v, want %#v", got, want)
+	}
+}
+
+func TestExtractCardTexts_RenderedUpgradeFallback(t *testing.T) {
+	msg := interactiveMessage("om_card_rendered", `{"title":null,"elements":[[{"tag":"text","text":"请升级至最新版本客户端，以查看内容"}]]}`)
+
+	got := ExtractCardTexts(msg)
+	want := []string{"请升级至最新版本客户端，以查看内容"}
+	if !equalStringSlices(got, want) {
+		t.Fatalf("ExtractCardTexts() = %#v, want %#v", got, want)
+	}
+}
+
+func TestExtractCardTexts_NestedTextObject(t *testing.T) {
+	msg := interactiveMessage("om_card_nested", `{
+		"body": {
+			"elements": [
+				{
+					"tag": "div",
+					"text": {"tag": "lark_md", "content": "嵌套正文"}
+				},
+				{
+					"tag": "button",
+					"text": {"tag": "plain_text", "content": "查看详情"},
+					"value": {"label": "隐藏 payload 不展示"}
+				}
+			]
+		}
+	}`)
+
+	got := ExtractCardTexts(msg)
+	want := []string{"嵌套正文", "查看详情"}
+	if !equalStringSlices(got, want) {
+		t.Fatalf("ExtractCardTexts() = %#v, want %#v", got, want)
+	}
+}
+
+func TestExtractCardTextMap(t *testing.T) {
+	textContent := `{"text":"hello"}`
+	got := ExtractCardTextMap([]*larkim.Message{
+		interactiveMessage("om_card", `{"body":{"elements":[{"tag":"plain_text","content":"hello card"}]}}`),
+		{MessageId: strPtr("om_text"), MsgType: strPtr("text"), Body: &larkim.MessageBody{Content: &textContent}},
+	})
+
+	if len(got) != 1 || !equalStringSlices(got["om_card"], []string{"hello card"}) {
+		t.Fatalf("ExtractCardTextMap() = %#v", got)
+	}
+}
+
+func interactiveMessage(id, content string) *larkim.Message {
+	return &larkim.Message{
+		MessageId: strPtr(id),
+		MsgType:   strPtr("interactive"),
+		Body:      &larkim.MessageBody{Content: &content},
+	}
+}
+
+func equalStringSlices(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}
+
+func strPtr(s string) *string {
+	return &s
+}


### PR DESCRIPTION
## Summary
- default message reads now request `user_card_content` so interactive cards do not degrade to “请升级客户端”
- add `--card-content-type rendered/default/legacy` compatibility path and expose the flag on `msg history`
- extract readable `card_texts` for card messages, including merge-forward sub-messages and search fallback results

## Session Review
- Used `session-review-team` perspectives for requirements, implementation, process/safety, and verification.
- Initial implementation review found two P2 issues: nested text objects were skipped and search fallback dropped merge-forward sub-messages. Both were fixed and re-reviewed with `Findings: none`.

## Verification
- `go test ./cmd ./internal/client`
- `go test ./...`
- `go vet ./...`
- `git diff --check`
- Real smoke: default `msg get` on the affected interactive card returned schema content and `card_texts` without “请升级”; `--card-content-type rendered` still reproduced the old degraded response; `msg history` default returned `card_texts`.