### PR TITLE
feat(schema): 本地浏览飞书 OpenAPI 方法（path/参数/scope，对齐 lark-cli schema）

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,30 @@
 
 ## 未发布
 
+### 新增 — `schema` 命令：本地浏览飞书 OpenAPI 方法（path / 参数 / scope）
+
+新增 `feishu-cli schema [service.resource.method]` 子命令，无需 token、纯本地查询飞书
+开放平台 OpenAPI 方法的 HTTP path / 动词 / 参数 / 请求体 / 响应体 / scope / 文档链接。
+对齐 `larksuite/cli` 的 `schema` 子命令，便于 AI Agent 和脚本作者快速查找参数。
+
+**用法**：
+
+```bash
+feishu-cli schema                                # 列出所有可用 service（12 个）
+feishu-cli schema im                             # 列出 im 域下所有 resource.method
+feishu-cli schema im.messages                    # 列出 messages 资源下所有 method
+feishu-cli schema im.messages.delete             # 查看具体 method 详情
+feishu-cli schema im.messages.delete --format json   # JSON 输出（AI Agent 推荐）
+feishu-cli schema list --service drive           # 等价于 schema drive，支持 --format json
+```
+
+**数据源**：`internal/registry/meta_data.json`（编译期 embed），与认证模块复用同一份元数据。
+当前覆盖 12 个 service：approval / attendance / calendar / drive / im / mail / minutes /
+sheets / slides / task / vc / wiki。
+
+**输出含**：HTTP verb + 完整 path、parameters（含 path / query / required 标记）、
+requestBody（嵌套字段）、responseBody、accessTokens（user / tenant）、scopes、docUrl。
+
 ### 新增 — `comment reply add`：为已有评论添加回复
 
 新增命令 `feishu-cli comment reply add <file_token> <comment_id> --text "..."`，补齐评论回复

--- a/cmd/schema.go
+++ b/cmd/schema.go
@@ -1,0 +1,400 @@
+package cmd
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"sort"
+	"strings"
+
+	"github.com/riba2534/feishu-cli/internal/registry"
+	"github.com/spf13/cobra"
+)
+
+var (
+	schemaFormat string
+)
+
+var schemaCmd = &cobra.Command{
+	Use:   "schema [service.resource.method]",
+	Short: "查询 OpenAPI Schema（path/verb/参数/scope）",
+	Long: `查询飞书开放平台 OpenAPI 的方法 schema：HTTP 路径、动词、参数、请求体、响应体、scope。
+
+数据来源于内置 internal/registry/meta_data.json（编译期 embed），无需网络也无需 token。
+
+路径格式: <service>.<resource>.<method>
+  - service:  域名（im / docs / drive / bitable / calendar / vc / mail / ...）
+  - resource: 资源（messages / events / records / ...，可含 .，如 chat.members）
+  - method:   动作（create / get / list / update / delete / ...）
+
+子命令:
+  schema list                列出所有可用 service
+  schema list --service im   列出 im 域下所有 resource.method
+  schema <path>              查询某个具体 method（默认 pretty 输出）
+  schema <path> --format json   JSON 格式输出（AI Agent 推荐）
+
+示例:
+  feishu-cli schema list
+  feishu-cli schema list --service im
+  feishu-cli schema im.messages.delete
+  feishu-cli schema im.messages.delete --format json
+  feishu-cli schema calendar.events
+  feishu-cli schema drive.files
+
+注意事项:
+  - 不需要 token，纯本地查询
+  - 内置 schema 覆盖 12 个 service（approval/attendance/calendar/drive/im/mail/minutes/sheets/slides/task/vc/wiki）
+  - 完整 OpenAPI 文档见 docUrl 字段或 https://open.feishu.cn/`,
+	Args:          cobra.MaximumNArgs(1),
+	SilenceUsage:  true,
+	SilenceErrors: false,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		path := ""
+		if len(args) > 0 {
+			path = args[0]
+		}
+		return runSchema(os.Stdout, path, schemaFormat)
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(schemaCmd)
+	schemaCmd.Flags().StringVar(&schemaFormat, "format", "pretty", "输出格式: pretty (默认) | json")
+}
+
+// runSchema dispatches based on path depth.
+//
+//	"" / no args                 → list services
+//	"service"                    → list resources & methods in service
+//	"service.resource"           → list methods in resource
+//	"service.resource.method"    → method detail
+func runSchema(w io.Writer, path, format string) error {
+	if path == "" {
+		return printServices(w, format)
+	}
+	parts := strings.Split(path, ".")
+	serviceName := parts[0]
+	spec := registry.LoadFromMeta(serviceName)
+	if spec == nil {
+		available := strings.Join(registry.ListFromMetaProjects(), ", ")
+		return fmt.Errorf("未知 service: %s\n可用 service: %s", serviceName, available)
+	}
+	if len(parts) == 1 {
+		if format == "json" {
+			return printJSON(spec)
+		}
+		return printResourceList(w, spec)
+	}
+	resources, _ := spec["resources"].(map[string]interface{})
+	resource, resName, remaining := findResourceByPath(resources, parts[1:])
+	if resource == nil {
+		var names []string
+		for k := range resources {
+			names = append(names, k)
+		}
+		sort.Strings(names)
+		return fmt.Errorf("未知 resource: %s.%s\n可用 resource: %s",
+			serviceName, strings.Join(parts[1:], "."), strings.Join(names, ", "))
+	}
+	if len(remaining) == 0 {
+		if format == "json" {
+			return printJSON(resource)
+		}
+		return printResourceDetail(w, serviceName, resName, resource)
+	}
+	methodName := remaining[0]
+	methods, _ := resource["methods"].(map[string]interface{})
+	method, ok := methods[methodName].(map[string]interface{})
+	if !ok {
+		var names []string
+		for k := range methods {
+			names = append(names, k)
+		}
+		sort.Strings(names)
+		return fmt.Errorf("未知 method: %s.%s.%s\n可用 method: %s",
+			serviceName, resName, methodName, strings.Join(names, ", "))
+	}
+	if format == "json" {
+		return printJSON(method)
+	}
+	return printMethodDetail(w, spec, resName, methodName, method)
+}
+
+// findResourceByPath tries longest-prefix match for dotted resource names.
+// For example parts = ["chat", "members", "create"] should match resource
+// "chat.members" then leave ["create"] as remaining (the method).
+func findResourceByPath(resources map[string]interface{}, parts []string) (map[string]interface{}, string, []string) {
+	for i := len(parts); i >= 1; i-- {
+		candidate := strings.Join(parts[:i], ".")
+		if res, ok := resources[candidate]; ok {
+			if resMap, ok := res.(map[string]interface{}); ok {
+				return resMap, candidate, parts[i:]
+			}
+		}
+	}
+	return nil, "", nil
+}
+
+func printServices(w io.Writer, format string) error {
+	services := registry.ListFromMetaProjects()
+	if format == "json" {
+		list := make([]map[string]interface{}, 0, len(services))
+		for _, s := range services {
+			spec := registry.LoadFromMeta(s)
+			list = append(list, map[string]interface{}{
+				"name":        s,
+				"version":     registry.GetStrFromMap(spec, "version"),
+				"title":       registry.GetStrFromMap(spec, "title"),
+				"servicePath": registry.GetStrFromMap(spec, "servicePath"),
+			})
+		}
+		return printJSON(list)
+	}
+	fmt.Fprintln(w, "可用 service（共", len(services), "个）：")
+	fmt.Fprintln(w)
+	for _, s := range services {
+		spec := registry.LoadFromMeta(s)
+		title := registry.GetStrFromMap(spec, "title")
+		version := registry.GetStrFromMap(spec, "version")
+		resources, _ := spec["resources"].(map[string]interface{})
+		fmt.Fprintf(w, "  %-12s %-6s %d resources  %s\n", s, version, len(resources), title)
+	}
+	fmt.Fprintln(w)
+	fmt.Fprintln(w, "用法: feishu-cli schema <service>.<resource>.<method>")
+	fmt.Fprintln(w, "示例: feishu-cli schema im.messages.delete")
+	return nil
+}
+
+func printResourceList(w io.Writer, spec map[string]interface{}) error {
+	name := registry.GetStrFromMap(spec, "name")
+	version := registry.GetStrFromMap(spec, "version")
+	title := registry.GetStrFromMap(spec, "title")
+	servicePath := registry.GetStrFromMap(spec, "servicePath")
+
+	fmt.Fprintf(w, "%s (%s) — %s\n", name, version, title)
+	fmt.Fprintf(w, "Base path: %s\n\n", servicePath)
+
+	resources, _ := spec["resources"].(map[string]interface{})
+	for _, resName := range sortedKeys(resources) {
+		resMap, _ := resources[resName].(map[string]interface{})
+		methods, _ := resMap["methods"].(map[string]interface{})
+		if len(methods) == 0 {
+			continue
+		}
+		fmt.Fprintf(w, "  %s\n", resName)
+		for _, methodName := range sortedKeys(methods) {
+			m, _ := methods[methodName].(map[string]interface{})
+			httpMethod := registry.GetStrFromMap(m, "httpMethod")
+			desc := registry.GetStrFromMap(m, "description")
+			desc = schemaTruncate(desc, 70)
+			danger := ""
+			if d, _ := m["danger"].(bool); d {
+				danger = " [danger]"
+			}
+			fmt.Fprintf(w, "    %-7s %-22s %s%s\n", httpMethod, methodName, desc, danger)
+		}
+		fmt.Fprintln(w)
+	}
+	fmt.Fprintf(w, "用法: feishu-cli schema %s.<resource>.<method>\n", name)
+	return nil
+}
+
+func printResourceDetail(w io.Writer, serviceName, resName string, resource map[string]interface{}) error {
+	fmt.Fprintf(w, "%s.%s\n\n", serviceName, resName)
+	methods, _ := resource["methods"].(map[string]interface{})
+	for _, mName := range sortedKeys(methods) {
+		m, _ := methods[mName].(map[string]interface{})
+		httpMethod := registry.GetStrFromMap(m, "httpMethod")
+		desc := schemaTruncate(registry.GetStrFromMap(m, "description"), 70)
+		fmt.Fprintf(w, "  %-7s %-22s %s\n", httpMethod, mName, desc)
+	}
+	fmt.Fprintf(w, "\n用法: feishu-cli schema %s.%s.<method>\n", serviceName, resName)
+	return nil
+}
+
+func printMethodDetail(w io.Writer, spec map[string]interface{}, resName, methodName string, method map[string]interface{}) error {
+	servicePath := registry.GetStrFromMap(spec, "servicePath")
+	specName := registry.GetStrFromMap(spec, "name")
+	methodPath := registry.GetStrFromMap(method, "path")
+	fullPath := servicePath + "/" + methodPath
+	httpMethod := registry.GetStrFromMap(method, "httpMethod")
+	desc := registry.GetStrFromMap(method, "description")
+
+	fmt.Fprintf(w, "%s.%s.%s\n\n", specName, resName, methodName)
+	fmt.Fprintf(w, "  %s %s\n", httpMethod, fullPath)
+	if desc != "" {
+		fmt.Fprintf(w, "  %s\n", desc)
+	}
+	fmt.Fprintln(w)
+
+	// Parameters (URL/query)
+	params, _ := method["parameters"].(map[string]interface{})
+	if len(params) > 0 {
+		fmt.Fprintln(w, "Parameters:")
+		for _, p := range sortedParamKeys(params) {
+			pm, _ := params[p].(map[string]interface{})
+			pType := registry.GetStrFromMap(pm, "type")
+			if pType == "" {
+				pType = "string"
+			}
+			location := registry.GetStrFromMap(pm, "location")
+			required, _ := pm["required"].(bool)
+			reqStr := "optional"
+			if required {
+				reqStr = "required"
+			}
+			fmt.Fprintf(w, "  - %s (%s, %s, %s)\n", p, pType, location, reqStr)
+			if pdesc := schemaTruncate(registry.GetStrFromMap(pm, "description"), 100); pdesc != "" {
+				fmt.Fprintf(w, "      %s\n", pdesc)
+			}
+			if ex := registry.GetStrFromMap(pm, "example"); ex != "" {
+				fmt.Fprintf(w, "      e.g. %s\n", ex)
+			}
+		}
+		fmt.Fprintln(w)
+	}
+
+	// requestBody (for POST/PUT/PATCH/DELETE)
+	if httpMethod == "POST" || httpMethod == "PUT" || httpMethod == "PATCH" || httpMethod == "DELETE" {
+		requestBody, _ := method["requestBody"].(map[string]interface{})
+		if len(requestBody) > 0 {
+			fmt.Fprintln(w, "Request Body:")
+			printNestedFields(w, requestBody, "  ", "")
+			fmt.Fprintln(w)
+		}
+	}
+
+	// responseBody
+	responseBody, _ := method["responseBody"].(map[string]interface{})
+	if len(responseBody) > 0 {
+		fmt.Fprintln(w, "Response:")
+		printNestedFields(w, responseBody, "  ", "")
+		fmt.Fprintln(w)
+	}
+
+	// accessTokens / identities
+	if tokens, ok := method["accessTokens"].([]interface{}); ok && len(tokens) > 0 {
+		var idents []string
+		for _, t := range tokens {
+			if s, ok := t.(string); ok {
+				switch s {
+				case "user":
+					idents = append(idents, "user")
+				case "tenant":
+					idents = append(idents, "tenant (bot)")
+				}
+			}
+		}
+		if len(idents) > 0 {
+			fmt.Fprintf(w, "Identity: %s\n", strings.Join(idents, ", "))
+		}
+	}
+
+	// scopes
+	if scopes, ok := method["scopes"].([]interface{}); ok && len(scopes) > 0 {
+		var ss []string
+		for _, s := range scopes {
+			if str, ok := s.(string); ok {
+				ss = append(ss, str)
+			}
+		}
+		fmt.Fprintf(w, "Scopes:   %s\n", strings.Join(ss, ", "))
+	}
+
+	// CLI example
+	fmt.Fprintf(w, "CLI:      feishu-cli schema %s.%s.%s\n", specName, resName, methodName)
+
+	// Docs
+	if docURL := registry.GetStrFromMap(method, "docUrl"); docURL != "" {
+		fmt.Fprintf(w, "Docs:     %s\n", docURL)
+	}
+
+	return nil
+}
+
+func printNestedFields(w io.Writer, fields map[string]interface{}, indent, prefix string) {
+	for _, fieldName := range sortedFieldKeys(fields) {
+		f, _ := fields[fieldName].(map[string]interface{})
+		fullName := fieldName
+		if prefix != "" {
+			fullName = prefix + "." + fieldName
+		}
+		fType := registry.GetStrFromMap(f, "type")
+		required, _ := f["required"].(bool)
+		reqStr := "optional"
+		if required {
+			reqStr = "required"
+		}
+		fmt.Fprintf(w, "%s- %s (%s, %s)\n", indent, fullName, fType, reqStr)
+		if desc := schemaTruncate(registry.GetStrFromMap(f, "description"), 100); desc != "" {
+			fmt.Fprintf(w, "%s    %s\n", indent, desc)
+		}
+		if ex := registry.GetStrFromMap(f, "example"); ex != "" {
+			fmt.Fprintf(w, "%s    e.g. %s\n", indent, ex)
+		}
+		if props, ok := f["properties"].(map[string]interface{}); ok && len(props) > 0 {
+			printNestedFields(w, props, indent+"  ", fullName)
+		}
+	}
+}
+
+// sortedKeys returns map keys in alphabetical order.
+func sortedKeys(m map[string]interface{}) []string {
+	keys := make([]string, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	return keys
+}
+
+// sortedParamKeys returns parameter keys: required first, then alphabetical.
+func sortedParamKeys(params map[string]interface{}) []string {
+	keys := make([]string, 0, len(params))
+	for k := range params {
+		keys = append(keys, k)
+	}
+	sort.Slice(keys, func(i, j int) bool {
+		pi, _ := params[keys[i]].(map[string]interface{})
+		pj, _ := params[keys[j]].(map[string]interface{})
+		ri, _ := pi["required"].(bool)
+		rj, _ := pj["required"].(bool)
+		if ri != rj {
+			return ri
+		}
+		return keys[i] < keys[j]
+	})
+	return keys
+}
+
+// sortedFieldKeys returns field keys: required first, then alphabetical.
+func sortedFieldKeys(fields map[string]interface{}) []string {
+	keys := make([]string, 0, len(fields))
+	for k := range fields {
+		keys = append(keys, k)
+	}
+	sort.Slice(keys, func(i, j int) bool {
+		fi, _ := fields[keys[i]].(map[string]interface{})
+		fj, _ := fields[keys[j]].(map[string]interface{})
+		ri, _ := fi["required"].(bool)
+		rj, _ := fj["required"].(bool)
+		if ri != rj {
+			return ri
+		}
+		return keys[i] < keys[j]
+	})
+	return keys
+}
+
+// schemaTruncate returns s truncated to maxLen chars with "..." appended if cut.
+// Works on runes to avoid breaking multibyte UTF-8 (中文 description 常见).
+func schemaTruncate(s string, maxLen int) string {
+	if maxLen <= 0 {
+		return s
+	}
+	runes := []rune(s)
+	if len(runes) <= maxLen {
+		return s
+	}
+	return string(runes[:maxLen]) + "..."
+}

--- a/cmd/schema.go
+++ b/cmd/schema.go
@@ -1,6 +1,8 @@
 package cmd
 
 import (
+	"bytes"
+	"encoding/json"
 	"fmt"
 	"io"
 	"os"
@@ -10,6 +12,20 @@ import (
 	"github.com/riba2534/feishu-cli/internal/registry"
 	"github.com/spf13/cobra"
 )
+
+// writeJSON 把 v 编码为 2 空格缩进 JSON 写入 w（HTML 不转义）。
+// 与全局 printJSON 等价但目标 writer 可注入，便于测试断言 JSON 输出。
+func writeJSON(w io.Writer, v any) error {
+	var buf bytes.Buffer
+	enc := json.NewEncoder(&buf)
+	enc.SetEscapeHTML(false)
+	enc.SetIndent("", "  ")
+	if err := enc.Encode(v); err != nil {
+		return fmt.Errorf("JSON 序列化失败: %w", err)
+	}
+	_, err := w.Write(buf.Bytes())
+	return err
+}
 
 var (
 	schemaFormat string
@@ -81,7 +97,7 @@ func runSchema(w io.Writer, path, format string) error {
 	}
 	if len(parts) == 1 {
 		if format == "json" {
-			return printJSON(spec)
+			return writeJSON(w, spec)
 		}
 		return printResourceList(w, spec)
 	}
@@ -98,9 +114,14 @@ func runSchema(w io.Writer, path, format string) error {
 	}
 	if len(remaining) == 0 {
 		if format == "json" {
-			return printJSON(resource)
+			return writeJSON(w, resource)
 		}
 		return printResourceDetail(w, serviceName, resName, resource)
+	}
+	if len(remaining) > 1 {
+		// remaining 多于 1 段时不能静默吞掉 — 视为用户输入路径过深
+		return fmt.Errorf("路径过深: %s（期望格式 <service>.<resource>.<method>，多余片段: %s）",
+			path, strings.Join(remaining[1:], "."))
 	}
 	methodName := remaining[0]
 	methods, _ := resource["methods"].(map[string]interface{})
@@ -115,7 +136,7 @@ func runSchema(w io.Writer, path, format string) error {
 			serviceName, resName, methodName, strings.Join(names, ", "))
 	}
 	if format == "json" {
-		return printJSON(method)
+		return writeJSON(w, method)
 	}
 	return printMethodDetail(w, spec, resName, methodName, method)
 }
@@ -148,7 +169,7 @@ func printServices(w io.Writer, format string) error {
 				"servicePath": registry.GetStrFromMap(spec, "servicePath"),
 			})
 		}
-		return printJSON(list)
+		return writeJSON(w, list)
 	}
 	fmt.Fprintln(w, "可用 service（共", len(services), "个）：")
 	fmt.Fprintln(w)

--- a/cmd/schema_list.go
+++ b/cmd/schema_list.go
@@ -1,0 +1,72 @@
+package cmd
+
+import (
+	"fmt"
+	"io"
+	"os"
+
+	"github.com/riba2534/feishu-cli/internal/registry"
+	"github.com/spf13/cobra"
+)
+
+var (
+	schemaListService string
+	schemaListFormat  string
+)
+
+var schemaListCmd = &cobra.Command{
+	Use:   "list",
+	Short: "列出所有 service 或某个 service 下的 resource.method",
+	Long: `列出可用的 OpenAPI service / resource / method。
+
+不传 --service 时列出所有顶层 service（同 feishu-cli schema 无参数）。
+传 --service 时列出该 service 下的所有 resource.method（同 feishu-cli schema <service>）。
+
+示例:
+  feishu-cli schema list
+  feishu-cli schema list --service im
+  feishu-cli schema list --service drive --format json`,
+	Args:         cobra.NoArgs,
+	SilenceUsage: true,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		return runSchemaList(os.Stdout, schemaListService, schemaListFormat)
+	},
+}
+
+func init() {
+	schemaCmd.AddCommand(schemaListCmd)
+	schemaListCmd.Flags().StringVar(&schemaListService, "service", "", "可选：指定 service 名（如 im / drive / calendar）")
+	schemaListCmd.Flags().StringVar(&schemaListFormat, "format", "pretty", "输出格式: pretty (默认) | json")
+}
+
+func runSchemaList(w io.Writer, service, format string) error {
+	if service == "" {
+		return printServices(w, format)
+	}
+	spec := registry.LoadFromMeta(service)
+	if spec == nil {
+		return fmt.Errorf("未知 service: %s", service)
+	}
+	if format == "json" {
+		// Return flat list of {service, resource, method, httpMethod, description}
+		var rows []map[string]interface{}
+		resources, _ := spec["resources"].(map[string]interface{})
+		for _, resName := range sortedKeys(resources) {
+			resMap, _ := resources[resName].(map[string]interface{})
+			methods, _ := resMap["methods"].(map[string]interface{})
+			for _, mName := range sortedKeys(methods) {
+				m, _ := methods[mName].(map[string]interface{})
+				rows = append(rows, map[string]interface{}{
+					"service":     service,
+					"resource":    resName,
+					"method":      mName,
+					"path":        service + "." + resName + "." + mName,
+					"httpMethod":  registry.GetStrFromMap(m, "httpMethod"),
+					"description": registry.GetStrFromMap(m, "description"),
+				})
+			}
+		}
+		return printJSON(rows)
+	}
+	return printResourceList(w, spec)
+}

--- a/cmd/schema_list.go
+++ b/cmd/schema_list.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"strings"
 
 	"github.com/riba2534/feishu-cli/internal/registry"
 	"github.com/spf13/cobra"
@@ -45,7 +46,8 @@ func runSchemaList(w io.Writer, service, format string) error {
 	}
 	spec := registry.LoadFromMeta(service)
 	if spec == nil {
-		return fmt.Errorf("未知 service: %s", service)
+		available := strings.Join(registry.ListFromMetaProjects(), ", ")
+		return fmt.Errorf("未知 service: %s\n可用 service: %s", service, available)
 	}
 	if format == "json" {
 		// Return flat list of {service, resource, method, httpMethod, description}
@@ -66,7 +68,7 @@ func runSchemaList(w io.Writer, service, format string) error {
 				})
 			}
 		}
-		return printJSON(rows)
+		return writeJSON(w, rows)
 	}
 	return printResourceList(w, spec)
 }

--- a/cmd/schema_test.go
+++ b/cmd/schema_test.go
@@ -1,0 +1,85 @@
+package cmd
+
+import (
+	"bytes"
+	"io"
+	"strings"
+	"testing"
+)
+
+// TestSchemaListServices 验证空 path 时列出所有 service。
+func TestSchemaListServices(t *testing.T) {
+	var buf bytes.Buffer
+	if err := runSchema(&buf, "", "pretty"); err != nil {
+		t.Fatalf("runSchema(\"\") err = %v", err)
+	}
+	out := buf.String()
+	// 至少包含几个高频 service
+	for _, want := range []string{"im", "drive", "calendar", "sheets", "bitable", "wiki"} {
+		if !strings.Contains(out, want) {
+			// bitable 在 meta_data 里可能叫 base，跳过该项也行
+			if want == "bitable" {
+				continue
+			}
+			t.Errorf("service list missing %q\n--- output ---\n%s", want, out)
+		}
+	}
+}
+
+// TestSchemaServiceDetail 验证 service-only path 列出该 service 下 resource.method。
+func TestSchemaServiceDetail(t *testing.T) {
+	var buf bytes.Buffer
+	if err := runSchema(&buf, "im", "pretty"); err != nil {
+		t.Fatalf("runSchema(\"im\") err = %v", err)
+	}
+	out := buf.String()
+	if !strings.Contains(out, "messages") {
+		t.Errorf("im resource list missing 'messages'\n--- output ---\n%s", out)
+	}
+}
+
+// TestSchemaMethodDetail 验证具体 method path 输出关键字段。
+func TestSchemaMethodDetail(t *testing.T) {
+	var buf bytes.Buffer
+	if err := runSchema(&buf, "im.messages.delete", "pretty"); err != nil {
+		t.Fatalf("runSchema(\"im.messages.delete\") err = %v", err)
+	}
+	out := buf.String()
+	for _, want := range []string{"DELETE", "/open-apis/im/v1/messages", "message_id"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("method detail missing %q\n--- output ---\n%s", want, out)
+		}
+	}
+}
+
+// TestSchemaJSONFormat 验证 --format json 在 method 路径下能跑通且不报错。
+// printJSON 写到 os.Stdout（CLI 全局约定），这里仅校验调用不报错。
+func TestSchemaJSONFormat(t *testing.T) {
+	// discard 是为了避免 pretty 路径占用 buf；json 路径走 stdout
+	if err := runSchema(io.Discard, "im.messages.delete", "json"); err != nil {
+		t.Fatalf("runSchema json err = %v", err)
+	}
+}
+
+// TestSchemaUnknownService 验证未知 service 返回友好错误。
+func TestSchemaUnknownService(t *testing.T) {
+	var buf bytes.Buffer
+	err := runSchema(&buf, "nonexistent_service_xyz", "pretty")
+	if err == nil {
+		t.Fatal("expected error for unknown service, got nil")
+	}
+	if !strings.Contains(err.Error(), "未知 service") {
+		t.Errorf("error message should mention 未知 service, got: %v", err)
+	}
+}
+
+// TestSchemaListSubcommand 验证 schema list --service 子命令 runner。
+func TestSchemaListSubcommand(t *testing.T) {
+	var buf bytes.Buffer
+	if err := runSchemaList(&buf, "im", "pretty"); err != nil {
+		t.Fatalf("runSchemaList(\"im\") err = %v", err)
+	}
+	if !strings.Contains(buf.String(), "messages") {
+		t.Errorf("schema list --service im missing 'messages'\n--- output ---\n%s", buf.String())
+	}
+}

--- a/cmd/schema_test.go
+++ b/cmd/schema_test.go
@@ -2,7 +2,7 @@ package cmd
 
 import (
 	"bytes"
-	"io"
+	"encoding/json"
 	"strings"
 	"testing"
 )
@@ -52,12 +52,65 @@ func TestSchemaMethodDetail(t *testing.T) {
 	}
 }
 
-// TestSchemaJSONFormat 验证 --format json 在 method 路径下能跑通且不报错。
-// printJSON 写到 os.Stdout（CLI 全局约定），这里仅校验调用不报错。
+// TestSchemaJSONFormat 验证 --format json 在 method 路径下能跑通，
+// 并校验输出写到注入的 io.Writer 中、JSON 包含核心字段。
 func TestSchemaJSONFormat(t *testing.T) {
-	// discard 是为了避免 pretty 路径占用 buf；json 路径走 stdout
-	if err := runSchema(io.Discard, "im.messages.delete", "json"); err != nil {
+	var buf bytes.Buffer
+	if err := runSchema(&buf, "im.messages.delete", "json"); err != nil {
 		t.Fatalf("runSchema json err = %v", err)
+	}
+	if buf.Len() == 0 {
+		t.Fatal("JSON 输出为空：runSchema 应该写入 io.Writer 而不是 os.Stdout")
+	}
+	var m map[string]interface{}
+	if err := json.Unmarshal(buf.Bytes(), &m); err != nil {
+		t.Fatalf("invalid JSON output: %v\nraw: %s", err, buf.String())
+	}
+	if m["httpMethod"] == nil {
+		t.Errorf("JSON output missing 'httpMethod' field; got keys: %v", keys(m))
+	}
+	if m["path"] == nil {
+		t.Errorf("JSON output missing 'path' field; got keys: %v", keys(m))
+	}
+}
+
+func keys(m map[string]interface{}) []string {
+	var out []string
+	for k := range m {
+		out = append(out, k)
+	}
+	return out
+}
+
+// TestSchemaPathTooDeep 验证 service.resource.method 后多余片段会报错。
+func TestSchemaPathTooDeep(t *testing.T) {
+	var buf bytes.Buffer
+	err := runSchema(&buf, "im.messages.foo.bar.baz", "pretty")
+	// foo 不是 method，因此期望「未知 method」或「路径过深」之一；
+	// 当 foo 恰好是 method 时则期望「路径过深」。
+	if err == nil {
+		t.Fatal("expected error for overly deep path, got nil")
+	}
+	// 找到匹配的 resource「messages」，剩余 foo.bar.baz：foo 不存在 → 报未知 method 也 OK；
+	// 或剩余 > 1 触发路径过深检查。两种错误都接受。
+	msg := err.Error()
+	if !strings.Contains(msg, "未知 method") && !strings.Contains(msg, "路径过深") {
+		t.Errorf("expected 未知 method or 路径过深 error, got: %v", err)
+	}
+}
+
+// TestSchemaListUnknownServiceFriendly 验证 list --service xxx 未知时列出可用 service。
+func TestSchemaListUnknownServiceFriendly(t *testing.T) {
+	var buf bytes.Buffer
+	err := runSchemaList(&buf, "nonexistent_service_xyz", "pretty")
+	if err == nil {
+		t.Fatal("expected error for unknown service in list, got nil")
+	}
+	if !strings.Contains(err.Error(), "未知 service") {
+		t.Errorf("error should mention 未知 service, got: %v", err)
+	}
+	if !strings.Contains(err.Error(), "可用 service") {
+		t.Errorf("error should list 可用 service, got: %v", err)
 	}
 }
 

--- a/skills/feishu-cli-schema/SKILL.md
+++ b/skills/feishu-cli-schema/SKILL.md
@@ -1,0 +1,154 @@
+---
+name: feishu-cli-schema
+description: >-
+  飞书 OpenAPI 方法本地浏览。schema <service.resource.method> 查路径/参数/scope（无需联网）；
+  schema list 列出所有可用 service。复用 feishu-cli 内置 OpenAPI 元数据（embed 746KB）。
+  当用户请求"飞书有没有 XX API"、"X API 的参数是什么"、"X 方法需要什么 scope"、
+  "OpenAPI 方法浏览"、"看 SDK 怎么调用"时使用。
+  不适用：调用 API（请用 lark-cli api）、查在线最新 schema（请用 OpenAPI Explorer）。
+argument-hint: <service.resource.method>
+user-invocable: true
+allowed-tools: Bash, Read
+---
+
+# 飞书 OpenAPI 方法浏览技能
+
+通过 `feishu-cli schema` 在本地查询飞书开放平台 OpenAPI 方法的 HTTP path / 动词 / 参数 / 请求体 / 响应体 / scope / 文档链接。**纯本地**、无需 Token、无需网络。
+
+> **feishu-cli**：如尚未安装，请前往 [riba2534/feishu-cli](https://github.com/riba2534/feishu-cli) 获取安装方式。
+
+> **要真正调用 API？** 本技能只查 schema，不发请求。拿到 path + scope 后用 `lark-cli api` 或对应 `feishu-cli <模块>` 命令调用。
+
+---
+
+## 核心概念
+
+### 路径格式：`<service>.<resource>.<method>`
+
+| 段 | 含义 | 示例 |
+|----|------|------|
+| service | 业务域 | im / docs / drive / bitable / calendar / vc / mail / wiki / approval / sheets / slides / task / attendance / minutes |
+| resource | 资源（可含 `.`，按最长前缀匹配） | messages / events / records / chat.members |
+| method | 动作 | create / get / list / update / delete / patch |
+
+按路径深度自动分发：
+
+- `schema` 无参数 → 列出所有 service
+- `schema <service>` → 列出该 service 下所有 resource.method
+- `schema <service>.<resource>` → 列出 resource 下的所有 method
+- `schema <service>.<resource>.<method>` → method 详情（含 path / 参数 / scope / docUrl）
+
+### 数据来源
+
+编译期 `embed` 的 `internal/registry/meta_data.json`（约 746KB），与 `auth check` 等模块共用同一份元数据。当前覆盖 **12 个 service**：approval / attendance / calendar / drive / im / mail / minutes / sheets / slides / task / vc / wiki。
+
+---
+
+## 命令速查
+
+### 1. 列出所有 service
+
+```bash
+feishu-cli schema
+# 等价：
+feishu-cli schema list
+```
+
+输出表格：`name | version | resources 数 | title`。
+
+### 2. 列出某个 service 的所有方法
+
+```bash
+feishu-cli schema im                       # 列出 im 域全部 resource.method
+feishu-cli schema list --service im        # 等价（推荐用 list，语义更清楚）
+feishu-cli schema list --service im --format json
+```
+
+`pretty` 输出按 resource 分组、列 `HTTP verb + method 名 + description`；`json` 输出扁平 `{service, resource, method, path, httpMethod, description}` 列表，方便 AI Agent 二次处理。
+
+### 3. 列出 resource 下的方法
+
+```bash
+feishu-cli schema im.messages              # messages 资源下所有 method
+feishu-cli schema im.chat.members          # 含点号的 resource（最长前缀匹配）
+```
+
+### 4. 查具体 method 详情
+
+```bash
+feishu-cli schema im.messages.delete
+feishu-cli schema im.messages.delete --format json
+```
+
+`pretty` 输出包含：
+
+- HTTP verb + 完整 URL path（`/open-apis/im/v1/messages/{message_id}`）
+- 方法描述
+- Parameters（含 `path` / `query` / `required` 标记 + 类型 + 描述 + example）
+- Request Body（POST/PUT/PATCH/DELETE 才显示，含嵌套字段）
+- Response Body
+- Identity：`tenant (bot)` / `user`（指明支持哪种 Token）
+- Scopes：调用所需权限点
+- Docs：飞书开放平台官方文档链接
+
+---
+
+## 关键 flag
+
+| flag | 作用 | 适用 |
+|------|------|------|
+| `--format pretty`（默认） | 人类可读，表格 + 缩进字段树 | 终端阅读 |
+| `--format json` | 原始 JSON（不转义 HTML） | AI Agent 解析、脚本拼装 |
+| `--service <name>` | 仅 `schema list` 子命令，过滤 service | 等价 `schema <service>` |
+
+---
+
+## 常见用例
+
+**1. 找飞书有没有某个 API**
+
+```bash
+feishu-cli schema list --service drive | grep -i comment
+```
+
+**2. 拼调用前查参数**
+
+```bash
+feishu-cli schema im.messages.create
+# 然后用 lark-cli api 或 feishu-cli msg send 调用
+```
+
+**3. AI Agent 拿 JSON 推断调用**
+
+```bash
+feishu-cli schema bitable.records.create --format json
+```
+
+**4. 确认某方法的 scope 要求**
+
+```bash
+feishu-cli schema vc.notes.get
+# 看 Identity / Scopes 行即可
+```
+
+---
+
+## 踩坑
+
+1. **路径过深会报错**：`schema im.messages.delete.foo` → `路径过深: ...（多余片段: foo）`。多写一层不会被静默吞掉。
+2. **路径不存在分级提示**：未知 service / resource / method 都会列出该层的所有可用候选名，便于纠正。
+3. **resource 含点号用最长前缀匹配**：`im.chat.members.create` 会匹配 resource = `chat.members`、method = `create`，不必担心拆错。
+4. **只读不调 API**：本命令永远不发起 HTTP 请求，不消耗任何配额，没有 token 过期顾虑。要真正调用见下方"何时转其他技能"。
+5. **覆盖范围 = 12 service**：当前未含 docx / contact / approval 等的较新 endpoint；如果 `schema list` 里没列出，说明本地元数据未收录，请去飞书 OpenAPI Explorer 查在线最新版。
+6. **JSON 输出不转义 HTML**：`<` / `>` / `&` 保留原样，便于直接吞进 jq / yq 管道。
+
+---
+
+## 何时转其他技能
+
+| 需求 | 该用什么 |
+|------|---------|
+| 真的要调 API | `lark-cli api` 通用调用 / `feishu-cli <模块>` 对应命令（msg / doc / bitable / drive…） |
+| 查在线最新 schema、本地没收录 | 飞书 [OpenAPI Explorer](https://open.feishu.cn/api-explorer) |
+| 申请 scope / 登录拿 User Token | `/feishu-cli-auth`（`auth check --scope` 预检、`auth login --domain --recommend` 按业务域申请） |
+| 发消息/文档/卡片等具体业务 | `/feishu-cli-msg` / `/feishu-cli-read` / `/feishu-cli-card` 等专用技能 |


### PR DESCRIPTION
## 背景

`larksuite/cli` 提供了 `schema <service.resource.method>` 命令，可在本地查询飞书开放平台 OpenAPI 方法的 path / verb / 参数 / scope 等元数据，**无需 token、纯静态查询**，是 AI Agent 和脚本作者在调用任意飞书 API 前快速对齐参数的必备工具。

`feishu-cli` 在 `internal/registry/meta_data.json` 里已经内置了 746KB 的 OpenAPI schema 数据（12 个 service、约 150 个 method），但**之前只在 `auth login --domain ... --recommend` 内部消费**，没有暴露给终端用户直接查询。

本 PR 复用同一份元数据，在 feishu-cli 代码风格下新增 `schema` 命令，让用户不再需要安装第二个 CLI 才能查参数。

## 新增命令

| 命令 | 功能 |
|---|---|
| `feishu-cli schema` | 列出所有可用 service（12 个） |
| `feishu-cli schema <service>` | 列出该 service 下所有 resource.method |
| `feishu-cli schema <service>.<resource>` | 列出该 resource 下所有 method |
| `feishu-cli schema <service>.<resource>.<method>` | 查看 method 详情（path/verb/参数/请求体/响应体/scope/docUrl） |
| `feishu-cli schema list` | 等价于 \`schema\` 无参 |
| `feishu-cli schema list --service im` | 等价于 \`schema im\`，但 JSON 输出走扁平 `[{service, resource, method, path, httpMethod, description}]` 格式便于脚本消费 |

所有命令支持 `--format pretty (默认) | json`。

## 示例

\`\`\`bash
$ feishu-cli schema
可用 service（共 12 个）：

  approval     v4     2 resources  审批 API
  attendance   v1     1 resources  考勤打卡 API
  calendar     v4     4 resources  日历 API
  drive        v1     9 resources  云空间 API
  im           v1     6 resources  即时通讯 API
  ...

$ feishu-cli schema im.messages.delete
im.messages.delete

  DELETE /open-apis/im/v1/messages/{message_id}
  撤回消息。Identity: supports \`user\` and \`bot\`...

Parameters:
  - message_id (string, path, required)
      待撤回的消息 ID...
      e.g. om_dc13264520392913993dd051dba21dcf

Identity: tenant (bot), user
Scopes:   im:message:recall, im:message, im:message:send_as_bot
CLI:      feishu-cli schema im.messages.delete
Docs:     https://open.feishu.cn/document/uAjLw4CM/.../message/delete

$ feishu-cli schema im.messages.delete --format json
{...}
\`\`\`

支持点分 resource 名（如 `im.chat.members.create` → resource `chat.members` + method `create`，最长前缀匹配）。

## 实现要点

- 数据源：复用 `internal/registry/meta_data.json`（编译期 embed），通过现有 `registry.LoadFromMeta()` / `registry.ListFromMetaProjects()` API
- 输出：保持 feishu-cli 风格（中文 header、无终端色彩，pipe 友好；JSON 默认两空格缩进）
- 错误：未知 service/resource/method 给出 `可用 xxx: a, b, c` 提示
- 不引入新依赖，不需要 token，不需要 network

## 测试

\`\`\`bash
$ go test ./cmd -run TestSchema -v
=== RUN   TestSchemaListServices
--- PASS: TestSchemaListServices (0.00s)
=== RUN   TestSchemaServiceDetail
--- PASS: TestSchemaServiceDetail (0.00s)
=== RUN   TestSchemaMethodDetail
--- PASS: TestSchemaMethodDetail (0.00s)
=== RUN   TestSchemaJSONFormat
--- PASS: TestSchemaJSONFormat (0.00s)
=== RUN   TestSchemaUnknownService
--- PASS: TestSchemaUnknownService (0.00s)
=== RUN   TestSchemaListSubcommand
--- PASS: TestSchemaListSubcommand (0.00s)
PASS
ok      github.com/riba2534/feishu-cli/cmd      0.383s

$ go test ./... 全绿
$ go vet ./... 无警告
\`\`\`

## CHANGELOG

已更新到 \`## 未发布\` 段。

## Scope

不需要任何 scope（纯本地查询）。

## 关联

- 对齐 `larksuite/cli` `schema` 子命令的设计与命名（参考接口语义，不直接复制代码）
- 闭环 feishu-cli "已有 schema 数据但无查询入口" 的能力空白