### PR TITLE
feat: support convert to markdown table

### DIFF
--- a/cmd/export_markdown.go
+++ b/cmd/export_markdown.go
@@ -54,20 +54,25 @@ var exportMarkdownCmd = &cobra.Command{
 
 		frontMatter, _ := cmd.Flags().GetBool("front-matter")
 		highlight, _ := cmd.Flags().GetBool("highlight")
+		maxEmbeddedRows, _ := cmd.Flags().GetInt("max-embedded-rows")
+		maxEmbeddedCols, _ := cmd.Flags().GetInt("max-embedded-cols")
 
 		expandMentions, _ := cmd.Flags().GetBool("expand-mentions")
 
 		// Convert to Markdown
 		cfg := config.Get()
 		options := converter.ConvertOptions{
-			DownloadImages:  downloadImages,
-			AssetsDir:       assetsDir,
-			DocumentID:      documentID,
-			UserAccessToken: userAccessToken,
-			Debug:           cfg.Debug,
-			FrontMatter:     frontMatter,
-			Highlight:       highlight,
-			ExpandMentions:  expandMentions,
+			DownloadImages:       downloadImages,
+			AssetsDir:            assetsDir,
+			DocumentID:           documentID,
+			UserAccessToken:      userAccessToken,
+			MaxEmbeddedRows:      maxEmbeddedRows,
+			MaxEmbeddedCols:      maxEmbeddedCols,
+			ExpandEmbeddedTables: true,
+			Debug:                cfg.Debug,
+			FrontMatter:          frontMatter,
+			Highlight:            highlight,
+			ExpandMentions:       expandMentions,
 		}
 
 		var conv *converter.BlockToMarkdown
@@ -133,5 +138,7 @@ func init() {
 	exportMarkdownCmd.Flags().Bool("front-matter", false, "添加 YAML front matter (标题和文档 ID)")
 	exportMarkdownCmd.Flags().Bool("highlight", false, "保留文本颜色和背景色 (输出为 HTML span)")
 	exportMarkdownCmd.Flags().Bool("expand-mentions", true, "展开 @用户为友好格式 (需要 contact:user.base:readonly 权限)")
+	exportMarkdownCmd.Flags().Int("max-embedded-rows", 100, "嵌入 sheet/bitable 展开为 Markdown 表格时最多导出的数据行数（不含表头）")
+	exportMarkdownCmd.Flags().Int("max-embedded-cols", 50, "嵌入 sheet/bitable 展开为 Markdown 表格时最多导出的列数")
 	exportMarkdownCmd.Flags().String("user-access-token", "", "User Access Token（用于访问无 App 权限的文档，自动从 auth login 读取）")
 }

--- a/internal/converter/block_to_markdown.go
+++ b/internal/converter/block_to_markdown.go
@@ -8,6 +8,7 @@ import (
 	"path/filepath"
 	"regexp"
 	"strings"
+	"time"
 
 	larkdocx "github.com/larksuite/oapi-sdk-go/v3/service/docx/v1"
 	"github.com/riba2534/feishu-cli/internal/client"
@@ -907,31 +908,11 @@ func (c *BlockToMarkdown) convertTable(block *larkdocx.Block) (string, error) {
 		table = append(table, row)
 	}
 
-	// Build markdown table
-	var sb strings.Builder
-
-	// Header row
-	if len(table) > 0 {
-		sb.WriteString("| ")
-		sb.WriteString(strings.Join(table[0], " | "))
-		sb.WriteString(" |\n")
-
-		// Separator
-		sb.WriteString("|")
-		for range table[0] {
-			sb.WriteString(" --- |")
-		}
-		sb.WriteString("\n")
-
-		// Data rows
-		for i := 1; i < len(table); i++ {
-			sb.WriteString("| ")
-			sb.WriteString(strings.Join(table[i], " | "))
-			sb.WriteString(" |\n")
-		}
+	if len(table) == 0 {
+		return "", nil
 	}
 
-	return sb.String(), nil
+	return formatMarkdownTablePresanitized(table[0], table[1:], 0), nil
 }
 
 func (c *BlockToMarkdown) getCellTextWithDepth(block *larkdocx.Block, depth int) string {
@@ -963,6 +944,85 @@ func (c *BlockToMarkdown) getCellTextWithDepth(block *larkdocx.Block, depth int)
 		return result
 	}
 	return ""
+}
+
+func formatMarkdownTable(headers []string, rows [][]string, truncatedRows int) string {
+	return formatMarkdownTableWithSanitize(headers, rows, truncatedRows, true)
+}
+
+func formatMarkdownTablePresanitized(headers []string, rows [][]string, truncatedRows int) string {
+	return formatMarkdownTableWithSanitize(headers, rows, truncatedRows, false)
+}
+
+func formatMarkdownTableWithSanitize(headers []string, rows [][]string, truncatedRows int, sanitize bool) string {
+	if len(headers) == 0 {
+		return ""
+	}
+
+	normalizedRows := make([][]string, len(rows))
+	for i, row := range rows {
+		normalizedRows[i] = normalizeMarkdownTableRow(row, len(headers), sanitize)
+	}
+	headers = normalizeMarkdownTableRow(headers, len(headers), sanitize)
+
+	var sb strings.Builder
+	sb.WriteString("| ")
+	sb.WriteString(strings.Join(headers, " | "))
+	sb.WriteString(" |\n|")
+	for range headers {
+		sb.WriteString(" --- |")
+	}
+	sb.WriteString("\n")
+	for _, row := range normalizedRows {
+		sb.WriteString("| ")
+		sb.WriteString(strings.Join(row, " | "))
+		sb.WriteString(" |\n")
+	}
+	if truncatedRows > 0 {
+		sb.WriteString(fmt.Sprintf("\n> 还有 %d 行未导出（设置 --max-embedded-rows 调整）\n", truncatedRows))
+	}
+	return sb.String()
+}
+
+func normalizeMarkdownTableRow(row []string, cols int, sanitize bool) []string {
+	out := make([]string, cols)
+	for i := 0; i < cols && i < len(row); i++ {
+		if sanitize {
+			out[i] = sanitizeMarkdownTableCell(row[i])
+		} else {
+			out[i] = row[i]
+		}
+	}
+	return out
+}
+
+func (c *BlockToMarkdown) embeddedTableFetcher() EmbeddedTableFetcher {
+	if c.options.EmbeddedTableFetcher != nil {
+		return c.options.EmbeddedTableFetcher
+	}
+	return feishuEmbeddedTableFetcher{}
+}
+
+func (c *BlockToMarkdown) shouldFetchEmbeddedTables() bool {
+	return c.options.EmbeddedTableFetcher != nil || c.options.ExpandEmbeddedTables
+}
+
+func splitEmbeddedToken(token string) (string, string) {
+	if idx := strings.Index(token, "_"); idx != -1 {
+		return token[:idx], token[idx+1:]
+	}
+	return token, ""
+}
+
+func derefString(s *string) string {
+	if s == nil {
+		return ""
+	}
+	return *s
+}
+
+func (c *BlockToMarkdown) isBitableGridView(block *larkdocx.Block) bool {
+	return block.Bitable.ViewType == nil || *block.Bitable.ViewType == 1
 }
 
 func (c *BlockToMarkdown) convertCallout(block *larkdocx.Block) (string, error) {
@@ -1150,6 +1210,26 @@ func (c *BlockToMarkdown) convertBitable(block *larkdocx.Block) (string, error) 
 		return "", nil
 	}
 
+	fallback := c.bitablePlaceholder(block)
+	baseToken, tableID := splitEmbeddedToken(derefString(block.Bitable.Token))
+	if baseToken != "" && tableID != "" && c.isBitableGridView(block) && c.shouldFetchEmbeddedTables() {
+		start := time.Now()
+		data, err := c.embeddedTableFetcher().FetchBitable(baseToken, tableID, c.options.MaxEmbeddedRows, c.options.MaxEmbeddedCols, c.options.UserAccessToken)
+		if err == nil && data != nil && len(data.Headers) > 0 {
+			if c.options.Debug {
+				fmt.Fprintf(os.Stderr, "[Debug] 展开嵌入 bitable: base=%s table=%s rows=%d elapsed=%s\n", baseToken, tableID, len(data.Rows), time.Since(start))
+			}
+			return formatMarkdownTable(data.Headers, data.Rows, data.TruncatedRows), nil
+		}
+		if c.options.Debug {
+			fmt.Fprintf(os.Stderr, "[Debug] 展开嵌入 bitable 失败，保留占位: %v\n", err)
+		}
+	}
+
+	return fallback, nil
+}
+
+func (c *BlockToMarkdown) bitablePlaceholder(block *larkdocx.Block) string {
 	var attrs []string
 	if block.Bitable.Token != nil && *block.Bitable.Token != "" {
 		attrs = append(attrs, fmt.Sprintf("token=\"%s\"", *block.Bitable.Token))
@@ -1172,7 +1252,7 @@ func (c *BlockToMarkdown) convertBitable(block *larkdocx.Block) (string, error) 
 	}
 	attrs = append(attrs, fmt.Sprintf("view=\"%s\"", viewStr))
 
-	return fmt.Sprintf("<bitable %s/>\n", strings.Join(attrs, " ")), nil
+	return fmt.Sprintf("<bitable %s/>\n", strings.Join(attrs, " "))
 }
 
 func (c *BlockToMarkdown) convertSheet(block *larkdocx.Block) (string, error) {
@@ -1180,6 +1260,30 @@ func (c *BlockToMarkdown) convertSheet(block *larkdocx.Block) (string, error) {
 		return "", nil
 	}
 
+	fallback := c.sheetPlaceholder(block)
+	spreadsheetToken, sheetID := splitEmbeddedToken(derefString(block.Sheet.Token))
+	if spreadsheetToken != "" && sheetID != "" && c.shouldFetchEmbeddedTables() {
+		start := time.Now()
+		maxCols := c.options.MaxEmbeddedCols
+		if maxCols <= 0 && block.Sheet.ColumnSize != nil {
+			maxCols = *block.Sheet.ColumnSize
+		}
+		data, err := c.embeddedTableFetcher().FetchSheet(spreadsheetToken, sheetID, c.options.MaxEmbeddedRows, maxCols, c.options.UserAccessToken)
+		if err == nil && data != nil && len(data.Headers) > 0 {
+			if c.options.Debug {
+				fmt.Fprintf(os.Stderr, "[Debug] 展开嵌入 sheet: token=%s sheet=%s rows=%d elapsed=%s\n", spreadsheetToken, sheetID, len(data.Rows), time.Since(start))
+			}
+			return formatMarkdownTable(data.Headers, data.Rows, data.TruncatedRows), nil
+		}
+		if c.options.Debug {
+			fmt.Fprintf(os.Stderr, "[Debug] 展开嵌入 sheet 失败，保留占位: %v\n", err)
+		}
+	}
+
+	return fallback, nil
+}
+
+func (c *BlockToMarkdown) sheetPlaceholder(block *larkdocx.Block) string {
 	var attrs []string
 	if block.Sheet.Token != nil && *block.Sheet.Token != "" {
 		token := *block.Sheet.Token
@@ -1197,7 +1301,7 @@ func (c *BlockToMarkdown) convertSheet(block *larkdocx.Block) (string, error) {
 		attrs = append(attrs, fmt.Sprintf("cols=\"%d\"", *block.Sheet.ColumnSize))
 	}
 
-	return fmt.Sprintf("<sheet %s/>\n", strings.Join(attrs, " ")), nil
+	return fmt.Sprintf("<sheet %s/>\n", strings.Join(attrs, " "))
 }
 
 func (c *BlockToMarkdown) convertChatCard(block *larkdocx.Block) (string, error) {

--- a/internal/converter/embedded_data.go
+++ b/internal/converter/embedded_data.go
@@ -13,6 +13,8 @@ import (
 const defaultMaxEmbeddedRows = 100
 const defaultMaxEmbeddedCols = 50
 
+var baseV3Call = client.BaseV3Call
+
 type feishuEmbeddedTableFetcher struct{}
 
 func (feishuEmbeddedTableFetcher) FetchSheet(token, sheetID string, maxRows, maxCols int, userAccessToken string) (*EmbeddedTableData, error) {
@@ -42,7 +44,7 @@ func (feishuEmbeddedTableFetcher) FetchBitable(baseToken, tableID string, maxRow
 	}
 	rowLimit := normalizedMaxEmbeddedRows(maxRows)
 	colLimit := normalizedMaxEmbeddedCols(maxCols)
-	headers, err := fetchBitableHeaders(baseToken, tableID, userAccessToken)
+	headers, err := fetchBitableHeaders(baseToken, tableID, colLimit, userAccessToken)
 	if err != nil {
 		return nil, err
 	}
@@ -158,31 +160,48 @@ func anyRowsToStringRows(values [][]any) [][]string {
 	return rows
 }
 
-func fetchBitableHeaders(baseToken, tableID, userAccessToken string) ([]string, error) {
-	data, err := client.BaseV3Call("GET", client.BaseV3Path("bases", baseToken, "tables", tableID, "fields"), map[string]any{"page_size": 100}, nil, userAccessToken)
-	if err != nil {
-		return nil, err
-	}
-	items, _ := data["items"].([]any)
-	headers := make([]string, 0, len(items))
-	if fields, ok := data["fields"].([]any); ok {
-		items = fields
-	}
-	for _, item := range items {
-		m, _ := item.(map[string]any)
-		name, _ := m["field_name"].(string)
-		if name == "" {
-			name, _ = m["name"].(string)
+func fetchBitableHeaders(baseToken, tableID string, maxCols int, userAccessToken string) ([]string, error) {
+	headers := make([]string, 0, maxCols)
+	pageToken := ""
+	for {
+		params := map[string]any{"page_size": 100}
+		if pageToken != "" {
+			params["page_token"] = pageToken
 		}
-		if name != "" {
-			headers = append(headers, name)
+		data, err := baseV3Call("GET", client.BaseV3Path("bases", baseToken, "tables", tableID, "fields"), params, nil, userAccessToken)
+		if err != nil {
+			return nil, err
+		}
+		items, _ := data["items"].([]any)
+		if fields, ok := data["fields"].([]any); ok {
+			items = fields
+		}
+		for _, item := range items {
+			m, _ := item.(map[string]any)
+			name, _ := m["field_name"].(string)
+			if name == "" {
+				name, _ = m["name"].(string)
+			}
+			if name != "" {
+				headers = append(headers, name)
+				if len(headers) >= maxCols {
+					return headers, nil
+				}
+			}
+		}
+		if !boolValue(data["has_more"]) {
+			break
+		}
+		pageToken = stringValue(data["page_token"])
+		if pageToken == "" {
+			break
 		}
 	}
 	return headers, nil
 }
 
 func fetchBitableRecords(baseToken, tableID string, limit int, userAccessToken string) ([]map[string]any, bool, error) {
-	data, err := client.BaseV3Call("GET", client.BaseV3Path("bases", baseToken, "tables", tableID, "records"), map[string]any{"page_size": limit}, nil, userAccessToken)
+	data, err := baseV3Call("GET", client.BaseV3Path("bases", baseToken, "tables", tableID, "records"), map[string]any{"page_size": limit}, nil, userAccessToken)
 	if err != nil {
 		return nil, false, err
 	}
@@ -234,6 +253,11 @@ func boolValue(v any) bool {
 	return b
 }
 
+func stringValue(v any) string {
+	s, _ := v.(string)
+	return s
+}
+
 func inferBitableHeaders(records []map[string]any) []string {
 	seen := map[string]bool{}
 	for _, record := range records {
@@ -254,9 +278,9 @@ func embeddedCellString(v any) string {
 	case nil:
 		return ""
 	case string:
-		return sanitizeMarkdownTableCell(x)
+		return strings.TrimSpace(x)
 	case fmt.Stringer:
-		return sanitizeMarkdownTableCell(x.String())
+		return strings.TrimSpace(x.String())
 	case json.Number:
 		return x.String()
 	case bool:
@@ -276,15 +300,15 @@ func embeddedCellString(v any) string {
 	case map[string]any:
 		for _, key := range []string{"text", "name", "title", "link", "url", "email", "en_name", "id"} {
 			if s, ok := x[key].(string); ok && s != "" {
-				return sanitizeMarkdownTableCell(s)
+				return strings.TrimSpace(s)
 			}
 		}
 		if data, err := json.Marshal(x); err == nil {
-			return sanitizeMarkdownTableCell(string(data))
+			return string(data)
 		}
 		return ""
 	default:
-		return sanitizeMarkdownTableCell(fmt.Sprintf("%v", x))
+		return strings.TrimSpace(fmt.Sprintf("%v", x))
 	}
 }
 

--- a/internal/converter/embedded_data.go
+++ b/internal/converter/embedded_data.go
@@ -1,0 +1,297 @@
+package converter
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/riba2534/feishu-cli/internal/client"
+)
+
+const defaultMaxEmbeddedRows = 100
+const defaultMaxEmbeddedCols = 50
+
+type feishuEmbeddedTableFetcher struct{}
+
+func (feishuEmbeddedTableFetcher) FetchSheet(token, sheetID string, maxRows, maxCols int, userAccessToken string) (*EmbeddedTableData, error) {
+	if token == "" || sheetID == "" {
+		return nil, fmt.Errorf("sheet token 或 sheet id 为空")
+	}
+	rowLimit := normalizedMaxEmbeddedRows(maxRows)
+	colLimit := normalizedMaxEmbeddedCols(maxCols)
+	rangeStr := fmt.Sprintf("%s!A1:%s%d", sheetID, columnName(colLimit), rowLimit+1)
+	cellRange, err := client.ReadCells(context.Background(), token, rangeStr, "ToString", "FormattedString", userAccessToken)
+	if err != nil {
+		return nil, err
+	}
+	if cellRange == nil {
+		return nil, fmt.Errorf("sheet 返回空数据")
+	}
+	rows := anyRowsToStringRows(cellRange.Values)
+	if len(rows) == 0 {
+		return &EmbeddedTableData{}, nil
+	}
+	return tableDataFromRows(rows, rowLimit, colLimit), nil
+}
+
+func (feishuEmbeddedTableFetcher) FetchBitable(baseToken, tableID string, maxRows, maxCols int, userAccessToken string) (*EmbeddedTableData, error) {
+	if baseToken == "" || tableID == "" {
+		return nil, fmt.Errorf("bitable token 或 table id 为空")
+	}
+	rowLimit := normalizedMaxEmbeddedRows(maxRows)
+	colLimit := normalizedMaxEmbeddedCols(maxCols)
+	headers, err := fetchBitableHeaders(baseToken, tableID, userAccessToken)
+	if err != nil {
+		return nil, err
+	}
+	records, hasMore, err := fetchBitableRecords(baseToken, tableID, rowLimit+1, userAccessToken)
+	if err != nil {
+		return nil, err
+	}
+	if len(headers) == 0 {
+		headers = inferBitableHeaders(records)
+	}
+	if len(headers) > colLimit {
+		headers = headers[:colLimit]
+	}
+
+	rows := make([][]string, 0, len(records))
+	for _, record := range records {
+		row := make([]string, len(headers))
+		for i, header := range headers {
+			row[i] = embeddedCellString(record[header])
+		}
+		rows = append(rows, row)
+	}
+	data := &EmbeddedTableData{Headers: headers, Rows: rows}
+	if len(data.Rows) > rowLimit {
+		data.TruncatedRows = len(data.Rows) - rowLimit
+		data.Rows = data.Rows[:rowLimit]
+	} else if hasMore {
+		data.TruncatedRows = 1
+	}
+	return data, nil
+}
+
+func normalizedMaxEmbeddedRows(maxRows int) int {
+	if maxRows <= 0 {
+		return defaultMaxEmbeddedRows
+	}
+	return maxRows
+}
+
+func normalizedMaxEmbeddedCols(maxCols int) int {
+	if maxCols <= 0 {
+		return defaultMaxEmbeddedCols
+	}
+	return maxCols
+}
+
+func tableDataFromRows(rows [][]string, maxRows, maxCols int) *EmbeddedTableData {
+	data := &EmbeddedTableData{}
+	rows = trimEmptyTableEdges(rows)
+	if len(rows) == 0 {
+		return data
+	}
+	data.Headers = rows[0]
+	if len(data.Headers) > maxCols {
+		data.Headers = data.Headers[:maxCols]
+	}
+	if len(data.Headers) == 0 {
+		return data
+	}
+	data.Rows = rows[1:]
+	if len(data.Rows) > maxRows {
+		data.TruncatedRows = len(data.Rows) - maxRows
+		data.Rows = data.Rows[:maxRows]
+	}
+	return data
+}
+
+func trimEmptyTableEdges(rows [][]string) [][]string {
+	lastRow := -1
+	lastCol := -1
+	for i, row := range rows {
+		for j, cell := range row {
+			if strings.TrimSpace(cell) != "" {
+				lastRow = i
+				if j > lastCol {
+					lastCol = j
+				}
+			}
+		}
+	}
+	if lastRow < 0 || lastCol < 0 {
+		return nil
+	}
+	trimmed := make([][]string, lastRow+1)
+	for i := 0; i <= lastRow; i++ {
+		trimmed[i] = make([]string, lastCol+1)
+		copy(trimmed[i], rows[i])
+	}
+	return trimmed
+}
+
+func columnName(n int) string {
+	if n <= 0 {
+		return "A"
+	}
+	var b []byte
+	for n > 0 {
+		n--
+		b = append([]byte{byte('A' + n%26)}, b...)
+		n /= 26
+	}
+	return string(b)
+}
+
+func anyRowsToStringRows(values [][]any) [][]string {
+	rows := make([][]string, len(values))
+	for i, row := range values {
+		rows[i] = make([]string, len(row))
+		for j, cell := range row {
+			rows[i][j] = embeddedCellString(cell)
+		}
+	}
+	return rows
+}
+
+func fetchBitableHeaders(baseToken, tableID, userAccessToken string) ([]string, error) {
+	data, err := client.BaseV3Call("GET", client.BaseV3Path("bases", baseToken, "tables", tableID, "fields"), map[string]any{"page_size": 100}, nil, userAccessToken)
+	if err != nil {
+		return nil, err
+	}
+	items, _ := data["items"].([]any)
+	headers := make([]string, 0, len(items))
+	if fields, ok := data["fields"].([]any); ok {
+		items = fields
+	}
+	for _, item := range items {
+		m, _ := item.(map[string]any)
+		name, _ := m["field_name"].(string)
+		if name == "" {
+			name, _ = m["name"].(string)
+		}
+		if name != "" {
+			headers = append(headers, name)
+		}
+	}
+	return headers, nil
+}
+
+func fetchBitableRecords(baseToken, tableID string, limit int, userAccessToken string) ([]map[string]any, bool, error) {
+	data, err := client.BaseV3Call("GET", client.BaseV3Path("bases", baseToken, "tables", tableID, "records"), map[string]any{"page_size": limit}, nil, userAccessToken)
+	if err != nil {
+		return nil, false, err
+	}
+	if matrix, ok := data["data"].([]any); ok {
+		return bitableMatrixRecords(data, matrix), boolValue(data["has_more"]), nil
+	}
+	items, _ := data["items"].([]any)
+	records := make([]map[string]any, 0, len(items))
+	for _, item := range items {
+		m, _ := item.(map[string]any)
+		fields, _ := m["fields"].(map[string]any)
+		if fields != nil {
+			records = append(records, fields)
+		}
+	}
+	hasMore, _ := data["has_more"].(bool)
+	return records, hasMore, nil
+}
+
+func bitableMatrixRecords(data map[string]any, matrix []any) []map[string]any {
+	fields := stringSliceFromAny(data["fields"])
+	records := make([]map[string]any, 0, len(matrix))
+	for _, rawRow := range matrix {
+		row, _ := rawRow.([]any)
+		record := make(map[string]any, len(fields))
+		for i, field := range fields {
+			if i < len(row) {
+				record[field] = row[i]
+			}
+		}
+		records = append(records, record)
+	}
+	return records
+}
+
+func stringSliceFromAny(v any) []string {
+	items, _ := v.([]any)
+	out := make([]string, 0, len(items))
+	for _, item := range items {
+		if s, ok := item.(string); ok {
+			out = append(out, s)
+		}
+	}
+	return out
+}
+
+func boolValue(v any) bool {
+	b, _ := v.(bool)
+	return b
+}
+
+func inferBitableHeaders(records []map[string]any) []string {
+	seen := map[string]bool{}
+	for _, record := range records {
+		for key := range record {
+			seen[key] = true
+		}
+	}
+	headers := make([]string, 0, len(seen))
+	for key := range seen {
+		headers = append(headers, key)
+	}
+	sort.Strings(headers)
+	return headers
+}
+
+func embeddedCellString(v any) string {
+	switch x := v.(type) {
+	case nil:
+		return ""
+	case string:
+		return sanitizeMarkdownTableCell(x)
+	case fmt.Stringer:
+		return sanitizeMarkdownTableCell(x.String())
+	case json.Number:
+		return x.String()
+	case bool:
+		if x {
+			return "TRUE"
+		}
+		return "FALSE"
+	case []any:
+		parts := make([]string, 0, len(x))
+		for _, item := range x {
+			text := embeddedCellString(item)
+			if text != "" {
+				parts = append(parts, text)
+			}
+		}
+		return strings.Join(parts, ", ")
+	case map[string]any:
+		for _, key := range []string{"text", "name", "title", "link", "url", "email", "en_name", "id"} {
+			if s, ok := x[key].(string); ok && s != "" {
+				return sanitizeMarkdownTableCell(s)
+			}
+		}
+		if data, err := json.Marshal(x); err == nil {
+			return sanitizeMarkdownTableCell(string(data))
+		}
+		return ""
+	default:
+		return sanitizeMarkdownTableCell(fmt.Sprintf("%v", x))
+	}
+}
+
+func sanitizeMarkdownTableCell(s string) string {
+	s = strings.TrimSpace(s)
+	s = strings.ReplaceAll(s, "\r", "")
+	s = strings.ReplaceAll(s, "\n", "<br>")
+	s = strings.ReplaceAll(s, "|", `\|`)
+	return s
+}

--- a/internal/converter/embedded_data_test.go
+++ b/internal/converter/embedded_data_test.go
@@ -1,0 +1,141 @@
+package converter
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	larkdocx "github.com/larksuite/oapi-sdk-go/v3/service/docx/v1"
+)
+
+type stubEmbeddedFetcher struct {
+	sheetData   *EmbeddedTableData
+	bitableData *EmbeddedTableData
+	err         error
+}
+
+func (s stubEmbeddedFetcher) FetchSheet(token, sheetID string, maxRows, maxCols int, userAccessToken string) (*EmbeddedTableData, error) {
+	if s.err != nil {
+		return nil, s.err
+	}
+	return s.sheetData, nil
+}
+
+func (s stubEmbeddedFetcher) FetchBitable(baseToken, tableID string, maxRows, maxCols int, userAccessToken string) (*EmbeddedTableData, error) {
+	if s.err != nil {
+		return nil, s.err
+	}
+	return s.bitableData, nil
+}
+
+func TestConvertEmbeddedSheetToMarkdownTable(t *testing.T) {
+	blockType := int(BlockTypeSheet)
+	block := &larkdocx.Block{
+		BlockType: &blockType,
+		Sheet: &larkdocx.Sheet{
+			Token: strPtr("sht123_sheet456"),
+		},
+	}
+	conv := NewBlockToMarkdown([]*larkdocx.Block{block}, ConvertOptions{
+		EmbeddedTableFetcher: stubEmbeddedFetcher{sheetData: &EmbeddedTableData{
+			Headers:       []string{"姓名", "备注"},
+			Rows:          [][]string{{"张三", "A|B\nC"}},
+			TruncatedRows: 2,
+		}},
+	})
+
+	got, err := conv.Convert()
+	if err != nil {
+		t.Fatalf("Convert() error = %v", err)
+	}
+	wantParts := []string{
+		"| 姓名 | 备注 |",
+		"| --- | --- |",
+		"| 张三 | A\\|B<br>C |",
+		"> 还有 2 行未导出（设置 --max-embedded-rows 调整）",
+	}
+	for _, want := range wantParts {
+		if !strings.Contains(got, want) {
+			t.Fatalf("expected %q in:\n%s", want, got)
+		}
+	}
+}
+
+func TestConvertEmbeddedBitableToMarkdownTable(t *testing.T) {
+	blockType := int(BlockTypeBitable)
+	viewType := 1
+	block := &larkdocx.Block{
+		BlockType: &blockType,
+		Bitable: &larkdocx.Bitable{
+			Token:    strPtr("bas123_tbl456"),
+			ViewType: &viewType,
+		},
+	}
+	conv := NewBlockToMarkdown([]*larkdocx.Block{block}, ConvertOptions{
+		EmbeddedTableFetcher: stubEmbeddedFetcher{bitableData: &EmbeddedTableData{
+			Headers: []string{"任务", "状态"},
+			Rows:    [][]string{{"实现导出", "完成"}},
+		}},
+	})
+
+	got, err := conv.Convert()
+	if err != nil {
+		t.Fatalf("Convert() error = %v", err)
+	}
+	if !strings.Contains(got, "| 任务 | 状态 |") || !strings.Contains(got, "| 实现导出 | 完成 |") {
+		t.Fatalf("expected markdown table, got:\n%s", got)
+	}
+}
+
+func TestConvertEmbeddedTableFallsBackOnFetchError(t *testing.T) {
+	blockType := int(BlockTypeSheet)
+	rows := 10
+	cols := 3
+	block := &larkdocx.Block{
+		BlockType: &blockType,
+		Sheet: &larkdocx.Sheet{
+			Token:      strPtr("sht123_sheet456"),
+			RowSize:    &rows,
+			ColumnSize: &cols,
+		},
+	}
+	conv := NewBlockToMarkdown([]*larkdocx.Block{block}, ConvertOptions{
+		EmbeddedTableFetcher: stubEmbeddedFetcher{err: fmt.Errorf("no permission")},
+	})
+
+	got, err := conv.Convert()
+	if err != nil {
+		t.Fatalf("Convert() error = %v", err)
+	}
+	want := `<sheet token="sht123" id="sheet456" rows="10" cols="3"/>`
+	if !strings.Contains(got, want) {
+		t.Fatalf("expected fallback %q, got:\n%s", want, got)
+	}
+}
+
+func TestConvertNonGridBitableKeepsPlaceholder(t *testing.T) {
+	blockType := int(BlockTypeBitable)
+	viewType := 2
+	block := &larkdocx.Block{
+		BlockType: &blockType,
+		Bitable: &larkdocx.Bitable{
+			Token:    strPtr("bas123_tbl456"),
+			ViewType: &viewType,
+		},
+	}
+	conv := NewBlockToMarkdown([]*larkdocx.Block{block}, ConvertOptions{
+		EmbeddedTableFetcher: stubEmbeddedFetcher{bitableData: &EmbeddedTableData{
+			Headers: []string{"任务"},
+			Rows:    [][]string{{"不应展开"}},
+		}},
+	})
+
+	got, err := conv.Convert()
+	if err != nil {
+		t.Fatalf("Convert() error = %v", err)
+	}
+	want := `<bitable token="bas123_tbl456" view="kanban"/>`
+	if !strings.Contains(got, want) {
+		t.Fatalf("expected placeholder %q, got:\n%s", want, got)
+	}
+}

--- a/internal/converter/embedded_data_test.go
+++ b/internal/converter/embedded_data_test.go
@@ -2,6 +2,7 @@ package converter
 
 import (
 	"fmt"
+	"reflect"
 	"strings"
 	"testing"
 
@@ -137,5 +138,76 @@ func TestConvertNonGridBitableKeepsPlaceholder(t *testing.T) {
 	want := `<bitable token="bas123_tbl456" view="kanban"/>`
 	if !strings.Contains(got, want) {
 		t.Fatalf("expected placeholder %q, got:\n%s", want, got)
+	}
+}
+
+func TestEmbeddedCellStringDefersMarkdownTableEscaping(t *testing.T) {
+	got := embeddedCellString("A|B\nC")
+	if got != "A|B\nC" {
+		t.Fatalf("embeddedCellString() = %q, want raw trimmed text", got)
+	}
+
+	table := tableDataFromRows([][]string{{"标题|列"}, {got}}, 10, 10)
+	md := formatMarkdownTable(table.Headers, table.Rows, table.TruncatedRows)
+	if !strings.Contains(md, "| 标题\\|列 |") {
+		t.Fatalf("expected header escaped once, got:\n%s", md)
+	}
+	if !strings.Contains(md, "| A\\|B<br>C |") {
+		t.Fatalf("expected cell escaped once, got:\n%s", md)
+	}
+	if strings.Contains(md, `A\\|B`) {
+		t.Fatalf("cell was double escaped:\n%s", md)
+	}
+}
+
+func TestFetchBitableHeadersPaginates(t *testing.T) {
+	oldBaseV3Call := baseV3Call
+	defer func() { baseV3Call = oldBaseV3Call }()
+
+	calls := 0
+	baseV3Call = func(method, path string, params map[string]any, body any, userAccessToken string) (map[string]any, error) {
+		calls++
+		if method != "GET" {
+			t.Fatalf("method = %s, want GET", method)
+		}
+		if userAccessToken != "user-token" {
+			t.Fatalf("userAccessToken = %q, want user-token", userAccessToken)
+		}
+		switch calls {
+		case 1:
+			if _, ok := params["page_token"]; ok {
+				t.Fatalf("first request should not include page_token: %#v", params)
+			}
+			return map[string]any{
+				"items": []any{
+					map[string]any{"field_name": "一列"},
+					map[string]any{"field_name": "二列"},
+				},
+				"has_more":   true,
+				"page_token": "next-page",
+			}, nil
+		case 2:
+			if params["page_token"] != "next-page" {
+				t.Fatalf("page_token = %#v, want next-page", params["page_token"])
+			}
+			return map[string]any{
+				"items": []any{
+					map[string]any{"field_name": "三列"},
+				},
+				"has_more": false,
+			}, nil
+		default:
+			t.Fatalf("unexpected extra call %d", calls)
+		}
+		return nil, nil
+	}
+
+	got, err := fetchBitableHeaders("base", "table", 10, "user-token")
+	if err != nil {
+		t.Fatalf("fetchBitableHeaders() error = %v", err)
+	}
+	want := []string{"一列", "二列", "三列"}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("fetchBitableHeaders() = %#v, want %#v", got, want)
 	}
 }

--- a/internal/converter/types.go
+++ b/internal/converter/types.go
@@ -93,16 +93,32 @@ type ImageInfo struct {
 
 // ConvertOptions holds conversion options
 type ConvertOptions struct {
-	DownloadImages      bool
-	AssetsDir           string
-	UploadImages        bool
-	DocumentID          string
-	UserAccessToken     string // User Access Token，用于下载图片和画板等需要权限的资源
-	Debug               bool   // 为 true 时，输出下载失败等调试信息到 stderr
-	DegradeDeepHeadings bool   // 为 true 时，Heading 7-9 输出为粗体段落而非 ######
-	FrontMatter         bool   // 为 true 时，导出时添加 YAML front matter
-	Highlight           bool   // 为 true 时，导出文本颜色和背景色为 HTML span
-	ExpandMentions      bool   // 导出时展开 @用户为友好格式（默认 false，CLI 默认 true）
+	DownloadImages       bool
+	AssetsDir            string
+	UploadImages         bool
+	DocumentID           string
+	UserAccessToken      string               // User Access Token，用于下载图片和画板等需要权限的资源
+	MaxEmbeddedRows      int                  // 嵌入 sheet/bitable 展开为 Markdown 表格时最多导出的数据行数（不含表头）
+	MaxEmbeddedCols      int                  // 嵌入 sheet/bitable 展开为 Markdown 表格时最多导出的列数
+	ExpandEmbeddedTables bool                 // 为 true 时把嵌入 sheet/bitable 展开为 Markdown 表格
+	Debug                bool                 // 为 true 时，输出下载失败等调试信息到 stderr
+	DegradeDeepHeadings  bool                 // 为 true 时，Heading 7-9 输出为粗体段落而非 ######
+	FrontMatter          bool                 // 为 true 时，导出时添加 YAML front matter
+	Highlight            bool                 // 为 true 时，导出文本颜色和背景色为 HTML span
+	ExpandMentions       bool                 // 导出时展开 @用户为友好格式（默认 false，CLI 默认 true）
+	EmbeddedTableFetcher EmbeddedTableFetcher // 测试或调用方可注入嵌入表格读取实现；为空时使用飞书 API
+}
+
+// EmbeddedTableFetcher 负责把嵌入的 Sheet/Bitable 读取为二维表格。
+type EmbeddedTableFetcher interface {
+	FetchSheet(token, sheetID string, maxRows, maxCols int, userAccessToken string) (*EmbeddedTableData, error)
+	FetchBitable(baseToken, tableID string, maxRows, maxCols int, userAccessToken string) (*EmbeddedTableData, error)
+}
+
+type EmbeddedTableData struct {
+	Headers       []string
+	Rows          [][]string
+	TruncatedRows int
 }
 
 // ConvertResult contains converted blocks and table data


### PR DESCRIPTION
## Summary
- support exporting compatible blocks as Markdown tables
- preserve embedded data handling in the converter path
- add converter coverage for embedded table data

Close #116

## Testing
- Not run in this turn; PR created from existing pushed branch eabdb94.