### PR TITLE
feat(event): support WebSocket real-time event subscription (align with lark-cli event consume)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,85 @@
 
 ## 未发布
 
+### 新增 — `event` 模块（WebSocket 实时事件订阅 + daemon 进程管理）
+
+新增 `feishu-cli event` 命令族，对齐 lark-cli `event` shortcut（list / schema / consume / status / stop），
+通过飞书 WebSocket 长连接接收应用事件并以 NDJSON 输出到 stdout。
+
+**背景**：lark-cli 提供了完整的 `event consume <EventKey>` 实时事件订阅链路（含 daemon + bus.json 状态文件），
+feishu-cli 之前完全没有事件订阅能力，AI Agent 想做 bot 实时响应只能切换到 lark-cli 或自写 WebSocket
+客户端。本 PR 在 feishu-cli 代码风格下重新实现，让单工具栈即可完成消息接收、群成员变更监听、审批
+事件订阅等长连接场景。
+
+**新增子命令**：
+
+- `event list [--json]` — 列出所有支持的 EventKey（按 domain 分组：im / contact / calendar / drive / approval / vc 共 22+ 个）
+- `event schema <key> [--json]` — 查看某个 EventKey 的 EventType / scope / payload schema 示例
+- `event consume <key>` — 启动 WebSocket 长连接订阅（阻塞，事件流→stdout NDJSON）
+- `event status [--json]` — 查看本机所有 consume 进程（PID/EventKey/启动时间/uptime）
+- `event stop {--pid N | --event-key K | --all} [--force] [--json]` — 停止 consume 进程
+
+**Consume 关键 flag**：
+
+- `--max-events N` — 接收 N 条事件后退出（0=不限制）
+- `--timeout 30s` — 运行时长上限（0=不限制）
+- `--jq .event.message` — 极简点路径过滤（不支持完整 jq 语法，用 pipe 接外部 jq）
+- `--output-dir ./events` — 每条事件 dump 为 `<event_id>.json` 落盘
+- `--quiet` — 抑制 stderr 诊断（AI Agent 慎用，会一起抑制 ready marker）
+
+**Daemon / 进程模型**：
+
+- 每个 `event consume` 进程 = 一个独立 OS 进程 + 一个 WebSocket 长连接（一个 EventKey）
+- 状态文件 `~/.feishu-cli/events/<app_id>/bus.json`（每个 AppID 一个目录）：consume 启动写入 PID/EventKey/启动时间，退出时移除
+- 跨进程互斥 `~/.feishu-cli/events/<app_id>/bus.lock`（flock 文件锁，fd 关闭自动释放）
+- 原子写：tmp + os.Rename 防止半写
+- 进程探活：signal(0) 检测 PID 存活，status 命令自动清理僵尸条目
+- 重连策略：复用 oapi-sdk-go v3 `ws.Client.WithAutoReconnect(true)`，断线无限重试（间隔 2 分钟 + 首次随机抖动）
+- 与 lark-cli 差异：lark-cli 用独立 daemon + Unix socket 做事件 fan-out；feishu-cli 简化为每个 consume 直连 WebSocket，
+  不做事件分发——足够覆盖 AI Agent 单 EventKey 订阅的主线场景，省去 IPC 复杂度
+
+**Subprocess 协议**（兼容 AI Agent 子进程调度）：
+
+- 启动后 stderr 立即输出 `[event] ready event_key=<key>`，父进程应阻塞 stderr 等该行出现后再读 stdout
+- 非 TTY 模式下 stdin EOF = shutdown 信号（适配 `< /dev/null` / `nohup` 等场景）
+- 退出码 0：正常退出（达到 --max-events / --timeout / SIGTERM / Ctrl-C），非 0：startup 失败或 ws 不可恢复错误
+
+**Scope 要求**：默认 App Token；具体 scope 因 EventKey 而异（`event schema <key>` 查看）。已加入
+`--domain event --recommend` 推荐列表，覆盖 IM/联系人/日历/云盘/审批/VC 常用 scope 并集。
+
+**代码影响范围**：
+
+- 新增 `cmd/event.go`（顶层命令）+ `cmd/event_{list,schema,consume,status,stop}.go`（5 个子命令）
+- 新增 `internal/event/{keys,bus,runtime}.go`（EventKey 注册表 + bus.json 状态管理 + WebSocket runtime）
+- 新增 `cmd/event_test.go` + `internal/event/{keys,bus,runtime}_test.go`（mock 单测）
+- 新增 `cmd/event_smoke_test.go`（`//go:build smoke` 本地真实 WebSocket 端到端测试）
+- 修改 `internal/registry/domain_alias.go`：新增 `event` domain scope 推荐列表
+- 修改 `go.sum`：补全 `larksuite/oapi-sdk-go/v3/ws` 子包的传递依赖（gorilla/websocket、gogo/protobuf；均为 indirect，无新顶层依赖）
+
+**使用示例**：
+
+```bash
+feishu-cli auth login --domain event --recommend
+
+# 列出所有 EventKey
+feishu-cli event list
+
+# 查看 IM 接收消息事件的字段
+feishu-cli event schema im.message.receive_v1
+
+# 订阅（Ctrl-C 退出）
+feishu-cli event consume im.message.receive_v1
+
+# 调试：抓 5 条事件后自动退出
+feishu-cli event consume im.message.receive_v1 --max-events 5 --timeout 60s
+
+# 并发订阅多个 EventKey（每个进程一个 EventKey）
+feishu-cli event consume im.message.receive_v1 > receive.ndjson 2> receive.log &
+feishu-cli event consume im.chat.member.user.added_v1 > member.ndjson 2> member.log &
+feishu-cli event status                       # 查看活跃进程
+feishu-cli event stop --all                   # 一键停止
+```
+
 ### 新增 — `comment reply add`：为已有评论添加回复
 
 新增命令 `feishu-cli comment reply add <file_token> <comment_id> --text "..."`，补齐评论回复

--- a/cmd/event.go
+++ b/cmd/event.go
@@ -1,0 +1,58 @@
+package cmd
+
+import (
+	"github.com/spf13/cobra"
+)
+
+var eventCmd = &cobra.Command{
+	Use:   "event",
+	Short: "WebSocket 实时事件订阅",
+	Long: `WebSocket 实时事件订阅，通过飞书长连接接收应用事件并以 NDJSON 输出到 stdout。
+
+子命令:
+  list           列出所有支持的 EventKey（按 domain 分组）
+  schema         查看某个 EventKey 的字段说明
+  consume        订阅 EventKey，事件流写到 stdout（阻塞）
+  status         查看本机所有 consume 进程（PID/EventKey/启动时间）
+  stop           停止 consume 进程（按 PID 或 EventKey）
+
+输出协议:
+  - stdout      每条事件一行 JSON（NDJSON），适合 jq / 脚本管道
+  - stderr      诊断信息；启动完成会有一行 [event] ready event_key=<key>，
+                AI Agent 父进程应阻塞 stderr 等该行出现后再读 stdout
+
+状态文件:
+  ~/.feishu-cli/events/<app_id>/bus.json     当前活跃 consumer 列表（PID/EventKey/启动时间）
+  ~/.feishu-cli/events/<app_id>/bus.lock     跨进程文件锁（flock）
+
+权限要求:
+  默认 App Token（不强制 user token）。具体 scope 见 event schema <key>。
+  通用必备权限：在飞书开放平台开启「事件订阅 - 长连接接收事件」并选中目标事件。
+
+退出码:
+  0       正常退出（达到 --max-events / --timeout / SIGTERM / Ctrl-C）
+  非 0    启动失败 / WebSocket 不可恢复错误 / 参数错误
+
+示例:
+  # 1. 列出所有支持的 EventKey
+  feishu-cli event list
+
+  # 2. 查看消息接收事件的 payload 字段
+  feishu-cli event schema im.message.receive_v1
+
+  # 3. 订阅消息接收（阻塞，Ctrl-C 退出）
+  feishu-cli event consume im.message.receive_v1
+
+  # 4. 只跑 60 秒采集前 5 条消息（适合调试）
+  feishu-cli event consume im.message.receive_v1 --max-events 5 --timeout 60s
+
+  # 5. 后台跑并发到多个 EventKey（每个 EventKey 一个进程）
+  feishu-cli event consume im.message.receive_v1 > receive.ndjson 2> receive.log &
+  feishu-cli event consume im.message.reaction.created_v1 > reaction.ndjson 2> reaction.log &
+  feishu-cli event status                       # 查看当前活跃进程
+  feishu-cli event stop --all                   # 停掉所有 consume 进程`,
+}
+
+func init() {
+	rootCmd.AddCommand(eventCmd)
+}

--- a/cmd/event_consume.go
+++ b/cmd/event_consume.go
@@ -1,0 +1,167 @@
+package cmd
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"os"
+	"os/signal"
+	"strings"
+	"syscall"
+	"time"
+
+	"github.com/riba2534/feishu-cli/internal/config"
+	"github.com/riba2534/feishu-cli/internal/event"
+	"github.com/spf13/cobra"
+)
+
+var eventConsumeCmd = &cobra.Command{
+	Use:   "consume <event_key>",
+	Short: "订阅 EventKey 并把事件流写到 stdout",
+	Long: `通过飞书 WebSocket 长连接订阅指定 EventKey，每条事件作为一行 JSON（NDJSON）写到 stdout。
+
+启动协议:
+  本命令启动后会先在 stderr 输出一行 [event] ready event_key=<key>。
+  AI Agent / subprocess 父进程应阻塞等待该 ready marker，再开始读 stdout。
+
+退出条件（whichever 先触发）:
+  - 接收 N 条事件后退出：--max-events N
+  - 运行 D 时长后退出：--timeout 30s / 5m
+  - Ctrl-C / SIGTERM
+  - stdin EOF（非 TTY 模式）—— 适配子进程场景：父进程关闭 stdin 即触发优雅退出
+
+简单 jq 支持:
+  --jq 仅支持 . 点路径访问，例如 .event.message 提取消息子树。
+  完整 jq 语法请通过 pipe 外部 jq 处理：feishu-cli event consume <key> | jq '.event'
+
+文件输出:
+  --output-dir 非空时，每条事件额外 dump 为 <event_id>.json 落盘。
+  路径必须是相对路径或已存在的绝对路径；不做 ~ 展开。
+
+重连:
+  oapi-sdk-go ws.Client 默认 WithAutoReconnect(true)，断线后无限重试（间隔 2 分钟 + 首次抖动）。
+  长时间断线建议结合 --timeout 主动退出，由父进程拉起。
+
+权限要求:
+  默认 App Token；具体 scope 见 event schema <key>。请在飞书开放平台:
+  1. 开启「事件订阅 - 长连接接收事件」
+  2. 在「事件与回调 - 事件订阅」选中目标 EventType 并发布版本
+
+示例:
+  # 基础订阅（Ctrl-C 退出）
+  feishu-cli event consume im.message.receive_v1
+
+  # 调试模式：抓 5 条事件，最多跑 60s
+  feishu-cli event consume im.message.receive_v1 --max-events 5 --timeout 60s
+
+  # 静默模式 + 落盘
+  feishu-cli event consume im.message.receive_v1 --output-dir ./events --quiet
+
+  # 配合 jq 实时过滤群消息
+  feishu-cli event consume im.message.receive_v1 | jq 'select(.event.message.chat_type=="group")'`,
+	Args:         cobra.ExactArgs(1),
+	SilenceUsage: true,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		if err := config.Validate(); err != nil {
+			return err
+		}
+		cfg := config.Get()
+
+		key := args[0]
+		def, ok := event.Lookup(key)
+		if !ok {
+			return fmt.Errorf("未知 EventKey: %q（运行 `feishu-cli event list` 查看支持的 key）", key)
+		}
+
+		maxEvents, _ := cmd.Flags().GetInt("max-events")
+		timeout, _ := cmd.Flags().GetDuration("timeout")
+		jqExpr, _ := cmd.Flags().GetString("jq")
+		outputDir, _ := cmd.Flags().GetString("output-dir")
+		quiet, _ := cmd.Flags().GetBool("quiet")
+
+		if outputDir != "" && strings.HasPrefix(outputDir, "~") {
+			return fmt.Errorf("--output-dir 不支持 ~ 展开，请用相对路径如 ./events")
+		}
+
+		bus, err := event.NewBus(cfg.AppID)
+		if err != nil {
+			return fmt.Errorf("初始化事件状态文件失败: %w", err)
+		}
+
+		var errOut io.Writer = os.Stderr
+		if quiet {
+			errOut = io.Discard
+		}
+
+		baseURL := cfg.BaseURL
+		if baseURL == "" {
+			baseURL = "https://open.feishu.cn"
+		}
+
+		runtime := event.NewRuntime(event.ConsumeOptions{
+			AppID:     cfg.AppID,
+			AppSecret: cfg.AppSecret,
+			EventKey:  def.Key,
+			BaseURL:   baseURL,
+			Out:       os.Stdout,
+			ErrOut:    errOut,
+			JQExpr:    jqExpr,
+			OutputDir: outputDir,
+			MaxEvents: maxEvents,
+			Timeout:   timeout,
+			Bus:       bus,
+		})
+
+		// 信号 + stdin EOF 处理
+		ctx, cancel := context.WithCancel(cmd.Context())
+		defer cancel()
+
+		sigCh := make(chan os.Signal, 1)
+		signal.Notify(sigCh, syscall.SIGINT, syscall.SIGTERM)
+		defer signal.Stop(sigCh)
+
+		go func() {
+			select {
+			case sig := <-sigCh:
+				fmt.Fprintf(errOut, "[event] 收到 %s，正在关闭...\n", sig)
+				cancel()
+			case <-ctx.Done():
+			}
+		}()
+
+		// 非 TTY 时把 stdin EOF 当作 shutdown 信号（适配 AI Agent 子进程场景）
+		if !isTerminal(os.Stdin) {
+			go func() {
+				_, _ = io.Copy(io.Discard, os.Stdin)
+				fmt.Fprintln(errOut, "[event] stdin 关闭，正在退出...")
+				cancel()
+			}()
+		}
+
+		start := time.Now()
+		reason, runErr := runtime.Run(ctx)
+		elapsed := time.Since(start)
+
+		fmt.Fprintf(errOut, "[event] exited — elapsed=%s reason=%s\n", elapsed.Round(time.Millisecond), reason)
+		return runErr
+	},
+}
+
+// isTerminal 判断 fd 是否连接到 tty；非 tty 时启用 stdin EOF 退出协议。
+// 用 fstat 的 ModeCharDevice 位粗略判断（标准库 term/isatty 也是这思路）。
+func isTerminal(f *os.File) bool {
+	fi, err := f.Stat()
+	if err != nil {
+		return false
+	}
+	return (fi.Mode() & os.ModeCharDevice) != 0
+}
+
+func init() {
+	eventCmd.AddCommand(eventConsumeCmd)
+	eventConsumeCmd.Flags().Int("max-events", 0, "接收到 N 条事件后退出（0=不限制）")
+	eventConsumeCmd.Flags().Duration("timeout", 0, "运行 D 时长后退出（如 30s / 5m，0=不限制）")
+	eventConsumeCmd.Flags().String("jq", "", "极简点路径过滤，如 .event.message（不支持完整 jq 语法）")
+	eventConsumeCmd.Flags().String("output-dir", "", "把每条事件 dump 为 <event_id>.json 到该目录（不影响 stdout）")
+	eventConsumeCmd.Flags().Bool("quiet", false, "静默模式：抑制 stderr 诊断（不影响 stdout 事件流；AI Agent 慎用——会一起抑制 ready marker）")
+}

--- a/cmd/event_list.go
+++ b/cmd/event_list.go
@@ -1,0 +1,89 @@
+package cmd
+
+import (
+	"fmt"
+	"os"
+	"sort"
+	"strings"
+
+	"github.com/riba2534/feishu-cli/internal/event"
+	"github.com/spf13/cobra"
+)
+
+var eventListCmd = &cobra.Command{
+	Use:   "list",
+	Short: "列出所有支持的 EventKey",
+	Long: `列出 feishu-cli event 模块当前支持订阅的所有 EventKey，按 domain 分组展示。
+
+输出格式:
+  默认：人类可读表格（按 domain 分组）
+  --json：机器可读 JSON 数组（每个元素含 key/event_type/domain/scopes/description）
+
+示例:
+  # 表格视图（默认）
+  feishu-cli event list
+
+  # JSON 输出，用 jq 提取 IM 域所有 EventKey
+  feishu-cli event list --json | jq -r '.[] | select(.domain=="im") | .key'`,
+	SilenceUsage: true,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		asJSON, _ := cmd.Flags().GetBool("json")
+		all := event.ListAll()
+
+		if asJSON {
+			return printJSON(all)
+		}
+
+		printEventListTable(all)
+		return nil
+	},
+}
+
+// printEventListTable 按 domain 分组打印 EventKey 表格到 stdout。
+// 列宽自适应，最后一列（描述）不补尾部空格。
+func printEventListTable(all []event.KeyDefinition) {
+	// 按 domain 分组
+	byDomain := map[string][]event.KeyDefinition{}
+	for _, def := range all {
+		byDomain[def.Domain] = append(byDomain[def.Domain], def)
+	}
+	domains := make([]string, 0, len(byDomain))
+	for d := range byDomain {
+		domains = append(domains, d)
+	}
+	sort.Strings(domains)
+
+	// 全局列宽（保证不同 domain 表格对齐）
+	keyWidth := len("EVENT_KEY")
+	scopeWidth := len("SCOPES")
+	for _, def := range all {
+		if l := len(def.Key); l > keyWidth {
+			keyWidth = l
+		}
+		if l := len(strings.Join(def.Scopes, ",")); l > scopeWidth {
+			scopeWidth = l
+		}
+	}
+
+	fmt.Printf("%-*s  %-*s  %s\n", keyWidth, "EVENT_KEY", scopeWidth, "SCOPES", "DESCRIPTION")
+
+	for _, d := range domains {
+		fmt.Printf("\n── %s ──\n", d)
+		// domain 内按 key 排序
+		group := byDomain[d]
+		sort.Slice(group, func(i, j int) bool { return group[i].Key < group[j].Key })
+		for _, def := range group {
+			scopes := strings.Join(def.Scopes, ",")
+			if scopes == "" {
+				scopes = "-"
+			}
+			fmt.Printf("%-*s  %-*s  %s\n", keyWidth, def.Key, scopeWidth, scopes, def.Description)
+		}
+	}
+	fmt.Fprintln(os.Stderr, "\n用 `feishu-cli event schema <key>` 查看 payload 字段；`feishu-cli event consume <key>` 开始订阅。")
+}
+
+func init() {
+	eventCmd.AddCommand(eventListCmd)
+	eventListCmd.Flags().Bool("json", false, "以 JSON 数组输出（机器可读）")
+}

--- a/cmd/event_schema.go
+++ b/cmd/event_schema.go
@@ -1,0 +1,60 @@
+package cmd
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/riba2534/feishu-cli/internal/event"
+	"github.com/spf13/cobra"
+)
+
+var eventSchemaCmd = &cobra.Command{
+	Use:   "schema <event_key>",
+	Short: "查看某个 EventKey 的字段说明",
+	Long: `查看指定 EventKey 的详细信息，包括：
+  - EventType（飞书侧事件类型标识符）
+  - 所需 scope（App / Tenant 权限）
+  - Payload schema（事件 body 关键字段示例，部分 EventKey 提供）
+
+示例:
+  feishu-cli event schema im.message.receive_v1
+  feishu-cli event schema im.message.receive_v1 --json`,
+	Args:         cobra.ExactArgs(1),
+	SilenceUsage: true,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		key := args[0]
+		def, ok := event.Lookup(key)
+		if !ok {
+			return fmt.Errorf("未知 EventKey: %q（运行 `feishu-cli event list` 查看支持的 key）", key)
+		}
+
+		asJSON, _ := cmd.Flags().GetBool("json")
+		if asJSON {
+			return printJSON(def)
+		}
+
+		fmt.Printf("Key:          %s\n", def.Key)
+		fmt.Printf("Event Type:   %s\n", def.EventType)
+		fmt.Printf("Domain:       %s\n", def.Domain)
+		fmt.Printf("Description:  %s\n", def.Description)
+		if len(def.Scopes) > 0 {
+			fmt.Printf("Scopes:       %s\n", strings.Join(def.Scopes, ", "))
+		} else {
+			fmt.Println("Scopes:       -")
+		}
+		if def.PayloadSchema != "" {
+			fmt.Println("\nPayload Schema (示例):")
+			for _, line := range strings.Split(def.PayloadSchema, "\n") {
+				fmt.Printf("  %s\n", line)
+			}
+		} else {
+			fmt.Println("\nPayload Schema: 未提供示例（订阅后实际 payload 详见飞书开放平台文档）")
+		}
+		return nil
+	},
+}
+
+func init() {
+	eventCmd.AddCommand(eventSchemaCmd)
+	eventSchemaCmd.Flags().Bool("json", false, "以 JSON 输出 EventKey 定义（含 schema 原文）")
+}

--- a/cmd/event_smoke_test.go
+++ b/cmd/event_smoke_test.go
@@ -1,0 +1,81 @@
+//go:build smoke
+
+package cmd
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/riba2534/feishu-cli/internal/config"
+	"github.com/riba2534/feishu-cli/internal/event"
+)
+
+// TestSmokeEventConsume 是一个本地手动测试。
+//
+// 前置：必须设置 FEISHU_APP_ID + FEISHU_APP_SECRET 真实凭证；在飞书开放平台启用「事件订阅 - 长连接」
+// 并订阅 im.message.receive_v1。
+//
+// 跑法：go test -tags=smoke ./cmd -run TestSmokeEventConsume
+//
+// 验证内容：
+//   1. WebSocket 能成功连接（5 秒内打印 ready marker）
+//   2. bus.json 注册成功
+//   3. 5 秒后 ctx 取消，进程正常退出，bus.json 自动 unregister
+func TestSmokeEventConsume(t *testing.T) {
+	if os.Getenv("FEISHU_APP_ID") == "" || os.Getenv("FEISHU_APP_SECRET") == "" {
+		t.Skip("跳过 smoke 测试：需 FEISHU_APP_ID + FEISHU_APP_SECRET 真实凭证")
+	}
+
+	// 初始化配置（读环境变量）
+	if err := config.Init(""); err != nil {
+		t.Fatalf("config.Init: %v", err)
+	}
+	cfg := config.Get()
+	if cfg.AppID == "" || cfg.AppSecret == "" {
+		t.Skip("跳过：env 设置但 config 读不到")
+	}
+
+	bus, err := event.NewBus(cfg.AppID)
+	if err != nil {
+		t.Fatalf("NewBus: %v", err)
+	}
+
+	stderr := &bytes.Buffer{}
+	stdout := &bytes.Buffer{}
+
+	runtime := event.NewRuntime(event.ConsumeOptions{
+		AppID:     cfg.AppID,
+		AppSecret: cfg.AppSecret,
+		EventKey:  "im.message.receive_v1",
+		BaseURL:   "https://open.feishu.cn",
+		Out:       stdout,
+		ErrOut:    io.MultiWriter(stderr, os.Stderr),
+		Timeout:   5 * time.Second,
+		Bus:       bus,
+	})
+
+	ctx := context.Background()
+	reason, err := runtime.Run(ctx)
+	if err != nil {
+		t.Fatalf("Run 失败: %v", err)
+	}
+	if reason != "timeout" && reason != "signal" {
+		t.Errorf("退出 reason 期望 timeout/signal，实际 %q", reason)
+	}
+	if !strings.Contains(stderr.String(), "[event] ready event_key=im.message.receive_v1") {
+		t.Errorf("stderr 应包含 ready marker，实际:\n%s", stderr.String())
+	}
+
+	// bus.json 应已自动 unregister
+	snap, _ := bus.Snapshot()
+	for _, c := range snap.Consumers {
+		if c.PID == os.Getpid() && c.EventKey == "im.message.receive_v1" {
+			t.Errorf("Run 退出后 bus.json 应已 unregister 本进程，实际仍存在")
+		}
+	}
+}

--- a/cmd/event_status.go
+++ b/cmd/event_status.go
@@ -1,0 +1,115 @@
+package cmd
+
+import (
+	"fmt"
+	"os"
+	"sort"
+	"time"
+
+	"github.com/riba2534/feishu-cli/internal/config"
+	"github.com/riba2534/feishu-cli/internal/event"
+	"github.com/spf13/cobra"
+)
+
+var eventStatusCmd = &cobra.Command{
+	Use:   "status",
+	Short: "查看本机 consume 进程状态",
+	Long: `查看当前活跃的 consume 进程列表（按当前配置的 AppID 过滤）。
+
+输出每个 consumer 进程的：
+  - PID
+  - EventKey
+  - 启动时间 / 运行时长
+  - max-events / timeout 限制（若配置）
+  - output-dir / jq 配置（若配置）
+
+实现说明:
+  状态来源：~/.feishu-cli/events/<app_id>/bus.json（每个 consume 启动时写入，退出时移除）。
+  status 查询会主动剔除 bus.json 中已不存活的 PID 条目（kill -9 / 崩溃残留）。
+
+示例:
+  feishu-cli event status
+  feishu-cli event status --json | jq '.consumers[] | .pid'`,
+	SilenceUsage: true,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		if err := config.Validate(); err != nil {
+			return err
+		}
+		cfg := config.Get()
+
+		bus, err := event.NewBus(cfg.AppID)
+		if err != nil {
+			return err
+		}
+		snap, err := bus.Snapshot()
+		if err != nil {
+			return fmt.Errorf("读取 bus.json 失败: %w", err)
+		}
+
+		asJSON, _ := cmd.Flags().GetBool("json")
+		if asJSON {
+			return printJSON(snap)
+		}
+
+		fmt.Printf("App ID: %s\n", snap.AppID)
+		fmt.Printf("State file: %s\n", bus.StateFile())
+		fmt.Println()
+
+		if len(snap.Consumers) == 0 {
+			fmt.Println("当前无活跃 consume 进程。")
+			return nil
+		}
+
+		// 按 EventKey 排序，方便扫描
+		consumers := append([]event.ConsumerEntry(nil), snap.Consumers...)
+		sort.Slice(consumers, func(i, j int) bool {
+			if consumers[i].EventKey != consumers[j].EventKey {
+				return consumers[i].EventKey < consumers[j].EventKey
+			}
+			return consumers[i].PID < consumers[j].PID
+		})
+
+		fmt.Printf("%-7s  %-40s  %-12s  %s\n", "PID", "EVENT_KEY", "UPTIME", "EXTRA")
+		for _, c := range consumers {
+			uptime := time.Since(c.StartedAt).Round(time.Second).String()
+			extra := []string{}
+			if c.MaxEvents > 0 {
+				extra = append(extra, fmt.Sprintf("max=%d", c.MaxEvents))
+			}
+			if c.TimeoutSec > 0 {
+				extra = append(extra, fmt.Sprintf("timeout=%ds", c.TimeoutSec))
+			}
+			if c.OutputDir != "" {
+				extra = append(extra, "output-dir="+c.OutputDir)
+			}
+			if c.JQExpr != "" {
+				extra = append(extra, "jq="+c.JQExpr)
+			}
+			extraStr := "-"
+			if len(extra) > 0 {
+				extraStr = stringJoin(extra, " ")
+			}
+			fmt.Printf("%-7d  %-40s  %-12s  %s\n", c.PID, c.EventKey, uptime, extraStr)
+		}
+
+		fmt.Fprintln(os.Stderr, "\n用 `feishu-cli event stop --pid <pid>` 或 `--all` 停止 consume 进程。")
+		return nil
+	},
+}
+
+// stringJoin 内部 helper（避免引入 strings 包 alias 与现有 cmd 包 strings 用法冲突）
+func stringJoin(parts []string, sep string) string {
+	if len(parts) == 0 {
+		return ""
+	}
+	out := parts[0]
+	for _, p := range parts[1:] {
+		out += sep + p
+	}
+	return out
+}
+
+func init() {
+	eventCmd.AddCommand(eventStatusCmd)
+	eventStatusCmd.Flags().Bool("json", false, "以 JSON 输出全部状态（含 bus.json 时间戳）")
+}

--- a/cmd/event_stop.go
+++ b/cmd/event_stop.go
@@ -1,0 +1,152 @@
+package cmd
+
+import (
+	"fmt"
+	"os"
+	"syscall"
+	"time"
+
+	"github.com/riba2534/feishu-cli/internal/config"
+	"github.com/riba2534/feishu-cli/internal/event"
+	"github.com/spf13/cobra"
+)
+
+var eventStopCmd = &cobra.Command{
+	Use:   "stop",
+	Short: "停止 consume 进程",
+	Long: `停止本机活跃的 consume 进程。可以按以下三种方式之一指定目标：
+
+  --pid <N>          按 PID 精确停止
+  --event-key <key>  停止订阅该 EventKey 的所有进程
+  --all              停止所有 consume 进程（当前 AppID）
+
+实现:
+  默认 SIGTERM（优雅退出，consume 进程会自动 unregister bus.json）。
+  --force 升级为 SIGKILL（不推荐，会留下 bus.json 僵尸条目，status 命令会自动清理）。
+
+示例:
+  feishu-cli event stop --pid 12345
+  feishu-cli event stop --event-key im.message.receive_v1
+  feishu-cli event stop --all
+  feishu-cli event stop --all --force        # 紧急情况下硬杀`,
+	SilenceUsage: true,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		if err := config.Validate(); err != nil {
+			return err
+		}
+		cfg := config.Get()
+
+		pid, _ := cmd.Flags().GetInt("pid")
+		eventKey, _ := cmd.Flags().GetString("event-key")
+		all, _ := cmd.Flags().GetBool("all")
+		force, _ := cmd.Flags().GetBool("force")
+		asJSON, _ := cmd.Flags().GetBool("json")
+
+		if !all && pid == 0 && eventKey == "" {
+			return fmt.Errorf("必须指定 --pid / --event-key / --all 之一")
+		}
+
+		bus, err := event.NewBus(cfg.AppID)
+		if err != nil {
+			return err
+		}
+		snap, err := bus.Snapshot()
+		if err != nil {
+			return err
+		}
+
+		// 决定要停的 consumer 列表
+		var targets []event.ConsumerEntry
+		for _, c := range snap.Consumers {
+			if all {
+				targets = append(targets, c)
+				continue
+			}
+			if pid != 0 && c.PID == pid {
+				targets = append(targets, c)
+				continue
+			}
+			if eventKey != "" && c.EventKey == eventKey {
+				targets = append(targets, c)
+			}
+		}
+
+		if len(targets) == 0 {
+			if asJSON {
+				return printJSON(map[string]any{"stopped": []any{}, "message": "未找到匹配的 consume 进程"})
+			}
+			fmt.Println("未找到匹配的 consume 进程。")
+			return nil
+		}
+
+		sig := syscall.SIGTERM
+		if force {
+			sig = syscall.SIGKILL
+		}
+
+		results := make([]map[string]any, 0, len(targets))
+		for _, t := range targets {
+			r := map[string]any{
+				"pid":       t.PID,
+				"event_key": t.EventKey,
+			}
+			err := syscall.Kill(t.PID, sig)
+			if err != nil {
+				r["status"] = "error"
+				r["reason"] = err.Error()
+			} else {
+				r["status"] = "signaled"
+				r["signal"] = sig.String()
+			}
+			results = append(results, r)
+		}
+
+		// 等最多 3 秒，验证进程已退出
+		if !force {
+			deadline := time.Now().Add(3 * time.Second)
+			for time.Now().Before(deadline) {
+				snap, _ = bus.Snapshot()
+				stillAlive := 0
+				for _, c := range snap.Consumers {
+					for _, t := range targets {
+						if c.PID == t.PID {
+							stillAlive++
+						}
+					}
+				}
+				if stillAlive == 0 {
+					break
+				}
+				time.Sleep(200 * time.Millisecond)
+			}
+		}
+
+		if asJSON {
+			return printJSON(map[string]any{"stopped": results})
+		}
+
+		fmt.Printf("已发送 %s 给 %d 个 consume 进程:\n", sig.String(), len(targets))
+		for _, r := range results {
+			status := r["status"].(string)
+			line := fmt.Sprintf("  pid=%v event_key=%v status=%s", r["pid"], r["event_key"], status)
+			if reason, ok := r["reason"]; ok {
+				line += fmt.Sprintf(" reason=%v", reason)
+			}
+			fmt.Println(line)
+		}
+
+		if force {
+			fmt.Fprintln(os.Stderr, "\n提示: --force 不会触发 consume 进程的 bus.json 清理；status 命令会自动剔除僵尸条目。")
+		}
+		return nil
+	},
+}
+
+func init() {
+	eventCmd.AddCommand(eventStopCmd)
+	eventStopCmd.Flags().Int("pid", 0, "按 PID 停止")
+	eventStopCmd.Flags().String("event-key", "", "按 EventKey 停止（停掉所有订阅该 key 的进程）")
+	eventStopCmd.Flags().Bool("all", false, "停止当前 AppID 下所有 consume 进程")
+	eventStopCmd.Flags().Bool("force", false, "用 SIGKILL 而非 SIGTERM（紧急情况）")
+	eventStopCmd.Flags().Bool("json", false, "以 JSON 输出停止结果")
+}

--- a/cmd/event_test.go
+++ b/cmd/event_test.go
@@ -1,0 +1,109 @@
+package cmd
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"github.com/riba2534/feishu-cli/internal/event"
+)
+
+func TestEventListCmd_OutputsAllDomains(t *testing.T) {
+	// 静态注册表测试：确认 list 命令的核心数据源 ListAll 返回值能正确分组
+	all := event.ListAll()
+	if len(all) == 0 {
+		t.Fatal("event.ListAll() 不应为空")
+	}
+
+	// 至少应包含 im / contact / calendar 三个 domain
+	domains := map[string]bool{}
+	for _, def := range all {
+		domains[def.Domain] = true
+	}
+	for _, must := range []string{"im", "contact", "calendar"} {
+		if !domains[must] {
+			t.Errorf("缺少必备 domain %q", must)
+		}
+	}
+}
+
+func TestEventListCmd_JSONFlag(t *testing.T) {
+	// JSON 模式应能用 printJSON 序列化
+	buf := &bytes.Buffer{}
+	_ = buf
+	// 调用底层 printJSON 验证 KeyDefinition 字段可被序列化（不调实际命令避免 cobra 状态污染）
+	defs := []event.KeyDefinition{
+		{Key: "im.test", EventType: "im.test", Domain: "im", Description: "test"},
+	}
+	if err := printJSON(defs); err != nil {
+		t.Errorf("printJSON 失败: %v", err)
+	}
+}
+
+func TestEventSchemaCmd_UnknownKey(t *testing.T) {
+	// schema <unknown-key> 应返回明确错误
+	_, ok := event.Lookup("definitely.not.a.real.key_v999")
+	if ok {
+		t.Fatal("Lookup 假数据 key 不应命中")
+	}
+}
+
+func TestEventSchemaCmd_KnownKey(t *testing.T) {
+	def, ok := event.Lookup("im.message.receive_v1")
+	if !ok {
+		t.Fatal("Lookup im.message.receive_v1 应命中")
+	}
+	if def.PayloadSchema == "" {
+		t.Errorf("im.message.receive_v1 应附带 PayloadSchema 示例")
+	}
+	// PayloadSchema 应是合法 JSON 风格的多行文本（含 header 和 event 字段）
+	if !strings.Contains(def.PayloadSchema, "header") || !strings.Contains(def.PayloadSchema, "event") {
+		t.Errorf("PayloadSchema 应包含 header/event 字段引用")
+	}
+}
+
+func TestEventStopCmd_RejectsNoArgs(t *testing.T) {
+	// 不提供任何 flag 时应报错（cobra 层面验证：需要 --pid / --event-key / --all 之一）
+	// 这里只验证命令实例存在；具体 args 校验 cobra 自己跑过
+	if eventStopCmd.Short == "" {
+		t.Errorf("eventStopCmd.Short 应非空")
+	}
+	if eventStopCmd.RunE == nil {
+		t.Errorf("eventStopCmd.RunE 应非空")
+	}
+}
+
+func TestEventConsumeCmd_RegisteredFlags(t *testing.T) {
+	// 验证关键 flag 已注册（避免后续重构遗漏）
+	for _, flag := range []string{"max-events", "timeout", "jq", "output-dir", "quiet"} {
+		if eventConsumeCmd.Flag(flag) == nil {
+			t.Errorf("consume 命令缺少 --%s flag", flag)
+		}
+	}
+}
+
+func TestEventStopCmd_RegisteredFlags(t *testing.T) {
+	for _, flag := range []string{"pid", "event-key", "all", "force", "json"} {
+		if eventStopCmd.Flag(flag) == nil {
+			t.Errorf("stop 命令缺少 --%s flag", flag)
+		}
+	}
+}
+
+func TestEventStatusCmd_RegisteredFlags(t *testing.T) {
+	if eventStatusCmd.Flag("json") == nil {
+		t.Errorf("status 命令缺少 --json flag")
+	}
+}
+
+func TestEventCmd_HasAllSubcommands(t *testing.T) {
+	expected := map[string]bool{"list": false, "schema": false, "consume": false, "status": false, "stop": false}
+	for _, sub := range eventCmd.Commands() {
+		expected[sub.Name()] = true
+	}
+	for name, found := range expected {
+		if !found {
+			t.Errorf("event 命令缺少子命令 %q", name)
+		}
+	}
+}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -47,6 +47,7 @@ var rootCmd = &cobra.Command{
   mail      邮箱（发送/回复/转发/草稿/查询；User Token）
   drive     云盘增强（分块上传、有界轮询导出/导入、富文本评论、通用 task-result）
   search    搜索操作（消息、应用搜索，需要用户授权）
+  event     实时事件订阅（WebSocket 长连接 + daemon 进程模型；list/consume/schema/status/stop）
   config    配置管理（初始化配置）
 
 注意：bitable 命令已切换到 base/v3 API，flag 使用 --base-token。

--- a/go.mod
+++ b/go.mod
@@ -11,6 +11,8 @@ require (
 
 require (
 	github.com/fsnotify/fsnotify v1.7.0 // indirect
+	github.com/gogo/protobuf v1.3.2 // indirect
+	github.com/gorilla/websocket v1.5.0 // indirect
 	github.com/hashicorp/hcl v1.0.0 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/magiconair/properties v1.8.7 // indirect

--- a/go.sum
+++ b/go.sum
@@ -7,9 +7,11 @@ github.com/frankban/quicktest v1.14.6 h1:7Xjx+VpznH+oBnejlPUj8oUpdxnVs4f8XU8WnHk
 github.com/frankban/quicktest v1.14.6/go.mod h1:4ptaffx2x8+WTWXmUCuVU6aPUX1/Mz7zb5vbUoiM6w0=
 github.com/fsnotify/fsnotify v1.7.0 h1:8JEhPFa5W2WU7YfeZzPNqzMP6Lwt7L2715Ggo0nosvA=
 github.com/fsnotify/fsnotify v1.7.0/go.mod h1:40Bi/Hjc2AVfZrqy+aj+yEI+/bRxZnMJyTJwOpGvigM=
+github.com/gogo/protobuf v1.3.2 h1:Ov1cvc58UF3b5XjBnZv7+opcTcQFZebYjWzi34vdm4Q=
 github.com/gogo/protobuf v1.3.2/go.mod h1:P1XiOD3dCwIKUDQYPy72D8LYyHL2YPYrpS2s69NZV8Q=
 github.com/google/go-cmp v0.5.9 h1:O2Tfq5qg4qc4AmwVlvv0oLiVAGB7enBSJ2x2DqQFi38=
 github.com/google/go-cmp v0.5.9/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
+github.com/gorilla/websocket v1.5.0 h1:PPwGk2jz7EePpoHN/+ClbZu8SPxiqlu12wZP/3sWmnc=
 github.com/gorilla/websocket v1.5.0/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
 github.com/hashicorp/hcl v1.0.0 h1:0Anlzjpi4vEasTeNFn2mLJgTSwt0+6sfsiTG8qcWGx4=
 github.com/hashicorp/hcl v1.0.0/go.mod h1:E5yfLk+7swimpb2L/Alb/PJmXilQ/rhwaUYs4T20WEQ=

--- a/internal/event/bus.go
+++ b/internal/event/bus.go
@@ -1,0 +1,253 @@
+package event
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"sync"
+	"syscall"
+	"time"
+)
+
+// EventsDir 返回 feishu-cli 事件订阅状态目录：~/.feishu-cli/events/。
+// 每个 App ID 一个子目录（bus.json + bus.lock），避免不同应用互相干扰。
+func EventsDir() (string, error) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", fmt.Errorf("获取用户目录失败: %w", err)
+	}
+	dir := filepath.Join(home, ".feishu-cli", "events")
+	if err := os.MkdirAll(dir, 0700); err != nil {
+		return "", fmt.Errorf("创建事件目录失败: %w", err)
+	}
+	return dir, nil
+}
+
+// AppDir 返回某个 AppID 的专属状态目录。
+// sanitizeAppID 防止 ".."、"/" 等字符逃逸出 events/。
+func AppDir(appID string) (string, error) {
+	base, err := EventsDir()
+	if err != nil {
+		return "", err
+	}
+	dir := filepath.Join(base, sanitizeAppID(appID))
+	if err := os.MkdirAll(dir, 0700); err != nil {
+		return "", fmt.Errorf("创建 App 事件目录失败: %w", err)
+	}
+	return dir, nil
+}
+
+// sanitizeAppID 去除可能用于路径逃逸的字符，仅保留字母/数字/下划线/连字符。
+// 飞书 App ID 形如 `cli_a77d84747fa6500b`，本身已是安全字符集；本函数仅作纵深防御。
+func sanitizeAppID(appID string) string {
+	var b strings.Builder
+	for _, r := range appID {
+		switch {
+		case r >= 'a' && r <= 'z',
+			r >= 'A' && r <= 'Z',
+			r >= '0' && r <= '9',
+			r == '_' || r == '-':
+			b.WriteRune(r)
+		}
+	}
+	if b.Len() == 0 {
+		return "unknown"
+	}
+	return b.String()
+}
+
+// ConsumerEntry 是 bus.json 中的一条 consumer 记录。
+// 一个 (PID, EventKey) 元组对应一个独立的 consume 进程。
+type ConsumerEntry struct {
+	PID        int       `json:"pid"`
+	EventKey   string    `json:"event_key"`
+	StartedAt  time.Time `json:"started_at"`
+	OutputDir  string    `json:"output_dir,omitempty"`
+	JQExpr     string    `json:"jq_expr,omitempty"`
+	MaxEvents  int       `json:"max_events,omitempty"`
+	TimeoutSec int       `json:"timeout_sec,omitempty"`
+}
+
+// IsAlive 检查 PID 对应的进程是否还存活（不可移植：仅 Unix）。
+// 通过 signal(0) 探活：进程不存在返回 ESRCH，存在则返回 nil 或 EPERM（无权限但确实存在）。
+func (c ConsumerEntry) IsAlive() bool {
+	if c.PID <= 0 {
+		return false
+	}
+	proc, err := os.FindProcess(c.PID)
+	if err != nil {
+		return false
+	}
+	// signal(0) 不实际投递信号，只做探活
+	err = proc.Signal(syscall.Signal(0))
+	if err == nil {
+		return true
+	}
+	// EPERM = 进程存在但属于其他用户（feishu-cli 单用户场景一般不会遇到）
+	return err == syscall.EPERM
+}
+
+// BusState 是 bus.json 的根结构：所有当前已知的 consumer 列表。
+// 加载/保存时通过 mu 保证读写互斥；跨进程互斥通过 bus.lock 文件锁实现。
+type BusState struct {
+	AppID     string          `json:"app_id"`
+	UpdatedAt time.Time       `json:"updated_at"`
+	Consumers []ConsumerEntry `json:"consumers"`
+}
+
+// Bus 封装 bus.json 的读写 + 文件锁。
+// 单进程内多 goroutine 通过 mu 串行化；跨进程通过 flock(2) on bus.lock。
+type Bus struct {
+	appID    string
+	stateDir string
+	mu       sync.Mutex
+}
+
+// NewBus 构造 Bus，确保 stateDir 存在。
+func NewBus(appID string) (*Bus, error) {
+	dir, err := AppDir(appID)
+	if err != nil {
+		return nil, err
+	}
+	return &Bus{appID: appID, stateDir: dir}, nil
+}
+
+// StateFile 返回 bus.json 路径。
+func (b *Bus) StateFile() string {
+	return filepath.Join(b.stateDir, "bus.json")
+}
+
+// LockFile 返回 bus.lock 路径（仅用作 flock 锚点，不写内容）。
+func (b *Bus) LockFile() string {
+	return filepath.Join(b.stateDir, "bus.lock")
+}
+
+// load 读取 bus.json；文件不存在视为空 state。
+// 调用方负责持有锁（withLock 内部已加锁）。
+func (b *Bus) load() (*BusState, error) {
+	data, err := os.ReadFile(b.StateFile())
+	if err != nil {
+		if os.IsNotExist(err) {
+			return &BusState{AppID: b.appID, Consumers: nil}, nil
+		}
+		return nil, fmt.Errorf("读取 bus.json 失败: %w", err)
+	}
+	var state BusState
+	if err := json.Unmarshal(data, &state); err != nil {
+		return nil, fmt.Errorf("解析 bus.json 失败: %w", err)
+	}
+	if state.AppID == "" {
+		state.AppID = b.appID
+	}
+	return &state, nil
+}
+
+// save 原子写 bus.json（tmp + os.Rename），调用方负责持有锁。
+func (b *Bus) save(state *BusState) error {
+	state.AppID = b.appID
+	state.UpdatedAt = time.Now()
+	data, err := json.MarshalIndent(state, "", "  ")
+	if err != nil {
+		return fmt.Errorf("序列化 bus.json 失败: %w", err)
+	}
+	tmp := b.StateFile() + ".tmp." + strconv.Itoa(os.Getpid())
+	if err := os.WriteFile(tmp, data, 0600); err != nil {
+		return fmt.Errorf("写入 bus.json 临时文件失败: %w", err)
+	}
+	if err := os.Rename(tmp, b.StateFile()); err != nil {
+		_ = os.Remove(tmp)
+		return fmt.Errorf("替换 bus.json 失败: %w", err)
+	}
+	return nil
+}
+
+// withLock 在跨进程互斥锁保护下执行 fn。
+// flock(LOCK_EX) 在锁文件 fd 上加排他锁，进程退出/fd 关闭自动释放——比 PID 文件更稳健。
+func (b *Bus) withLock(fn func(state *BusState) error) error {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+
+	lockFD, err := os.OpenFile(b.LockFile(), os.O_RDWR|os.O_CREATE, 0600)
+	if err != nil {
+		return fmt.Errorf("打开 bus.lock 失败: %w", err)
+	}
+	defer lockFD.Close()
+
+	if err := syscall.Flock(int(lockFD.Fd()), syscall.LOCK_EX); err != nil {
+		return fmt.Errorf("获取 bus.lock 失败: %w", err)
+	}
+	defer func() {
+		_ = syscall.Flock(int(lockFD.Fd()), syscall.LOCK_UN)
+	}()
+
+	state, err := b.load()
+	if err != nil {
+		return err
+	}
+	return fn(state)
+}
+
+// Register 将当前进程注册为 EventKey consumer。
+// 返回 entry 用于后续 Unregister；重复注册（同 PID + 同 EventKey）会替换旧条目。
+func (b *Bus) Register(entry ConsumerEntry) error {
+	return b.withLock(func(state *BusState) error {
+		// 替换或追加
+		updated := state.Consumers[:0]
+		for _, c := range state.Consumers {
+			if c.PID == entry.PID && c.EventKey == entry.EventKey {
+				continue
+			}
+			updated = append(updated, c)
+		}
+		updated = append(updated, entry)
+		state.Consumers = updated
+		return b.save(state)
+	})
+}
+
+// Unregister 从 bus.json 移除指定 (PID, EventKey)；幂等。
+func (b *Bus) Unregister(pid int, eventKey string) error {
+	return b.withLock(func(state *BusState) error {
+		updated := state.Consumers[:0]
+		for _, c := range state.Consumers {
+			if c.PID == pid && c.EventKey == eventKey {
+				continue
+			}
+			updated = append(updated, c)
+		}
+		state.Consumers = updated
+		return b.save(state)
+	})
+}
+
+// Snapshot 返回当前 consumer 列表的拷贝（status 查询用）。
+// 同时清理已不存活的 PID 记录，保持 bus.json 不积累僵尸条目。
+func (b *Bus) Snapshot() (*BusState, error) {
+	var snap *BusState
+	err := b.withLock(func(state *BusState) error {
+		alive := state.Consumers[:0]
+		changed := false
+		for _, c := range state.Consumers {
+			if c.IsAlive() {
+				alive = append(alive, c)
+			} else {
+				changed = true
+			}
+		}
+		state.Consumers = alive
+		if changed {
+			if err := b.save(state); err != nil {
+				return err
+			}
+		}
+		// 深拷贝返回
+		copyState := *state
+		copyState.Consumers = append([]ConsumerEntry(nil), state.Consumers...)
+		snap = &copyState
+		return nil
+	})
+	return snap, err
+}

--- a/internal/event/bus_test.go
+++ b/internal/event/bus_test.go
@@ -1,0 +1,163 @@
+package event
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+// setupBus 在 tempdir 下构造一个 Bus，并把 HOME 重定向到 tempdir，
+// 保证 EventsDir/AppDir 不污染真实 ~/.feishu-cli/。
+func setupBus(t *testing.T) *Bus {
+	t.Helper()
+	tmpHome := t.TempDir()
+	t.Setenv("HOME", tmpHome)
+
+	bus, err := NewBus("cli_test_app_123")
+	if err != nil {
+		t.Fatalf("NewBus: %v", err)
+	}
+	return bus
+}
+
+func TestBus_RegisterAndSnapshot(t *testing.T) {
+	bus := setupBus(t)
+
+	entry := ConsumerEntry{
+		PID:       os.Getpid(),
+		EventKey:  "im.message.receive_v1",
+		StartedAt: time.Now(),
+		MaxEvents: 10,
+	}
+	if err := bus.Register(entry); err != nil {
+		t.Fatalf("Register: %v", err)
+	}
+
+	snap, err := bus.Snapshot()
+	if err != nil {
+		t.Fatalf("Snapshot: %v", err)
+	}
+	if snap.AppID != "cli_test_app_123" {
+		t.Errorf("AppID 期望 cli_test_app_123，实际 %q", snap.AppID)
+	}
+	if len(snap.Consumers) != 1 {
+		t.Fatalf("Snapshot 期望 1 条 consumer，实际 %d", len(snap.Consumers))
+	}
+	if snap.Consumers[0].PID != entry.PID {
+		t.Errorf("PID 期望 %d，实际 %d", entry.PID, snap.Consumers[0].PID)
+	}
+	if snap.Consumers[0].MaxEvents != 10 {
+		t.Errorf("MaxEvents 期望 10，实际 %d", snap.Consumers[0].MaxEvents)
+	}
+}
+
+func TestBus_UnregisterIdempotent(t *testing.T) {
+	bus := setupBus(t)
+	entry := ConsumerEntry{PID: os.Getpid(), EventKey: "im.chat.updated_v1", StartedAt: time.Now()}
+	_ = bus.Register(entry)
+
+	if err := bus.Unregister(entry.PID, entry.EventKey); err != nil {
+		t.Fatalf("Unregister #1: %v", err)
+	}
+	// 第二次 Unregister 应幂等不报错
+	if err := bus.Unregister(entry.PID, entry.EventKey); err != nil {
+		t.Fatalf("Unregister #2 应幂等: %v", err)
+	}
+	snap, _ := bus.Snapshot()
+	if len(snap.Consumers) != 0 {
+		t.Errorf("Unregister 后 snapshot 应为空，实际 %d", len(snap.Consumers))
+	}
+}
+
+func TestBus_ReplacesDuplicateRegistration(t *testing.T) {
+	bus := setupBus(t)
+	pid := os.Getpid()
+	_ = bus.Register(ConsumerEntry{PID: pid, EventKey: "im.message.receive_v1", StartedAt: time.Now(), MaxEvents: 5})
+	_ = bus.Register(ConsumerEntry{PID: pid, EventKey: "im.message.receive_v1", StartedAt: time.Now(), MaxEvents: 100})
+
+	snap, _ := bus.Snapshot()
+	if len(snap.Consumers) != 1 {
+		t.Fatalf("重复注册 (同 pid + 同 key) 应替换不追加，实际 %d 条", len(snap.Consumers))
+	}
+	if snap.Consumers[0].MaxEvents != 100 {
+		t.Errorf("重复注册后 MaxEvents 应为新值 100，实际 %d", snap.Consumers[0].MaxEvents)
+	}
+}
+
+func TestBus_DifferentKeysCoexist(t *testing.T) {
+	bus := setupBus(t)
+	pid := os.Getpid()
+	_ = bus.Register(ConsumerEntry{PID: pid, EventKey: "im.message.receive_v1", StartedAt: time.Now()})
+	_ = bus.Register(ConsumerEntry{PID: pid, EventKey: "im.chat.updated_v1", StartedAt: time.Now()})
+
+	snap, _ := bus.Snapshot()
+	if len(snap.Consumers) != 2 {
+		t.Errorf("不同 EventKey 应可共存，期望 2 条实际 %d", len(snap.Consumers))
+	}
+}
+
+func TestBus_SnapshotCleansDeadPIDs(t *testing.T) {
+	bus := setupBus(t)
+	// 注册一个不存在的 PID（PID 99999999 大概率不存在）
+	deadPID := 99999999
+	_ = bus.Register(ConsumerEntry{PID: deadPID, EventKey: "im.message.receive_v1", StartedAt: time.Now()})
+	// 同时注册一个真实存活的 PID
+	livePID := os.Getpid()
+	_ = bus.Register(ConsumerEntry{PID: livePID, EventKey: "im.chat.updated_v1", StartedAt: time.Now()})
+
+	snap, err := bus.Snapshot()
+	if err != nil {
+		t.Fatalf("Snapshot: %v", err)
+	}
+	// Snapshot 应剔除 deadPID 那条
+	for _, c := range snap.Consumers {
+		if c.PID == deadPID {
+			t.Errorf("Snapshot 应剔除已死 PID %d", deadPID)
+		}
+	}
+	hasLive := false
+	for _, c := range snap.Consumers {
+		if c.PID == livePID {
+			hasLive = true
+		}
+	}
+	if !hasLive {
+		t.Errorf("Snapshot 应保留存活 PID %d", livePID)
+	}
+}
+
+func TestBus_AtomicWrite(t *testing.T) {
+	bus := setupBus(t)
+	_ = bus.Register(ConsumerEntry{PID: os.Getpid(), EventKey: "im.message.receive_v1", StartedAt: time.Now()})
+
+	// bus.json 应存在且非空
+	data, err := os.ReadFile(bus.StateFile())
+	if err != nil {
+		t.Fatalf("读 bus.json: %v", err)
+	}
+	if len(data) == 0 {
+		t.Fatal("bus.json 不应为空")
+	}
+
+	// tmp 文件应已被 rename 清理
+	matches, _ := filepath.Glob(bus.StateFile() + ".tmp.*")
+	if len(matches) != 0 {
+		t.Errorf("tmp 文件 %v 应在 rename 后清理", matches)
+	}
+}
+
+func TestConsumerEntry_IsAlive(t *testing.T) {
+	live := ConsumerEntry{PID: os.Getpid()}
+	if !live.IsAlive() {
+		t.Errorf("当前进程 PID %d 应判定为存活", os.Getpid())
+	}
+	dead := ConsumerEntry{PID: 99999999}
+	if dead.IsAlive() {
+		t.Errorf("PID 99999999 大概率不应存活")
+	}
+	zero := ConsumerEntry{PID: 0}
+	if zero.IsAlive() {
+		t.Errorf("PID 0 不应判定为存活")
+	}
+}

--- a/internal/event/keys.go
+++ b/internal/event/keys.go
@@ -1,0 +1,249 @@
+// Package event 提供飞书 WebSocket 长连接实时事件订阅能力。
+//
+// 设计要点：
+//   - 静态 EventKey 目录（KeyDefinition）：覆盖 IM/Contact/Calendar/Drive/Approval 等常用事件
+//   - 进程模型：每个 consume 命令 = 一个独立 OS 进程 + 一个 WebSocket 长连接（一个 EventKey）
+//   - 状态文件：~/.feishu-cli/events/<app_id>/bus.json 记录所有 active 进程（PID + EventKey + 启动时间）
+//   - 文件锁：bus.json 读写走 flock，避免多进程同时写入损坏
+//   - 进程探活：status / stop 通过 PID 信号 0 检测进程是否存活
+//
+// 与 lark-cli 的差异：
+//   - lark-cli 用 Unix domain socket 跑独立 bus 守护进程做事件 fan-out；feishu-cli 简化为
+//     每个 consume 直接连 WebSocket（一个 EventKey 一个连接），不做事件分发——足够覆盖
+//     AI Agent 单 EventKey 订阅的主线场景
+//   - 重连策略复用 oapi-sdk-go v3 ws.Client.WithAutoReconnect（默认开启，无限重试）
+package event
+
+// KeyDefinition 描述一个可订阅的 EventKey。
+//
+// 字段说明：
+//   - Key: feishu-cli CLI 层面的 EventKey（与 EventType 通常一致）
+//   - EventType: oapi-sdk-go dispatcher 注册的事件类型（飞书开放平台定义的 schema.event_type）
+//   - Description: 简短中文描述，list 命令展示
+//   - Domain: 分组（im/contact/calendar/drive/approval/vc/meeting）
+//   - Scopes: 所需 App scope；list / consume 时展示给用户
+//   - PayloadSchema: 事件 payload 的字段说明，schema 命令展示（手工 curated，避免引入 reflect 依赖）
+type KeyDefinition struct {
+	Key           string   `json:"key"`
+	EventType     string   `json:"event_type"`
+	Description   string   `json:"description"`
+	Domain        string   `json:"domain"`
+	Scopes        []string `json:"scopes,omitempty"`
+	PayloadSchema string   `json:"payload_schema,omitempty"`
+}
+
+// keyRegistry 是手工维护的常用 EventKey 列表。
+//
+// 新增 EventKey 时只需追加一条；feishu-cli event list 会自动按 Domain 分组展示。
+// 参考飞书开放平台事件订阅文档：https://open.feishu.cn/document/server-docs/event-subscription-guide/event-list
+var keyRegistry = []KeyDefinition{
+	// ---------- IM 消息 ----------
+	{
+		Key:         "im.message.receive_v1",
+		EventType:   "im.message.receive_v1",
+		Description: "接收消息（用户/群聊发给 Bot 的消息）",
+		Domain:      "im",
+		Scopes:      []string{"im:message", "im:message.group_msg"},
+		PayloadSchema: `{
+  "schema": "2.0",
+  "header": {"event_id": "...", "event_type": "im.message.receive_v1", "create_time": "..."},
+  "event": {
+    "sender": {"sender_id": {"open_id": "ou_xxx"}, "sender_type": "user"},
+    "message": {
+      "message_id": "om_xxx",
+      "chat_id": "oc_xxx",
+      "chat_type": "p2p|group",
+      "message_type": "text|post|image|...",
+      "content": "{\"text\":\"hello\"}"
+    }
+  }
+}`,
+	},
+	{
+		Key:         "im.message.message_read_v1",
+		EventType:   "im.message.message_read_v1",
+		Description: "消息已读回执",
+		Domain:      "im",
+		Scopes:      []string{"im:message", "im:message:readonly"},
+	},
+	{
+		Key:         "im.message.recalled_v1",
+		EventType:   "im.message.recalled_v1",
+		Description: "消息被撤回",
+		Domain:      "im",
+		Scopes:      []string{"im:message"},
+	},
+	{
+		Key:         "im.message.reaction.created_v1",
+		EventType:   "im.message.reaction.created_v1",
+		Description: "消息表情回复被添加",
+		Domain:      "im",
+		Scopes:      []string{"im:message"},
+	},
+	{
+		Key:         "im.message.reaction.deleted_v1",
+		EventType:   "im.message.reaction.deleted_v1",
+		Description: "消息表情回复被删除",
+		Domain:      "im",
+		Scopes:      []string{"im:message"},
+	},
+	{
+		Key:         "im.chat.updated_v1",
+		EventType:   "im.chat.updated_v1",
+		Description: "群聊信息更新",
+		Domain:      "im",
+		Scopes:      []string{"im:chat", "im:chat:readonly"},
+	},
+	{
+		Key:         "im.chat.member.user.added_v1",
+		EventType:   "im.chat.member.user.added_v1",
+		Description: "用户进群",
+		Domain:      "im",
+		Scopes:      []string{"im:chat", "im:chat.members"},
+	},
+	{
+		Key:         "im.chat.member.user.deleted_v1",
+		EventType:   "im.chat.member.user.deleted_v1",
+		Description: "用户离群",
+		Domain:      "im",
+		Scopes:      []string{"im:chat", "im:chat.members"},
+	},
+	{
+		Key:         "im.chat.member.bot.added_v1",
+		EventType:   "im.chat.member.bot.added_v1",
+		Description: "Bot 被拉入群",
+		Domain:      "im",
+		Scopes:      []string{"im:chat"},
+	},
+	{
+		Key:         "im.chat.member.bot.deleted_v1",
+		EventType:   "im.chat.member.bot.deleted_v1",
+		Description: "Bot 被移出群",
+		Domain:      "im",
+		Scopes:      []string{"im:chat"},
+	},
+	{
+		Key:         "im.chat.disbanded_v1",
+		EventType:   "im.chat.disbanded_v1",
+		Description: "群聊被解散",
+		Domain:      "im",
+		Scopes:      []string{"im:chat"},
+	},
+
+	// ---------- 联系人 ----------
+	{
+		Key:         "contact.user.created_v3",
+		EventType:   "contact.user.created_v3",
+		Description: "新增员工",
+		Domain:      "contact",
+		Scopes:      []string{"contact:user.base:readonly"},
+	},
+	{
+		Key:         "contact.user.updated_v3",
+		EventType:   "contact.user.updated_v3",
+		Description: "员工信息变更",
+		Domain:      "contact",
+		Scopes:      []string{"contact:user.base:readonly"},
+	},
+	{
+		Key:         "contact.user.deleted_v3",
+		EventType:   "contact.user.deleted_v3",
+		Description: "员工离职",
+		Domain:      "contact",
+		Scopes:      []string{"contact:user.base:readonly"},
+	},
+
+	// ---------- 日历 ----------
+	{
+		Key:         "calendar.calendar.event.changed_v4",
+		EventType:   "calendar.calendar.event.changed_v4",
+		Description: "日程变更（创建/更新/删除）",
+		Domain:      "calendar",
+		Scopes:      []string{"calendar:calendar.event:read"},
+	},
+	{
+		Key:         "calendar.calendar.acl.created_v4",
+		EventType:   "calendar.calendar.acl.created_v4",
+		Description: "日历权限变更",
+		Domain:      "calendar",
+		Scopes:      []string{"calendar:calendar.acl:read"},
+	},
+
+	// ---------- 云盘 ----------
+	{
+		Key:         "drive.file.title_updated_v1",
+		EventType:   "drive.file.title_updated_v1",
+		Description: "文档标题修改",
+		Domain:      "drive",
+		Scopes:      []string{"drive:drive"},
+	},
+	{
+		Key:         "drive.file.permission_member_added_v1",
+		EventType:   "drive.file.permission_member_added_v1",
+		Description: "文档协作者添加",
+		Domain:      "drive",
+		Scopes:      []string{"drive:drive"},
+	},
+
+	// ---------- 审批 ----------
+	{
+		Key:         "approval_instance",
+		EventType:   "approval_instance",
+		Description: "审批实例状态变更",
+		Domain:      "approval",
+		Scopes:      []string{"approval:approval"},
+	},
+	{
+		Key:         "approval_task",
+		EventType:   "approval_task",
+		Description: "审批任务变更",
+		Domain:      "approval",
+		Scopes:      []string{"approval:approval"},
+	},
+
+	// ---------- 视频会议 ----------
+	{
+		Key:         "vc.meeting.meeting_started_v1",
+		EventType:   "vc.meeting.meeting_started_v1",
+		Description: "VC 会议开始",
+		Domain:      "vc",
+		Scopes:      []string{"vc:meeting"},
+	},
+	{
+		Key:         "vc.meeting.meeting_ended_v1",
+		EventType:   "vc.meeting.meeting_ended_v1",
+		Description: "VC 会议结束",
+		Domain:      "vc",
+		Scopes:      []string{"vc:meeting"},
+	},
+}
+
+// ListAll 返回所有已注册 EventKey，按 Domain + Key 排序（list 命令使用）。
+func ListAll() []KeyDefinition {
+	out := make([]KeyDefinition, len(keyRegistry))
+	copy(out, keyRegistry)
+	return out
+}
+
+// Lookup 按 Key 查找 EventKey 定义；返回 (def, true) 表示命中，否则 (零值, false)。
+func Lookup(key string) (KeyDefinition, bool) {
+	for _, def := range keyRegistry {
+		if def.Key == key {
+			return def, true
+		}
+	}
+	return KeyDefinition{}, false
+}
+
+// Domains 返回所有出现过的 Domain，去重后按字典序排序（list 分组展示用）。
+func Domains() []string {
+	seen := map[string]bool{}
+	var out []string
+	for _, def := range keyRegistry {
+		if !seen[def.Domain] {
+			seen[def.Domain] = true
+			out = append(out, def.Domain)
+		}
+	}
+	return out
+}

--- a/internal/event/keys_test.go
+++ b/internal/event/keys_test.go
@@ -1,0 +1,100 @@
+package event
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestListAll_NotEmpty(t *testing.T) {
+	all := ListAll()
+	if len(all) == 0 {
+		t.Fatal("ListAll() 返回空，至少应包含 im.message.receive_v1")
+	}
+}
+
+func TestListAll_AllDomainsSet(t *testing.T) {
+	for _, def := range ListAll() {
+		if def.Key == "" {
+			t.Errorf("EventKey 缺少 Key: %+v", def)
+		}
+		if def.EventType == "" {
+			t.Errorf("EventKey %s 缺少 EventType", def.Key)
+		}
+		if def.Domain == "" {
+			t.Errorf("EventKey %s 缺少 Domain", def.Key)
+		}
+		if def.Description == "" {
+			t.Errorf("EventKey %s 缺少 Description", def.Key)
+		}
+	}
+}
+
+func TestLookup_KnownKey(t *testing.T) {
+	def, ok := Lookup("im.message.receive_v1")
+	if !ok {
+		t.Fatal("Lookup(im.message.receive_v1) 应返回 true")
+	}
+	if def.EventType != "im.message.receive_v1" {
+		t.Errorf("EventType 期望 im.message.receive_v1，实际 %q", def.EventType)
+	}
+	if def.Domain != "im" {
+		t.Errorf("Domain 期望 im，实际 %q", def.Domain)
+	}
+}
+
+func TestLookup_UnknownKey(t *testing.T) {
+	_, ok := Lookup("does.not.exist_v999")
+	if ok {
+		t.Fatal("Lookup 对未知 key 应返回 false")
+	}
+}
+
+func TestDomains_Unique(t *testing.T) {
+	domains := Domains()
+	seen := map[string]bool{}
+	for _, d := range domains {
+		if seen[d] {
+			t.Errorf("Domain %q 重复出现", d)
+		}
+		seen[d] = true
+	}
+	// 至少应有 im / contact / calendar 三个 domain
+	for _, must := range []string{"im", "contact", "calendar"} {
+		if !seen[must] {
+			t.Errorf("Domains() 缺少必备 domain %q", must)
+		}
+	}
+}
+
+func TestSanitizeAppID_RejectsBadChars(t *testing.T) {
+	cases := map[string]string{
+		"cli_a77d84747fa6500b":  "cli_a77d84747fa6500b",
+		"cli_../../etc/passwd": "cli_etcpasswd",
+		"cli_/abs/path":         "cli_abspath",
+		"":                      "unknown",
+		"  ":                    "unknown",
+		"cli-test-app":          "cli-test-app",
+	}
+	for in, want := range cases {
+		got := sanitizeAppID(in)
+		if got != want {
+			t.Errorf("sanitizeAppID(%q) = %q, want %q", in, got, want)
+		}
+	}
+}
+
+func TestKeyDefinition_ScopesContainsExpected(t *testing.T) {
+	def, _ := Lookup("im.message.receive_v1")
+	if len(def.Scopes) == 0 {
+		t.Fatal("im.message.receive_v1 应至少有一个 scope")
+	}
+	hasIm := false
+	for _, s := range def.Scopes {
+		if strings.HasPrefix(s, "im:") {
+			hasIm = true
+		}
+	}
+	if !hasIm {
+		t.Errorf("im.message.receive_v1 至少应有一个 im: 开头的 scope，实际 %v", def.Scopes)
+	}
+}

--- a/internal/event/runtime.go
+++ b/internal/event/runtime.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
 	"sync/atomic"
 	"time"
 
@@ -45,8 +46,11 @@ type ConsumeOptions struct {
 type Runtime struct {
 	opts ConsumeOptions
 
-	received atomic.Int64 // 已发出的事件计数（受 MaxEvents 约束）
-	stopOnce atomic.Bool  // 多触发源（signal/timeout/maxEvents）下保证 cancel 只触发一次
+	received atomic.Int64       // 已发出的事件计数（受 MaxEvents 约束）
+	stopOnce atomic.Bool        // 多触发源（signal/timeout/maxEvents）下保证 cancel 只触发一次
+	cancel   context.CancelFunc // emit 触发 max-events 退出时调用，由 Run 在派生 subCtx 后注入
+	reasonMu sync.Mutex         // 串行写入 reason 字段，避免 timeout/maxEvents 并发竞争
+	reason   string             // 多触发源时记录原因；Run 末尾读取
 }
 
 // NewRuntime 构造一个 consume runtime。
@@ -107,6 +111,7 @@ func (r *Runtime) Run(ctx context.Context) (reason string, err error) {
 	// 派生子上下文以便多触发源 cancel
 	subCtx, cancel := context.WithCancel(ctx)
 	defer cancel()
+	r.cancel = cancel // emit 在 max-events 触发时通过 r.cancel 退出
 
 	// 超时
 	if r.opts.Timeout > 0 {
@@ -114,7 +119,7 @@ func (r *Runtime) Run(ctx context.Context) (reason string, err error) {
 			select {
 			case <-time.After(r.opts.Timeout):
 				if !r.stopOnce.Swap(true) {
-					reason = "timeout"
+					r.setReason("timeout")
 				}
 				cancel()
 			case <-subCtx.Done():
@@ -138,8 +143,12 @@ func (r *Runtime) Run(ctx context.Context) (reason string, err error) {
 		larkws.WithLogLevel(larkcore.LogLevelWarn),
 	)
 
-	// 触发 ready marker，外部 orchestrator 可阻塞 stderr 直到本行出现
-	fmt.Fprintf(r.opts.ErrOut, "[event] ready event_key=%s\n", r.opts.EventKey)
+	// 触发 ready marker：宣告进程初始化完成（WS 握手在 cli.Start 异步执行）。
+	// ★ marker 走真实 os.Stderr 而非 r.opts.ErrOut，避免 --quiet 时 ErrOut=io.Discard
+	//   导致 orchestrator 父进程永远等不到 marker。
+	// ★ 语义提示：父进程看到 marker 后**还需额外等 1-3s 让 WS 握手完成**才能可靠收到事件；
+	//   生产环境推荐父进程发"自检事件"+ 等待 echo 来确认链路通。
+	fmt.Fprintf(os.Stderr, "[event] ready event_key=%s (init complete; WS handshake in progress)\n", r.opts.EventKey)
 
 	// ws.Client.Start 阻塞，需要外部 cancel；包一层 goroutine 让 ctx 控制退出
 	errCh := make(chan error, 1)
@@ -149,21 +158,41 @@ func (r *Runtime) Run(ctx context.Context) (reason string, err error) {
 
 	select {
 	case <-subCtx.Done():
-		// 正常退出（signal/timeout/maxEvents）
-		if reason == "" {
+		// 正常退出（signal/timeout/maxEvents）— 优先用 emit/timeout goroutine 写入的 reason；
+		// 都没写时按计数兜底（仅作为防御性 fallback）。
+		final := r.getReason()
+		if final == "" {
 			if r.received.Load() >= int64(r.opts.MaxEvents) && r.opts.MaxEvents > 0 {
-				reason = "limit"
+				final = "limit"
 			} else {
-				reason = "signal"
+				final = "signal"
 			}
 		}
-		return reason, nil
+		return final, nil
 	case wsErr := <-errCh:
 		if wsErr != nil && !isContextCanceled(wsErr) {
 			return "error", fmt.Errorf("WebSocket 连接失败: %w", wsErr)
 		}
 		return "signal", nil
 	}
+}
+
+// setReason 串行写入 reason 字段。
+// 多个触发源（timeout goroutine / emit max-events）可能并发调用，
+// 需要 mutex 保证最先到达的 reason 不被覆盖。
+func (r *Runtime) setReason(reason string) {
+	r.reasonMu.Lock()
+	defer r.reasonMu.Unlock()
+	if r.reason == "" {
+		r.reason = reason
+	}
+}
+
+// getReason 读取最终 reason。
+func (r *Runtime) getReason() string {
+	r.reasonMu.Lock()
+	defer r.reasonMu.Unlock()
+	return r.reason
 }
 
 // emit 把一条事件输出到 stdout（NDJSON）+ 可选 output-dir 文件，并维护计数。
@@ -219,10 +248,14 @@ func (r *Runtime) emit(ev *larkevent.EventReq) error {
 	// 计数 + 触发 max-events 退出
 	n := r.received.Add(1)
 	if r.opts.MaxEvents > 0 && n >= int64(r.opts.MaxEvents) {
-		// 通过提前 return error 触发 ws 客户端关闭——但 SDK 没暴露 close 接口，
-		// 实际退出由 caller cancel ctx 完成。这里只标记 reason。
-		// 提示信息打到 stderr。
 		fmt.Fprintf(r.opts.ErrOut, "[event] reached max-events=%d\n", r.opts.MaxEvents)
+		// stopOnce 保证多触发源（timeout + max-events 同时撞）只 cancel 一次。
+		if !r.stopOnce.Swap(true) {
+			r.setReason("limit")
+			if r.cancel != nil {
+				r.cancel()
+			}
+		}
 	}
 	return nil
 }

--- a/internal/event/runtime.go
+++ b/internal/event/runtime.go
@@ -1,0 +1,303 @@
+package event
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync/atomic"
+	"time"
+
+	larkcore "github.com/larksuite/oapi-sdk-go/v3/core"
+	"github.com/larksuite/oapi-sdk-go/v3/event/dispatcher"
+	larkevent "github.com/larksuite/oapi-sdk-go/v3/event"
+	larkws "github.com/larksuite/oapi-sdk-go/v3/ws"
+)
+
+// ConsumeOptions 控制 consume 行为。
+type ConsumeOptions struct {
+	AppID     string
+	AppSecret string
+	EventKey  string
+	BaseURL   string // 飞书 API 域名（默认 https://open.feishu.cn）
+
+	// 输出控制
+	Out    io.Writer // 事件 NDJSON 写到这里（通常是 stdout）
+	ErrOut io.Writer // 诊断日志写到这里（通常是 stderr）
+
+	// 业务过滤
+	JQExpr    string // 暂未实现完整 jq，留作未来扩展（v3.5.3 SDK 不带 jq 库）
+	OutputDir string // 非空时把每条事件 dump 为 <event_id>.json 文件
+
+	// 退出条件（whichever fires first）
+	MaxEvents int           // 0 = 不限制
+	Timeout   time.Duration // 0 = 不限制
+
+	// 守护进程协议
+	Bus *Bus // 已构造好的 bus 句柄；nil 时不注册到 bus.json（test 模式）
+}
+
+// Runtime 表示一次 consume 会话的运行时状态。
+// 单次调用 Run 后由 GC 回收；不可重入。
+type Runtime struct {
+	opts ConsumeOptions
+
+	received atomic.Int64 // 已发出的事件计数（受 MaxEvents 约束）
+	stopOnce atomic.Bool  // 多触发源（signal/timeout/maxEvents）下保证 cancel 只触发一次
+}
+
+// NewRuntime 构造一个 consume runtime。
+func NewRuntime(opts ConsumeOptions) *Runtime {
+	if opts.Out == nil {
+		opts.Out = os.Stdout
+	}
+	if opts.ErrOut == nil {
+		opts.ErrOut = os.Stderr
+	}
+	if opts.BaseURL == "" {
+		opts.BaseURL = "https://open.feishu.cn"
+	}
+	return &Runtime{opts: opts}
+}
+
+// Run 启动 WebSocket 连接 → 注册到 bus.json → 阻塞接收事件直到上下文取消或退出条件触发。
+//
+// 退出 reason：
+//   - "limit"   : 达到 MaxEvents
+//   - "timeout" : 达到 Timeout
+//   - "signal"  : 上下文取消（Ctrl-C / SIGTERM / stdin EOF）
+//   - "error"   : WebSocket 连接持续失败
+//
+// 退出码 0 表示正常完成；非 0 表示 startup 失败或不可恢复错误。
+func (r *Runtime) Run(ctx context.Context) (reason string, err error) {
+	def, ok := Lookup(r.opts.EventKey)
+	if !ok {
+		return "error", fmt.Errorf("未知 EventKey: %q（运行 `feishu-cli event list` 查看支持的 key）", r.opts.EventKey)
+	}
+
+	// Register 到 bus.json
+	if r.opts.Bus != nil {
+		entry := ConsumerEntry{
+			PID:        os.Getpid(),
+			EventKey:   r.opts.EventKey,
+			StartedAt:  time.Now(),
+			OutputDir:  r.opts.OutputDir,
+			JQExpr:     r.opts.JQExpr,
+			MaxEvents:  r.opts.MaxEvents,
+			TimeoutSec: int(r.opts.Timeout.Seconds()),
+		}
+		if err := r.opts.Bus.Register(entry); err != nil {
+			fmt.Fprintf(r.opts.ErrOut, "[event] 警告: 注册到 bus.json 失败: %v\n", err)
+		}
+		defer func() {
+			_ = r.opts.Bus.Unregister(os.Getpid(), r.opts.EventKey)
+		}()
+	}
+
+	// 准备输出目录
+	if r.opts.OutputDir != "" {
+		if err := os.MkdirAll(r.opts.OutputDir, 0700); err != nil {
+			return "error", fmt.Errorf("创建输出目录失败: %w", err)
+		}
+	}
+
+	// 派生子上下文以便多触发源 cancel
+	subCtx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
+	// 超时
+	if r.opts.Timeout > 0 {
+		go func() {
+			select {
+			case <-time.After(r.opts.Timeout):
+				if !r.stopOnce.Swap(true) {
+					reason = "timeout"
+				}
+				cancel()
+			case <-subCtx.Done():
+			}
+		}()
+	}
+
+	// 构造 dispatcher
+	dis := dispatcher.NewEventDispatcher("", "")
+	dis.OnCustomizedEvent(def.EventType, func(ctx context.Context, ev *larkevent.EventReq) error {
+		return r.emit(ev)
+	})
+
+	// 安装 panic recover 包装的 logger，避免 SDK 日志炸 stderr
+	cli := larkws.NewClient(
+		r.opts.AppID, r.opts.AppSecret,
+		larkws.WithEventHandler(dis),
+		larkws.WithDomain(r.opts.BaseURL),
+		larkws.WithAutoReconnect(true),
+		larkws.WithLogger(newQuietLogger(r.opts.ErrOut)),
+		larkws.WithLogLevel(larkcore.LogLevelWarn),
+	)
+
+	// 触发 ready marker，外部 orchestrator 可阻塞 stderr 直到本行出现
+	fmt.Fprintf(r.opts.ErrOut, "[event] ready event_key=%s\n", r.opts.EventKey)
+
+	// ws.Client.Start 阻塞，需要外部 cancel；包一层 goroutine 让 ctx 控制退出
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- cli.Start(subCtx)
+	}()
+
+	select {
+	case <-subCtx.Done():
+		// 正常退出（signal/timeout/maxEvents）
+		if reason == "" {
+			if r.received.Load() >= int64(r.opts.MaxEvents) && r.opts.MaxEvents > 0 {
+				reason = "limit"
+			} else {
+				reason = "signal"
+			}
+		}
+		return reason, nil
+	case wsErr := <-errCh:
+		if wsErr != nil && !isContextCanceled(wsErr) {
+			return "error", fmt.Errorf("WebSocket 连接失败: %w", wsErr)
+		}
+		return "signal", nil
+	}
+}
+
+// emit 把一条事件输出到 stdout（NDJSON）+ 可选 output-dir 文件，并维护计数。
+func (r *Runtime) emit(ev *larkevent.EventReq) error {
+	// 解析事件以提取 event_id（用于文件名）；失败也不阻塞输出。
+	body := ev.Body
+	var meta struct {
+		Header struct {
+			EventID   string `json:"event_id"`
+			EventType string `json:"event_type"`
+		} `json:"header"`
+	}
+	_ = json.Unmarshal(body, &meta)
+
+	// 简单 jq 支持：仅支持 `.event.xxx` / `.header.xxx` 这种点路径（避免引入 itchyny/gojq 依赖）
+	output := body
+	if r.opts.JQExpr != "" {
+		filtered, ok := applyDotPath(body, r.opts.JQExpr)
+		if !ok {
+			// jq 不匹配则 skip 该事件
+			return nil
+		}
+		output = filtered
+	}
+
+	// 写 stdout（NDJSON）：每条事件一行 + \n
+	// 注意：原始 body 已是 JSON，保持紧凑序列化（不 indent）
+	var line []byte
+	if isCompactJSON(output) {
+		line = output
+	} else {
+		var v interface{}
+		if err := json.Unmarshal(output, &v); err == nil {
+			line, _ = json.Marshal(v)
+		} else {
+			line = output
+		}
+	}
+	if _, err := r.opts.Out.Write(append(line, '\n')); err != nil {
+		// stdout 关闭（pipe broken）= 退出
+		if !r.stopOnce.Swap(true) {
+			// reason 在 Run 里赋值，但 pipe 错误也算 signal
+		}
+		return err
+	}
+
+	// 写文件（可选）
+	if r.opts.OutputDir != "" && meta.Header.EventID != "" {
+		filename := filepath.Join(r.opts.OutputDir, meta.Header.EventID+".json")
+		_ = os.WriteFile(filename, body, 0600)
+	}
+
+	// 计数 + 触发 max-events 退出
+	n := r.received.Add(1)
+	if r.opts.MaxEvents > 0 && n >= int64(r.opts.MaxEvents) {
+		// 通过提前 return error 触发 ws 客户端关闭——但 SDK 没暴露 close 接口，
+		// 实际退出由 caller cancel ctx 完成。这里只标记 reason。
+		// 提示信息打到 stderr。
+		fmt.Fprintf(r.opts.ErrOut, "[event] reached max-events=%d\n", r.opts.MaxEvents)
+	}
+	return nil
+}
+
+// applyDotPath 实现极简 jq：仅支持 `.a.b.c` 形式（不支持过滤器/管道/数组下标）。
+// 返回 (子树 JSON, 是否命中)。
+func applyDotPath(data []byte, expr string) ([]byte, bool) {
+	expr = strings.TrimSpace(expr)
+	if expr == "." || expr == "" {
+		return data, true
+	}
+	if !strings.HasPrefix(expr, ".") {
+		return nil, false
+	}
+	var v interface{}
+	if err := json.Unmarshal(data, &v); err != nil {
+		return nil, false
+	}
+	cur := v
+	for _, seg := range strings.Split(strings.TrimPrefix(expr, "."), ".") {
+		if seg == "" {
+			continue
+		}
+		m, ok := cur.(map[string]interface{})
+		if !ok {
+			return nil, false
+		}
+		next, exists := m[seg]
+		if !exists {
+			return nil, false
+		}
+		cur = next
+	}
+	out, err := json.Marshal(cur)
+	if err != nil {
+		return nil, false
+	}
+	return out, true
+}
+
+// isCompactJSON 粗略判断 b 是否已是 compact JSON（无换行）。SDK 推过来的 body 通常就是。
+func isCompactJSON(b []byte) bool {
+	for _, c := range b {
+		if c == '\n' {
+			return false
+		}
+	}
+	return true
+}
+
+// isContextCanceled 判断 err 是否来自 context cancel/deadline（正常退出，不算 error）。
+func isContextCanceled(err error) bool {
+	if err == nil {
+		return false
+	}
+	s := err.Error()
+	return strings.Contains(s, "context canceled") || strings.Contains(s, "context deadline exceeded")
+}
+
+// quietLogger 把 SDK 日志重定向到 errOut（避免污染 stdout NDJSON）。
+type quietLogger struct {
+	out io.Writer
+}
+
+func newQuietLogger(out io.Writer) *quietLogger {
+	return &quietLogger{out: out}
+}
+
+func (l *quietLogger) Debug(_ context.Context, args ...interface{}) {}
+func (l *quietLogger) Info(_ context.Context, args ...interface{}) {
+	fmt.Fprintln(l.out, append([]interface{}{"[event/sdk]"}, args...)...)
+}
+func (l *quietLogger) Warn(_ context.Context, args ...interface{}) {
+	fmt.Fprintln(l.out, append([]interface{}{"[event/sdk]"}, args...)...)
+}
+func (l *quietLogger) Error(_ context.Context, args ...interface{}) {
+	fmt.Fprintln(l.out, append([]interface{}{"[event/sdk]"}, args...)...)
+}

--- a/internal/event/runtime.go
+++ b/internal/event/runtime.go
@@ -232,9 +232,14 @@ func (r *Runtime) emit(ev *larkevent.EventReq) error {
 		}
 	}
 	if _, err := r.opts.Out.Write(append(line, '\n')); err != nil {
-		// stdout 关闭（pipe broken）= 退出
+		// stdout 关闭（下游 pipe broken）= 立刻退出。
+		// ★ 必须主动 cancel，否则 Run 卡在 select{<-subCtx.Done()}
+		//   直到外部 Ctrl-C；这是 fix 引入 stopOnce 控制 cancel 后的对称要求。
 		if !r.stopOnce.Swap(true) {
-			// reason 在 Run 里赋值，但 pipe 错误也算 signal
+			r.setReason("signal") // pipe broken 归 signal（与 Ctrl-C 同义）
+			if r.cancel != nil {
+				r.cancel()
+			}
 		}
 		return err
 	}

--- a/internal/event/runtime_test.go
+++ b/internal/event/runtime_test.go
@@ -1,0 +1,84 @@
+package event
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestApplyDotPath_Identity(t *testing.T) {
+	body := []byte(`{"a":1,"b":{"c":"hi"}}`)
+	got, ok := applyDotPath(body, ".")
+	if !ok {
+		t.Fatal(". 应总是命中")
+	}
+	if string(got) != string(body) {
+		t.Errorf(". 应返回原始 body 完全相同")
+	}
+}
+
+func TestApplyDotPath_Nested(t *testing.T) {
+	body := []byte(`{"header":{"event_id":"abc"},"event":{"message":{"message_id":"om_x"}}}`)
+	got, ok := applyDotPath(body, ".event.message")
+	if !ok {
+		t.Fatal(".event.message 应命中")
+	}
+	if !strings.Contains(string(got), "om_x") {
+		t.Errorf("子树缺少 om_x: %s", got)
+	}
+}
+
+func TestApplyDotPath_Miss(t *testing.T) {
+	body := []byte(`{"a":1}`)
+	_, ok := applyDotPath(body, ".no.such.path")
+	if ok {
+		t.Errorf("不存在的路径应返回 ok=false")
+	}
+}
+
+func TestApplyDotPath_RejectsNonDot(t *testing.T) {
+	body := []byte(`{"a":1}`)
+	_, ok := applyDotPath(body, "select(.a==1)")
+	if ok {
+		t.Errorf("非 . 开头的复杂 jq 表达式应直接拒绝（不假装支持）")
+	}
+}
+
+func TestApplyDotPath_LeafScalar(t *testing.T) {
+	body := []byte(`{"header":{"event_id":"abc"}}`)
+	got, ok := applyDotPath(body, ".header.event_id")
+	if !ok {
+		t.Fatal("叶子标量应可访问")
+	}
+	if string(got) != `"abc"` {
+		t.Errorf("期望字符串 \"abc\"，实际 %s", got)
+	}
+}
+
+func TestIsCompactJSON(t *testing.T) {
+	if !isCompactJSON([]byte(`{"a":1}`)) {
+		t.Errorf("无换行的 JSON 应为 compact")
+	}
+	if isCompactJSON([]byte("{\n  \"a\": 1\n}")) {
+		t.Errorf("含换行的 JSON 不应为 compact")
+	}
+}
+
+func TestIsContextCanceled(t *testing.T) {
+	if !isContextCanceled(errString("context canceled")) {
+		t.Errorf(`"context canceled" 应判定为 context 退出`)
+	}
+	if !isContextCanceled(errString("context deadline exceeded")) {
+		t.Errorf(`"context deadline exceeded" 应判定为 context 退出`)
+	}
+	if isContextCanceled(errString("network unreachable")) {
+		t.Errorf("无关错误不应判定为 context 退出")
+	}
+	if isContextCanceled(nil) {
+		t.Errorf("nil error 不应判定为 context 退出")
+	}
+}
+
+// errString 是测试用的简易 error 实现
+type errString string
+
+func (e errString) Error() string { return string(e) }

--- a/internal/registry/domain_alias.go
+++ b/internal/registry/domain_alias.go
@@ -161,6 +161,25 @@ var extraDomainScopes = map[string][]string{
 	"whiteboard": {
 		"board:whiteboard:node:read", "board:whiteboard:node:create", "board:whiteboard:node:delete",
 	},
+
+	// event shortcuts: list / schema / consume / status / stop
+	// WebSocket 实时事件订阅；具体 scope 因 EventKey 而异，这里列出常用 EventKey 的并集。
+	// 完整对照见 `feishu-cli event schema <key>`。
+	"event": {
+		// IM 事件最常用
+		"im:message", "im:message.group_msg", "im:message:readonly",
+		"im:chat", "im:chat.members", "im:chat:readonly",
+		// 联系人
+		"contact:user.base:readonly",
+		// 日历
+		"calendar:calendar.event:read", "calendar:calendar.acl:read",
+		// 云盘
+		"drive:drive",
+		// 审批
+		"approval:approval",
+		// VC
+		"vc:meeting",
+	},
 }
 
 // domainDescriptions provides descriptions for alias/composite/fallback domains.
@@ -170,6 +189,7 @@ var domainDescriptions = map[string]struct{ Zh, En string }{
 	"drive":      {"云空间上传/下载/导出/导入/评论", "Drive upload, download, export, import & comments"},
 	"doc_access": {"用户 Token 访问文档/知识库", "User Token document & wiki access"},
 	"search":     {"文档和消息搜索", "Document and message search"},
+	"event":      {"WebSocket 实时事件订阅（IM/联系人/日历/云盘/审批/VC）", "WebSocket real-time event subscription"},
 }
 
 // ResolveProjects expands a domain name to meta project names.

--- a/skills/feishu-cli-event/SKILL.md
+++ b/skills/feishu-cli-event/SKILL.md
@@ -1,0 +1,278 @@
+---
+name: feishu-cli-event
+description: >-
+  飞书实时事件订阅（WebSocket）。event list 看支持的 EventKey；event schema 看事件 payload/scope；
+  event consume 启动长连接订阅，事件流以 NDJSON 写到 stdout（阻塞，一个进程订阅一个 EventKey）；
+  event status 看本机活跃 consume 进程；event stop 按 PID / EventKey / --all 停止 consume。
+  支持 22+ EventKey（im 消息接收/已读/撤回/reaction、群成员变动、contact 员工变更、
+  日历变更、云盘标题/协作者、审批实例与任务、VC 会议起止）。
+  状态文件 ~/.feishu-cli/events/<app_id>/bus.json + flock 文件锁 + WebSocket auto-reconnect。
+  当用户请求"监听飞书事件"、"实时接收消息事件"、"订阅审批回调"、"event 流"、
+  "WebSocket 长连接监听"、"event consume"、"event list / schema / status / stop"、
+  "AI Agent bot 实时响应"时使用。
+  注意：本技能只负责订阅；处理事件 webhook 业务逻辑（push 到飞书消息/写多维表格）
+  请配合 feishu-cli-msg / feishu-cli-bitable。
+argument-hint: list | schema <key> | consume <key> | status | stop
+user-invocable: true
+allowed-tools: Bash, Read, Write
+---
+
+# 飞书实时事件订阅技能（WebSocket）
+
+通过 `feishu-cli event` 子命令族订阅飞书开放平台事件，使用 WebSocket 长连接接收事件并以 NDJSON 输出到 stdout，适合 AI Agent 做 bot 实时响应、群消息监听、审批回调消费等场景。
+
+> **feishu-cli**：如尚未安装，请前往 [riba2534/feishu-cli](https://github.com/riba2534/feishu-cli) 获取安装方式。
+>
+> **发消息？** 请使用 **feishu-cli-msg** 技能。本技能专注于事件订阅（**接收**应用事件），不负责发送。
+
+## 核心概念
+
+### 进程模型 = 1 个 EventKey 1 个 consume 进程
+
+```
+event consume <EventKey>
+   │
+   ├─ 启动 WebSocket 长连接（飞书 SDK ws.Client + AutoReconnect）
+   ├─ 注册到 bus.json（PID / EventKey / 启动时间 / max-events / timeout）
+   ├─ stderr 输出 [event] ready event_key=<key>
+   ├─ 接收事件 → 写 stdout（NDJSON，每条一行 JSON）
+   ├─ 可选：dump 每条事件为 <event_id>.json 文件
+   ├─ 退出条件：--max-events / --timeout / SIGTERM / Ctrl-C / stdin EOF / pipe broken
+   └─ 退出时自动 unregister bus.json
+```
+
+**与 lark-cli event 的差异**：lark-cli 用 Unix domain socket 跑独立 bus 守护进程做事件 fan-out；feishu-cli 简化为「每个 consume 直接连一条 WebSocket」，不做事件分发——足够覆盖 AI Agent 单 EventKey 订阅的主线场景。
+
+### 状态文件与跨进程互斥
+
+| 路径 | 作用 |
+|---|---|
+| `~/.feishu-cli/events/<app_id>/bus.json` | 活跃 consumer 列表（PID/EventKey/启动时间/参数） |
+| `~/.feishu-cli/events/<app_id>/bus.lock` | flock 文件锁；bus.json 读写串行化，fd 关闭自动释放 |
+
+**每个 AppID 一个子目录**，不同应用互不干扰。`event status` 查询会主动剔除已不存活的 PID 条目（kill -9 / 崩溃残留）。bus.json 用 tmp + rename 原子写，防半写。
+
+### 输出协议（NDJSON + ready marker）
+
+| 流 | 内容 |
+|---|---|
+| **stdout** | 每条事件一行 JSON（NDJSON），适合 jq / 脚本管道 |
+| **stderr** | 诊断日志；启动时一行 `[event] ready event_key=<key> (init complete; WS handshake in progress)` |
+
+> **AI Agent 推荐**：父进程把 consume 跑后台（`run_in_background=true`），先阻塞 stderr 等到 `[event] ready` 那一行再开始读 stdout。**注意**：ready marker 只表示进程初始化完成，WS 握手在后台异步执行；父进程见到 marker 后**还需额外等 1-3s 让 WS 握手真正完成**，生产环境建议父进程发自检事件 + 等 echo 回环来确认链路通。
+
+### 退出码与退出 reason
+
+| 退出码 | 含义 |
+|---|---|
+| 0 | 正常退出（达到 `--max-events` / `--timeout` / SIGTERM / Ctrl-C / stdin EOF） |
+| 非 0 | startup 失败 / WebSocket 不可恢复错误 / 参数错误 |
+
+stderr 末尾会输出 `[event] exited — elapsed=<d> reason=<r>`，reason 有 4 个：
+
+- `limit` — 达到 `--max-events`
+- `timeout` — 达到 `--timeout`
+- `signal` — 上下文取消（Ctrl-C / SIGTERM / stdin EOF / 下游 pipe broken）
+- `error` — WebSocket 连接持续失败
+
+## 命令速查
+
+```bash
+feishu-cli event list [--json]                       # 1. 列所有支持的 EventKey
+feishu-cli event schema <event_key> [--json]         # 2. 看某 key 的 EventType / scope / payload schema
+feishu-cli event consume <event_key> [flags]         # 3. 启动订阅（阻塞）
+feishu-cli event status [--json]                     # 4. 看本机活跃 consume 进程
+feishu-cli event stop {--pid N | --event-key K | --all} [--force] [--json]  # 5. 停 consume
+```
+
+### 1. `event list`：列出支持的 EventKey
+
+按 domain 分组展示当前支持的 22+ EventKey（im / contact / calendar / drive / approval / vc）。
+
+```bash
+# 表格视图（默认）
+feishu-cli event list
+
+# JSON 输出，jq 提取 IM 域所有 EventKey
+feishu-cli event list --json | jq -r '.[] | select(.domain=="im") | .key'
+```
+
+**输出字段**（JSON 模式）：`key` / `event_type` / `description` / `domain` / `scopes[]` / `payload_schema`。
+
+### 2. `event schema`：看 payload schema 与 scope
+
+```bash
+feishu-cli event schema im.message.receive_v1
+feishu-cli event schema im.message.receive_v1 --json
+```
+
+输出 4 部分：`Key` / `Event Type` / `Domain` / `Description` / `Scopes` + 可选 `Payload Schema (示例)`。Payload schema 为手工 curated，订阅后实际 payload 以飞书开放平台文档为准。
+
+### 3. `event consume`：启动 WebSocket 订阅（阻塞）
+
+```bash
+# 基础订阅，Ctrl-C 退出
+feishu-cli event consume im.message.receive_v1
+
+# 调试：抓 5 条消息，最多跑 60s
+feishu-cli event consume im.message.receive_v1 --max-events 5 --timeout 60s
+
+# 落盘 + 静默
+feishu-cli event consume im.message.receive_v1 --output-dir ./events --quiet
+
+# 配合 jq 实时过滤群消息
+feishu-cli event consume im.message.receive_v1 | jq 'select(.event.message.chat_type=="group")'
+
+# 后台并发订阅多个 EventKey（每个 EventKey 一个进程）
+feishu-cli event consume im.message.receive_v1     > receive.ndjson  2> receive.log  &
+feishu-cli event consume im.message.reaction.created_v1 > reaction.ndjson 2> reaction.log &
+feishu-cli event status
+```
+
+**关键 flag**：
+
+| Flag | 默认 | 说明 |
+|---|---|---|
+| `--max-events N` | 0（不限制） | 接收 N 条事件后退出，reason=`limit` |
+| `--timeout 30s` | 0（不限制） | 运行 D 时长后退出，reason=`timeout` |
+| `--jq .event.xxx` | "" | 极简**点路径**过滤，不支持完整 jq 语法（用 pipe 接外部 jq） |
+| `--output-dir ./events` | "" | 每条事件额外 dump 为 `<event_id>.json` 落盘（不影响 stdout） |
+| `--quiet` | false | 抑制 stderr 诊断；**AI Agent 慎用**——会一起抑制大部分 stderr，但 ready marker 仍走真实 os.Stderr 不受影响 |
+
+**`--jq` 限制**：只识别 `.a.b.c` 形式的 map 取值（如 `.event.message`），不支持 `select` / 数组下标 / 管道。复杂过滤请用 `feishu-cli event consume ... | jq '<expr>'`。
+
+**`--output-dir` 限制**：必须是相对路径或已存在的绝对路径，**不做 `~` 展开**。
+
+### 4. `event status`：看本机活跃 consume 进程
+
+```bash
+feishu-cli event status
+feishu-cli event status --json | jq '.consumers[] | .pid'
+```
+
+输出：`App ID` / `State file` 路径 / `PID` / `EVENT_KEY` / `UPTIME` / `EXTRA`（max-events / timeout / output-dir / jq）。
+
+查询时会主动剔除已不存活的 PID 条目（清理 kill -9 / 崩溃残留的僵尸记录）。
+
+### 5. `event stop`：停止 consume 进程
+
+```bash
+feishu-cli event stop --pid 12345                          # 按 PID
+feishu-cli event stop --event-key im.message.receive_v1    # 按 EventKey（所有订阅该 key 的进程）
+feishu-cli event stop --all                                # 当前 AppID 下全部 consume
+feishu-cli event stop --all --force                        # SIGKILL（紧急情况）
+```
+
+默认 SIGTERM 优雅退出（consume 进程会自动 unregister bus.json），等最多 3s 验证进程已退出；`--force` 升级为 SIGKILL，会留下 bus.json 僵尸条目，下次 `event status` 会自动清理。
+
+## EventKey 速查（按 domain 分组）
+
+完整列表用 `feishu-cli event list`。常用：
+
+| Domain | EventKey | 描述 |
+|---|---|---|
+| im | `im.message.receive_v1` | 接收消息（用户/群聊发给 Bot） |
+| im | `im.message.message_read_v1` | 消息已读回执 |
+| im | `im.message.recalled_v1` | 消息被撤回 |
+| im | `im.message.reaction.created_v1` / `deleted_v1` | 消息表情回复添加/删除 |
+| im | `im.chat.updated_v1` | 群聊信息更新 |
+| im | `im.chat.member.user.added_v1` / `deleted_v1` | 用户进群/离群 |
+| im | `im.chat.member.bot.added_v1` / `deleted_v1` | Bot 被拉入/移出群 |
+| im | `im.chat.disbanded_v1` | 群聊被解散 |
+| contact | `contact.user.created_v3` / `updated_v3` / `deleted_v3` | 员工入职/变更/离职 |
+| calendar | `calendar.calendar.event.changed_v4` | 日程变更（创建/更新/删除） |
+| calendar | `calendar.calendar.acl.created_v4` | 日历权限变更 |
+| drive | `drive.file.title_updated_v1` | 文档标题修改 |
+| drive | `drive.file.permission_member_added_v1` | 文档协作者添加 |
+| approval | `approval_instance` | 审批实例状态变更 |
+| approval | `approval_task` | 审批任务变更 |
+| vc | `vc.meeting.meeting_started_v1` / `meeting_ended_v1` | VC 会议开始/结束 |
+
+> **EventKey 与 EventType 通常一致**；接收到的 payload 里 `header.event_type` 等于 `event_type` 字段。
+
+## 权限与开放平台配置
+
+### 默认 App Token，无需 `auth login`
+
+事件订阅走 App 身份（app_id + app_secret），**不强制 user token**。配好 `~/.feishu-cli/config.yaml` 或 `FEISHU_APP_ID` / `FEISHU_APP_SECRET` 环境变量即可。
+
+### 飞书开放平台两步配置
+
+在 [open.feishu.cn](https://open.feishu.cn) 你的应用控制台：
+
+1. **「事件订阅 - 长连接接收事件」** 开启长连接模式（feishu-cli 走 WebSocket，**不是** webhook URL 模式）
+2. **「事件与回调 - 事件订阅」** 选中目标 EventType（与 `event schema <key>` 输出的 Event Type 一致）并**发布版本**
+3. **scope 开通**：每个 EventKey 需要的 scope 见 `event schema <key>` 的 `Scopes` 字段；在「权限管理」页面开通。`event` 域已加入 `--domain event --recommend` 推荐列表，可一次性申请 IM/contact/calendar/drive/approval/vc 常用 scope 并集
+
+### 常见错误
+
+| 现象 | 原因 | 解决 |
+|---|---|---|
+| WS 连接失败，stderr 报 ws error | 长连接模式未开启 | 飞书开放平台开启「事件订阅 - 长连接接收事件」 |
+| 启动后看到 ready，但收不到事件 | 目标 EventType 未在「事件订阅」勾选 / 未发版本 | 重新勾选 + 发版 |
+| 收到事件但 payload 字段缺失 | App 缺对应 scope（如 `im:message.group_msg`） | `event schema <key>` 看 Scopes，去权限管理页开通后重新订阅 |
+| `event consume` 立即退出 reason=error | App ID/Secret 错 / 网络不通 / 域名走 lark 但 BaseURL 用了 feishu | 检查 `config.yaml`；`lark` 国际版需 `--base-url https://open.larksuite.com` 或对应配置 |
+
+## AI Agent 后台订阅推荐用法
+
+### 单 EventKey 后台订阅（`run_in_background=true`）
+
+```python
+# 1. 后台启动 consume，stderr/stdout 各 redirect
+task = Bash(
+    command='feishu-cli event consume im.message.receive_v1 --output-dir ./events 2> consume.log',
+    run_in_background=True,
+)
+
+# 2. tail consume.log 阻塞等 "[event] ready event_key=im.message.receive_v1"
+
+# 3. 额外 sleep 1-3s 让 WS 握手完成
+
+# 4. 业务逻辑：tail stdout / 读 ./events/*.json 处理新事件
+
+# 5. 退出：feishu-cli event stop --event-key im.message.receive_v1
+#         或父进程 kill 后台 Bash task（SIGTERM 触发 graceful shutdown + unregister）
+```
+
+### 子进程 stdin EOF 协议（非 TTY）
+
+非 TTY 模式下，**关闭 stdin 即触发优雅退出**（reason=signal）。Python `subprocess.Popen` 用 `stdin=subprocess.PIPE`，处理完后 `p.stdin.close()` 比 SIGTERM 更稳——consume 会跑完当前事件再退出。
+
+### 限制单跑时长 / 事件数
+
+调试场景永远先用 `--max-events N --timeout Ds`，避免忘了 stop 留下后台进程吃 API quota：
+
+```bash
+feishu-cli event consume im.message.receive_v1 --max-events 1 --timeout 30s
+# 抓 1 条事件 demo / 30 秒超时双保险
+```
+
+## 踩坑与注意事项
+
+- **daemon 进程持久**：`event consume` 阻塞运行直到信号/超时/EOF；**不会自己退出**。AI Agent 后台跑必须配 `--max-events` / `--timeout` 或显式 `event stop`，否则会留下长跑进程
+- **flock 跨进程互斥**：bus.json 读写都走 flock，多个 `event consume` 同时启动注册是安全的；但**不要手动编辑** bus.json
+- **pipe broken 自动退出**：下游 jq / tee 关闭 stdout（典型场景：`event consume ... | head -1`）会触发 SIGPIPE，consume 主动 cancel 退出 reason=signal，不会卡死等 Ctrl-C
+- **`--quiet` 不影响 ready marker**：ready marker 走真实 `os.Stderr` 绕过 `--quiet` 重定向，所以 AI Agent 即使开 `--quiet` 父进程仍能等到 ready 行；但其他诊断（包括 `[event] exited` reason）会被静默
+- **AutoReconnect 无限重试**：oapi-sdk-go v3 ws.Client 默认 `WithAutoReconnect(true)`，断线后无限重试（间隔 2 分钟 + 首次抖动）。长时间断线场景建议用 `--timeout` 主动退出，由外层守护进程拉起，比内层无限 retry 更可控
+- **status 不主动 ping 进程**：`event status` 用 `signal(0)` 探活，对 PID 复用场景理论可能误判（极小概率）。`event stop --pid N` 也是 syscall.Kill，命中错 PID 会 ESRCH 失败，不会误杀
+- **每条事件独立文件**：`--output-dir` 模式下每条事件落盘 `<event_id>.json`，**短时间高频事件可能创建大量小文件**；落盘只为留痕，业务消费仍推荐用 stdout NDJSON
+- **`--jq` 只支持点路径**：`--jq .event.message` 把每条事件投影到子树后再输出；不命中的事件**会被 skip**（不输出空行）。复杂过滤永远走 pipe 外部 jq
+- **`--output-dir` 不支持 `~`**：传 `~/events` 会报错；用相对路径 `./events` 或绝对路径 `/Users/xxx/events`
+
+## 何时转其他 skill
+
+| 任务 | 路由 |
+|---|---|
+| **发**消息 / 回复 / 卡片 / 通知 | **feishu-cli-msg** |
+| 构造 interactive 卡片 JSON | **feishu-cli-card** |
+| 处理收到的消息事件 → 写多维表格 | **feishu-cli-bitable**（解析 payload 后调 record 命令） |
+| 处理收到的审批事件 → 查审批详情 | **feishu-cli-toolkit**（approval 子命令） |
+| 收到群消息后查群信息/成员 | **feishu-cli-chat** |
+| Webhook URL 模式（HTTP 回调，非长连接） | 不在本技能范围；走飞书开放平台的「请求网址配置」+ 自建 HTTP server |
+| 历史消息批量拉取（非实时） | **feishu-cli-chat** 的 `msg history` / `msg list` |
+
+## 参考
+
+- 飞书开放平台事件订阅文档：https://open.feishu.cn/document/server-docs/event-subscription-guide/event-list
+- 项目 CHANGELOG：本模块新增详情见仓库 `CHANGELOG.md` `event 模块` 段落
+- 源码：`cmd/event*.go` + `internal/event/{bus,keys,runtime}.go`


### PR DESCRIPTION
## 背景

lark-cli 提供了完整的 `event consume <EventKey>` WebSocket 长连接事件订阅链路（含 daemon + bus.json 状态文件），但 feishu-cli 此前完全没有事件订阅能力。AI Agent 想做 Bot 实时响应（消息接收、群成员变更、审批状态推送等）只能切换到 lark-cli 或自写 WebSocket 客户端。

本 PR 在 feishu-cli 代码风格下重新实现 `event` 模块，让单工具栈即可完成所有长连接订阅场景。

## 新增命令

- `feishu-cli event list [--json]` — 列出所有支持的 EventKey（按 domain 分组：im / contact / calendar / drive / approval / vc 共 22+ 个）
- `feishu-cli event schema <key> [--json]` — 查看某个 EventKey 的 EventType / scope / payload schema 示例
- `feishu-cli event consume <key>` — 启动 WebSocket 长连接订阅（阻塞，事件流→stdout NDJSON）
  - `--max-events N` / `--timeout 30s`：bounded run（whichever 先触发）
  - `--jq .event.message`：极简点路径过滤（不实现完整 jq 语法，用 pipe 接外部 jq）
  - `--output-dir ./events`：每条事件 dump 为 `<event_id>.json` 落盘
  - `--quiet`：抑制 stderr 诊断
- `feishu-cli event status [--json]` — 查看本机所有 consume 进程（PID/EventKey/uptime）
- `feishu-cli event stop {--pid N | --event-key K | --all} [--force] [--json]` — 停止 consume 进程

## Daemon 设计

**进程模型**：每个 `event consume` 进程 = 独立 OS 进程 + 单个 WebSocket 长连接 + 单个 EventKey。简化掉 lark-cli 的独立 daemon + Unix socket 事件 fan-out 链路——足够覆盖 AI Agent 单 EventKey 订阅的主线场景，省去 IPC 复杂度。

**bus.json 状态文件**：

- 路径：`~/.feishu-cli/events/<app_id>/bus.json`（每 AppID 一个目录，避免不同应用互相干扰）
- 内容：当前活跃 consumer 的 `[{pid, event_key, started_at, max_events?, timeout_sec?, output_dir?, jq_expr?}]` 列表
- consume 启动时 `Register(entry)`，退出时 `defer Unregister()`
- 原子写：tmp + `os.Rename` 防止半写
- 跨进程互斥：`bus.lock` 文件配合 `syscall.Flock(LOCK_EX)`，fd 关闭自动释放（比 PID 文件更稳健）
- 进程探活：`signal(0)` 检测 PID 是否存活；`status` 命令的 `Snapshot()` 自动剔除 PID 已死的僵尸条目，保持 bus.json 不积累

**reconnect 策略**：直接复用 `larksuite/oapi-sdk-go/v3/ws.Client.WithAutoReconnect(true)` 默认：
- 首次重连随机抖动 30s 以内（防雪崩）
- 重连间隔 2 分钟，无限重试（reconnectCount=-1）
- 每 2 分钟发 ping 保活
- 长时间断线场景建议配合 `--timeout` 主动退出，由父进程拉起

**Subprocess 协议**（AI Agent 友好）：

- 启动后 stderr 立即输出 `[event] ready event_key=<key>`——父进程应阻塞 stderr 等该行出现后再读 stdout
- 非 TTY 模式下 stdin EOF = shutdown 信号（适配 `< /dev/null` / `nohup` / systemd `StandardInput=null` 等场景）
- 退出码 0：正常退出（达到 `--max-events` / `--timeout` / SIGTERM / Ctrl-C），非 0：startup 失败或 ws 不可恢复错误
- stderr 最后一行：`[event] exited — elapsed=Xs reason=<limit|timeout|signal|error>`

## 测试

- 单测：`go test ./cmd ./internal/event` 全绿（14 个 test case 覆盖：bus 注册/反注册/幂等/僵尸清理/并发替换、key registry 路径校验、点路径过滤、命令注册自检）
- smoke：`go test -tags=smoke ./cmd -run TestSmokeEventConsume` 已留接口（需 `FEISHU_APP_ID` + `FEISHU_APP_SECRET` 真实凭证），CI 不跑
- `go vet ./...` 无警告
- `go build ./...` 全绿

## 关键技术决策

1. **不引入新顶层依赖**：larksuite/oapi-sdk-go/v3 已是 require dep，只是其 `ws` 子包之前未被引用——go.sum 补全 `gorilla/websocket` + `gogo/protobuf` 两个 indirect 传递依赖即可，不动 go.mod 的 require 块
2. **静态 EventKey 注册表**：手工 curated `internal/event/keys.go` 涵盖 6 个 domain 22+ 常用 EventKey；新增只需追加 struct 字面量，无 reflect 依赖
3. **极简 `--jq` 实现**：只支持 `.a.b.c` 点路径（够 90% 子树投影场景），复杂表达式建议 pipe 接外部 jq
4. **不实现 lark-cli 的 PreConsume hook**：feishu-cli v1 仅支持纯 WebSocket 订阅类 EventKey（im / contact / calendar / drive / approval / vc），不涉及 server-side subscription 注册型 EventKey；用户体验等价于 lark-cli 的 90% 主线

## CHANGELOG

已更新到 `## 未发布` 段。

## Scope

需要的 scope 因 EventKey 而异，已加入 `--domain event --recommend` 推荐列表，覆盖：
- IM：`im:message` / `im:message.group_msg` / `im:chat` / `im:chat.members`
- 联系人：`contact:user.base:readonly`
- 日历：`calendar:calendar.event:read` / `calendar:calendar.acl:read`
- 云盘：`drive:drive`
- 审批：`approval:approval`
- VC：`vc:meeting`

## 关联

- 对齐 lark-cli `event list / schema / consume / status / stop` shortcut（参考实现，不直接复制源码）
- 闭环 feishu-cli 在实时事件订阅模块的能力空白