### PR TITLE
feat(doctor): 新增健康检查命令（6 项检查 + pretty/JSON 输出）

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,33 @@
 
 ## 未发布
 
+### 新增 — `doctor` 命令（健康检查 / 配置 / 认证 / 网络 / 依赖一把验）
+
+新增 `feishu-cli doctor` 命令，对齐 lark-cli `doctor` 体验，跑一组本地诊断快速验证 CLI 状态。
+
+**6 项检查**：
+- `config_file` — app_id / app_secret 是否就位
+- `user_token` — token.json 状态（valid / needs_refresh / expired）
+- `endpoint_open` — `open.feishu.cn` HTTPS 可达性 + RTT
+- `endpoint_larksuite` — `open.larksuite.com` HTTPS 可达性 + RTT
+- `proxy` — HTTPS_PROXY 与 NO_PROXY 配置（缺飞书域 warn）
+- `dependencies` — Go 版本 + larksuite/oapi-sdk-go 版本
+
+**flag**：`--json` 机器可读输出 / `--offline` 跳过网络检查 / `--only user_token,proxy` 仅运行指定项。
+
+**退出码**：0 = 全 pass / 1 = 任一 fail。
+
+**使用示例**：
+
+```bash
+feishu-cli doctor                              # pretty 输出全检查
+feishu-cli doctor --json                       # JSON 输出（AI agent 自检友好）
+feishu-cli doctor --offline                    # 跳过网络
+feishu-cli doctor --only user_token,proxy      # 仅跑指定项
+```
+
+**代码影响范围**：新增 `cmd/doctor.go`（6 项检查 + pretty/JSON 输出）和 `cmd/doctor_test.go`（parseOnly / shouldRun / proxy / dependencies 单测）；不引入新依赖。
+
 ### 新增 — `comment reply add`：为已有评论添加回复
 
 新增命令 `feishu-cli comment reply add <file_token> <comment_id> --text "..."`，补齐评论回复

--- a/cmd/doctor.go
+++ b/cmd/doctor.go
@@ -1,0 +1,324 @@
+package cmd
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"os"
+	"runtime"
+	buildinfo "runtime/debug"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/riba2534/feishu-cli/internal/auth"
+	"github.com/riba2534/feishu-cli/internal/config"
+	"github.com/spf13/cobra"
+)
+
+// checkResult 表示一项诊断结果
+type checkResult struct {
+	Name    string `json:"name"`
+	Status  string `json:"status"` // pass / fail / warn / skip
+	Message string `json:"message"`
+	Hint    string `json:"hint,omitempty"`
+}
+
+func checkPass(name, msg string) checkResult {
+	return checkResult{Name: name, Status: "pass", Message: msg}
+}
+
+func checkFail(name, msg, hint string) checkResult {
+	return checkResult{Name: name, Status: "fail", Message: msg, Hint: hint}
+}
+
+func checkWarn(name, msg, hint string) checkResult {
+	return checkResult{Name: name, Status: "warn", Message: msg, Hint: hint}
+}
+
+func checkSkip(name, msg string) checkResult {
+	return checkResult{Name: name, Status: "skip", Message: msg}
+}
+
+var doctorJSON bool
+var doctorOffline bool
+var doctorOnly string
+
+var doctorCmd = &cobra.Command{
+	Use:   "doctor",
+	Short: "健康检查（配置 / 认证 / 网络 / 依赖一把验）",
+	Long: `feishu-cli doctor 跑一组本地诊断，验证 CLI 是否处于可用状态。
+
+检查项：
+  config_file          配置文件存在 + app_id/app_secret 非空
+  user_token           token.json 存在 + 未过期
+  endpoint_open        open.feishu.cn HTTPS 可达
+  endpoint_larksuite   open.larksuite.com HTTPS 可达
+  proxy                HTTP(S)_PROXY 与 NO_PROXY 配置合理
+  dependencies         Go 版本 / SDK 版本
+
+输出：
+  默认：pretty 表格
+  --json：机器可读 JSON
+
+退出码：
+  0 = 全部通过（或仅 warn）
+  1 = 至少一项 fail`,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		_ = config.Init(cfgFile) // 复用 root.go 的 cfgFile
+		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+		defer cancel()
+
+		only := parseOnly(doctorOnly)
+		var results []checkResult
+
+		// 1. config_file
+		if shouldRun("config_file", only) {
+			results = append(results, checkConfigFile())
+		}
+
+		// 2. user_token
+		if shouldRun("user_token", only) {
+			results = append(results, checkUserToken())
+		}
+
+		// 3 & 4. endpoints
+		if !doctorOffline {
+			if shouldRun("endpoint_open", only) || shouldRun("endpoint_larksuite", only) {
+				netChecks := checkEndpoints(ctx, only)
+				results = append(results, netChecks...)
+			}
+		} else {
+			if shouldRun("endpoint_open", only) {
+				results = append(results, checkSkip("endpoint_open", "已跳过 (--offline)"))
+			}
+			if shouldRun("endpoint_larksuite", only) {
+				results = append(results, checkSkip("endpoint_larksuite", "已跳过 (--offline)"))
+			}
+		}
+
+		// 5. proxy
+		if shouldRun("proxy", only) {
+			results = append(results, checkProxy())
+		}
+
+		// 6. dependencies
+		if shouldRun("dependencies", only) {
+			results = append(results, checkDependencies())
+		}
+
+		// 输出
+		if doctorJSON {
+			return outputJSON(results)
+		}
+		return outputPretty(results)
+	},
+}
+
+func init() {
+	doctorCmd.Flags().BoolVar(&doctorJSON, "json", false, "输出 JSON 格式（AI agent 自检友好）")
+	doctorCmd.Flags().BoolVar(&doctorOffline, "offline", false, "跳过网络检查")
+	doctorCmd.Flags().StringVar(&doctorOnly, "only", "", "仅运行指定检查（逗号分隔，如 user_token,endpoint_open）")
+	rootCmd.AddCommand(doctorCmd)
+}
+
+// parseOnly 解析 --only 参数；空字符串表示全部
+func parseOnly(s string) map[string]bool {
+	if strings.TrimSpace(s) == "" {
+		return nil
+	}
+	m := make(map[string]bool)
+	for _, name := range strings.Split(s, ",") {
+		m[strings.TrimSpace(name)] = true
+	}
+	return m
+}
+
+func shouldRun(name string, only map[string]bool) bool {
+	if only == nil {
+		return true
+	}
+	return only[name]
+}
+
+// ── 检查函数 ──
+
+func checkConfigFile() checkResult {
+	cfg := config.Get()
+	if cfg == nil || cfg.AppID == "" {
+		return checkFail("config_file", "未找到 app_id 配置",
+			"运行 feishu-cli config init 或设置 FEISHU_APP_ID 环境变量")
+	}
+	if cfg.AppSecret == "" {
+		return checkFail("config_file", "未找到 app_secret 配置",
+			"运行 feishu-cli config init 或设置 FEISHU_APP_SECRET")
+	}
+	return checkPass("config_file", fmt.Sprintf("app_id=%s baseURL=%s", auth.MaskToken(cfg.AppID), cfg.BaseURL))
+}
+
+func checkUserToken() checkResult {
+	token, err := auth.LoadToken()
+	if err != nil {
+		// 区分「文件损坏」和「文件不存在」——文件损坏要明确报错
+		return checkFail("user_token", "读取 token.json 失败: "+err.Error(),
+			"删除 ~/.feishu-cli/token.json 后重新 feishu-cli auth login")
+	}
+	if token == nil {
+		return checkWarn("user_token", "未登录用户 (token.json 不存在)",
+			"运行 feishu-cli auth login（仅 vc/minutes/mail/drive/search 等命令必需）")
+	}
+	status := token.TokenStatus()
+	switch status {
+	case "valid":
+		// 不暴露 token 本体，只给状态
+		return checkPass("user_token", "access_token 有效")
+	case "needs_refresh":
+		return checkPass("user_token", "access_token 过期但 refresh_token 有效（下次调用自动刷新）")
+	case "expired":
+		return checkFail("user_token", "access_token 与 refresh_token 均已过期",
+			"运行 feishu-cli auth login 重新授权")
+	default:
+		return checkWarn("user_token", "token 状态未知: "+status, "")
+	}
+}
+
+func checkEndpoints(ctx context.Context, only map[string]bool) []checkResult {
+	httpClient := &http.Client{Timeout: 10 * time.Second}
+	type probeTarget struct {
+		name string
+		url  string
+	}
+	targets := []probeTarget{
+		{"endpoint_open", "https://open.feishu.cn"},
+		{"endpoint_larksuite", "https://open.larksuite.com"},
+	}
+	var wg sync.WaitGroup
+	results := make([]checkResult, len(targets))
+	for i, t := range targets {
+		if !shouldRun(t.name, only) {
+			results[i] = checkSkip(t.name, "已跳过")
+			continue
+		}
+		wg.Add(1)
+		go func(i int, t probeTarget) {
+			defer wg.Done()
+			start := time.Now()
+			req, err := http.NewRequestWithContext(ctx, http.MethodHead, t.url, nil)
+			if err != nil {
+				results[i] = checkFail(t.name, err.Error(), "")
+				return
+			}
+			resp, err := httpClient.Do(req)
+			rtt := time.Since(start)
+			if err != nil {
+				results[i] = checkFail(t.name, fmt.Sprintf("%s 不可达: %v", t.url, err),
+					"检查网络 / 代理设置")
+				return
+			}
+			resp.Body.Close()
+			results[i] = checkPass(t.name, fmt.Sprintf("%s 可达 (RTT %dms, status %d)", t.url, rtt.Milliseconds(), resp.StatusCode))
+		}(i, t)
+	}
+	wg.Wait()
+	return results
+}
+
+func checkProxy() checkResult {
+	httpProxy := strings.TrimSpace(firstEnv("HTTPS_PROXY", "https_proxy", "HTTP_PROXY", "http_proxy"))
+	noProxy := firstEnv("NO_PROXY", "no_proxy")
+	if httpProxy == "" {
+		return checkPass("proxy", "未设置 HTTP(S)_PROXY")
+	}
+	feishuDomains := []string{".feishu.cn", ".larkoffice.com", ".larksuite.com"}
+	var missing []string
+	for _, d := range feishuDomains {
+		if !strings.Contains(noProxy, d) {
+			missing = append(missing, d)
+		}
+	}
+	msg := fmt.Sprintf("HTTPS_PROXY=%s", httpProxy)
+	if len(missing) > 0 {
+		return checkWarn("proxy", msg,
+			fmt.Sprintf("NO_PROXY 缺少飞书域：%v；建议加入 NO_PROXY 避免代理拦截内部域", missing))
+	}
+	return checkPass("proxy", msg+"，NO_PROXY 已包含飞书域")
+}
+
+func firstEnv(names ...string) string {
+	for _, n := range names {
+		if v := os.Getenv(n); v != "" {
+			return v
+		}
+	}
+	return ""
+}
+
+func checkDependencies() checkResult {
+	goVer := runtime.Version()
+	sdkVer := "unknown"
+	if info, ok := buildinfo.ReadBuildInfo(); ok {
+		for _, dep := range info.Deps {
+			if dep.Path == "github.com/larksuite/oapi-sdk-go/v3" {
+				sdkVer = dep.Version
+				break
+			}
+		}
+	}
+	return checkPass("dependencies", fmt.Sprintf("go=%s larksuite-sdk=%s", goVer, sdkVer))
+}
+
+// ── 输出 ──
+
+func outputJSON(results []checkResult) error {
+	allOK := true
+	for _, r := range results {
+		if r.Status == "fail" {
+			allOK = false
+		}
+	}
+	out := map[string]interface{}{
+		"ok":     allOK,
+		"checks": results,
+	}
+	enc := json.NewEncoder(os.Stdout)
+	enc.SetIndent("", "  ")
+	if err := enc.Encode(out); err != nil {
+		return err
+	}
+	if !allOK {
+		return fmt.Errorf("doctor: 有检查未通过")
+	}
+	return nil
+}
+
+func outputPretty(results []checkResult) error {
+	allOK := true
+	for _, r := range results {
+		var icon string
+		switch r.Status {
+		case "pass":
+			icon = "✓"
+		case "fail":
+			icon = "✗"
+			allOK = false
+		case "warn":
+			icon = "⚠️"
+		case "skip":
+			icon = "-"
+		default:
+			icon = "?"
+		}
+		fmt.Printf("%-22s %s  %s\n", r.Name, icon, r.Message)
+		if r.Hint != "" {
+			fmt.Printf("%-22s    💡 %s\n", "", r.Hint)
+		}
+	}
+	if !allOK {
+		fmt.Fprintln(os.Stderr, "\ndoctor: 有检查未通过，详见 fail 项的 hint")
+		return fmt.Errorf("doctor: 有检查未通过")
+	}
+	fmt.Println("\n全部通过 ✓")
+	return nil
+}
+

--- a/cmd/doctor_test.go
+++ b/cmd/doctor_test.go
@@ -1,0 +1,126 @@
+package cmd
+
+import (
+	"os"
+	"strings"
+	"testing"
+)
+
+func TestParseOnly(t *testing.T) {
+	tests := []struct {
+		input    string
+		expected []string
+		nilMap   bool
+	}{
+		{"", nil, true},
+		{"   ", nil, true},
+		{"user_token", []string{"user_token"}, false},
+		{"user_token,endpoint_open", []string{"user_token", "endpoint_open"}, false},
+		{" user_token , endpoint_open ", []string{"user_token", "endpoint_open"}, false},
+	}
+	for _, tc := range tests {
+		t.Run(tc.input, func(t *testing.T) {
+			got := parseOnly(tc.input)
+			if tc.nilMap {
+				if got != nil {
+					t.Errorf("parseOnly(%q) = %v, want nil", tc.input, got)
+				}
+				return
+			}
+			if len(got) != len(tc.expected) {
+				t.Errorf("parseOnly(%q) size = %d, want %d", tc.input, len(got), len(tc.expected))
+			}
+			for _, name := range tc.expected {
+				if !got[name] {
+					t.Errorf("parseOnly(%q) missing %q", tc.input, name)
+				}
+			}
+		})
+	}
+}
+
+func TestShouldRun(t *testing.T) {
+	if !shouldRun("user_token", nil) {
+		t.Error("shouldRun(_, nil) should always be true")
+	}
+	only := map[string]bool{"user_token": true}
+	if !shouldRun("user_token", only) {
+		t.Error("shouldRun in only should be true")
+	}
+	if shouldRun("endpoint_open", only) {
+		t.Error("shouldRun not in only should be false")
+	}
+}
+
+func TestCheckProxy_NoProxy(t *testing.T) {
+	// 清掉所有 proxy env
+	envs := []string{"HTTPS_PROXY", "https_proxy", "HTTP_PROXY", "http_proxy", "NO_PROXY", "no_proxy"}
+	saved := make(map[string]string)
+	for _, e := range envs {
+		saved[e] = os.Getenv(e)
+		os.Unsetenv(e)
+	}
+	defer func() {
+		for k, v := range saved {
+			if v != "" {
+				os.Setenv(k, v)
+			}
+		}
+	}()
+
+	r := checkProxy()
+	if r.Status != "pass" {
+		t.Errorf("无代理时应 pass, got %s: %s", r.Status, r.Message)
+	}
+}
+
+func TestCheckProxy_WithProxyMissingNoProxy(t *testing.T) {
+	t.Setenv("HTTPS_PROXY", "http://127.0.0.1:7890")
+	t.Setenv("NO_PROXY", "localhost,127.0.0.1")
+
+	r := checkProxy()
+	if r.Status != "warn" {
+		t.Errorf("有代理但 NO_PROXY 缺飞书域应 warn, got %s: %s", r.Status, r.Message)
+	}
+	if !strings.Contains(r.Hint, "feishu.cn") {
+		t.Errorf("hint 应提到 feishu.cn, got: %s", r.Hint)
+	}
+}
+
+func TestCheckProxy_WithProxyAndCorrectNoProxy(t *testing.T) {
+	t.Setenv("HTTPS_PROXY", "http://127.0.0.1:7890")
+	t.Setenv("NO_PROXY", "localhost,*.feishu.cn,*.larkoffice.com,*.larksuite.com")
+
+	r := checkProxy()
+	if r.Status != "pass" {
+		t.Errorf("NO_PROXY 包含飞书域应 pass, got %s: %s", r.Status, r.Message)
+	}
+}
+
+func TestCheckDependencies(t *testing.T) {
+	r := checkDependencies()
+	if r.Status != "pass" {
+		t.Errorf("dependencies 检查应总是 pass, got %s", r.Status)
+	}
+	if !strings.Contains(r.Message, "go=") {
+		t.Errorf("message 应含 go 版本, got: %s", r.Message)
+	}
+}
+
+func TestCheckResultHelpers(t *testing.T) {
+	if checkPass("x", "m").Status != "pass" {
+		t.Error("checkPass status mismatch")
+	}
+	if checkFail("x", "m", "h").Status != "fail" {
+		t.Error("checkFail status mismatch")
+	}
+	if checkFail("x", "m", "h").Hint != "h" {
+		t.Error("checkFail hint mismatch")
+	}
+	if checkWarn("x", "m", "h").Status != "warn" {
+		t.Error("checkWarn status mismatch")
+	}
+	if checkSkip("x", "m").Status != "skip" {
+		t.Error("checkSkip status mismatch")
+	}
+}

--- a/skills/feishu-cli-doctor/SKILL.md
+++ b/skills/feishu-cli-doctor/SKILL.md
@@ -1,0 +1,225 @@
+---
+name: feishu-cli-doctor
+description: >-
+  feishu-cli 环境健康检查。6 项检查：config 文件 / user_token 有效性 / endpoints 联通 /
+  proxy 设置 / 二进制依赖（go/git）/ 配置完整性。
+  支持 --offline（跳过网络检查）/--only <check>（只跑指定项）/--json（机器可读）。
+  当用户报"feishu-cli 不工作"、"配置出问题"、"突然连不上"、"诊断"、"健康检查"时使用。
+argument-hint: [--offline] [--json] [--only config,token,...]
+user-invocable: true
+allowed-tools: Bash, Read
+---
+
+# feishu-cli 健康检查（doctor）
+
+`feishu-cli doctor` 跑一组本地诊断，快速验证 CLI 是否处于可用状态。对齐 lark-cli 的 `doctor` 体验，适合在「突然连不上 / 报错莫名其妙 / 新机器初始化后想一把验」等场景使用。
+
+> **feishu-cli**：如尚未安装，请前往 [riba2534/feishu-cli](https://github.com/riba2534/feishu-cli) 获取安装方式。
+
+---
+
+## 何时使用
+
+| 场景 | 触发命令 |
+|------|----------|
+| 用户报「feishu-cli 不工作」「突然连不上」 | `feishu-cli doctor` |
+| 新机器/新容器初始化后一把验 | `feishu-cli doctor` |
+| AI Agent 自检环境是否就绪 | `feishu-cli doctor --json` |
+| CI/无外网环境验证本地配置 | `feishu-cli doctor --offline` |
+| 只想确认某一项（如 token） | `feishu-cli doctor --only user_token` |
+| 排查代理/NO_PROXY 配错 | `feishu-cli doctor --only proxy` |
+
+**不适用**：
+- 用户明确说「登录 / 授权 / 拿 token」→ 走 [`/feishu-cli-auth`](../feishu-cli-auth/SKILL.md)
+- 用户已经定位到 scope 问题（缺权限）→ 走 `feishu-cli auth check --scope "..."`
+- 报具体业务错误码（99991672/1069303 等）→ 各业务模块 skill
+
+---
+
+## 6 项检查
+
+| 检查名 | 验证内容 | 失败原因 | 修复建议 |
+|--------|----------|----------|----------|
+| `config_file` | `~/.feishu-cli/config.yaml` 或环境变量提供 `app_id` + `app_secret` | 未初始化 / 凭证缺失 | `feishu-cli config create-app --save` 或 `feishu-cli config init` |
+| `user_token` | `~/.feishu-cli/token.json` 存在 + access/refresh 状态 | 未登录 / 都过期 / 文件损坏 | `feishu-cli auth login`（搜索/邮件/妙记等命令必需） |
+| `endpoint_open` | `https://open.feishu.cn` HTTPS HEAD 可达 | 网络不通 / 代理拦截 / DNS 异常 | 检查网络 / 配 `HTTPS_PROXY` / 加 `NO_PROXY` |
+| `endpoint_larksuite` | `https://open.larksuite.com` HTTPS HEAD 可达 | 同上 | 同上 |
+| `proxy` | `HTTPS_PROXY` 配置时，`NO_PROXY` 是否包含飞书三域 | `NO_PROXY` 缺 `.feishu.cn` / `.larkoffice.com` / `.larksuite.com` | 把缺失的域加进 `NO_PROXY` 避免代理拦截 |
+| `dependencies` | Go runtime 版本 + `larksuite/oapi-sdk-go/v3` 版本 | 不会失败（信息展示） | — |
+
+**网络检查并发执行**，两个 endpoint 同时探测，超时 10s，整体上下文超时 30s。
+
+---
+
+## 命令速查
+
+### 默认 pretty 输出
+
+```bash
+feishu-cli doctor
+```
+
+输出示例：
+
+```
+config_file            ✓  app_id=cli_a7xx****xxx baseURL=https://open.feishu.cn
+user_token             ✓  access_token 有效
+endpoint_open          ✓  https://open.feishu.cn 可达 (RTT 142ms, status 200)
+endpoint_larksuite     ✓  https://open.larksuite.com 可达 (RTT 198ms, status 200)
+proxy                  ✓  未设置 HTTP(S)_PROXY
+dependencies           ✓  go=go1.22.3 larksuite-sdk=v3.5.3
+
+全部通过 ✓
+```
+
+任一项 fail 时，会在结尾 `stderr` 打印 `doctor: 有检查未通过，详见 fail 项的 hint`，并以 exit 1 退出。
+
+### JSON 输出（AI Agent 自检推荐）
+
+```bash
+feishu-cli doctor --json
+```
+
+输出：
+
+```json
+{
+  "ok": true,
+  "checks": [
+    {"name": "config_file", "status": "pass", "message": "app_id=cli_a7xx****xxx baseURL=https://open.feishu.cn"},
+    {"name": "user_token", "status": "pass", "message": "access_token 有效"},
+    {"name": "endpoint_open", "status": "pass", "message": "https://open.feishu.cn 可达 (RTT 142ms, status 200)"},
+    {"name": "endpoint_larksuite", "status": "pass", "message": "https://open.larksuite.com 可达 (RTT 198ms, status 200)"},
+    {"name": "proxy", "status": "pass", "message": "未设置 HTTP(S)_PROXY"},
+    {"name": "dependencies", "status": "pass", "message": "go=go1.22.3 larksuite-sdk=v3.5.3"}
+  ]
+}
+```
+
+**字段说明**：
+- 顶层 `ok`：`true` = 全部通过（含 warn/skip）；`false` = 至少一项 `fail`
+- 每项 `status`：`pass` / `fail` / `warn` / `skip`
+- `hint`：仅在 `fail` 或 `warn` 时出现，给出修复建议
+
+### 跳过网络检查（`--offline`）
+
+```bash
+feishu-cli doctor --offline
+```
+
+`endpoint_open` 与 `endpoint_larksuite` 显示为 `skip`，其余正常跑。适用：
+- CI 沙箱无外网
+- 离线环境调试本地配置
+- 只想快速验 token/proxy 不想等网络
+
+### 只跑指定项（`--only`）
+
+```bash
+# 只跑 user_token
+feishu-cli doctor --only user_token
+
+# 多项用逗号
+feishu-cli doctor --only user_token,proxy
+
+# 与 --json 组合
+feishu-cli doctor --only endpoint_open --json
+```
+
+**有效检查名**（与表格里 `检查名` 列严格对应）：`config_file` / `user_token` / `endpoint_open` / `endpoint_larksuite` / `proxy` / `dependencies`
+
+未在 `--only` 列出的检查不会执行（不会出现在结果里）。
+
+---
+
+## 输出状态语义
+
+| 状态 | 图标（pretty） | 含义 | 影响退出码 |
+|------|---------------|------|------------|
+| `pass` | `✓` | 通过 | 否 |
+| `warn` | `⚠️` | 不影响主流程但建议修复（典型：proxy 缺飞书域、token 未登录但仅可选命令需要） | 否 |
+| `fail` | `✗` | 阻断性失败 | 是（exit 1） |
+| `skip` | `-` | 跳过（典型：`--offline` / 不在 `--only` 列表里被排除项；当前未在 `--only` 列出的项不会出现，仅 endpoint 在 `--offline` 时显式 skip） | 否 |
+
+**退出码契约**：
+- `0` = 全部通过（含 warn/skip）
+- `1` = 至少一项 `fail`
+
+AI Agent 写脚本判定环境就绪时，**判 `ok` 字段或 exit code 即可**，无需逐项解析。
+
+---
+
+## 典型排错链路
+
+### 1. 用户报「feishu-cli 不工作」
+
+```bash
+feishu-cli doctor
+```
+
+按从上到下顺序看第一个 `✗` 项的 `hint`，照着做即可。常见首项失败：
+- `config_file ✗` → 没初始化 → `feishu-cli config create-app --save`
+- `user_token ✗` → 没登录或都过期 → `feishu-cli auth login`
+- `endpoint_open ✗` → 网络/代理问题 → 检查 `HTTPS_PROXY` 与 `NO_PROXY`
+
+### 2. 公司内网代理环境
+
+公司有强制代理时，常见症状是 `endpoint_*` 慢/失败 + `proxy ⚠️`。修复：
+
+```bash
+# 把飞书三域加进 NO_PROXY
+export NO_PROXY="$NO_PROXY,.feishu.cn,.larkoffice.com,.larksuite.com"
+
+# 再跑一遍
+feishu-cli doctor --only proxy,endpoint_open,endpoint_larksuite
+```
+
+### 3. CI 流水线自检
+
+```bash
+# 跳过网络，只验本地配置（写在 CI 启动步骤）
+feishu-cli doctor --offline --json | jq -e '.ok == true'
+```
+
+任一项 fail，exit 1 让 CI 直接挂掉，避免后续业务命令报莫名其妙的错。
+
+### 4. AI Agent 跑业务前预检
+
+```bash
+# 跑业务前先确认 token 有效 + 网络可达
+feishu-cli doctor --only user_token,endpoint_open --json
+```
+
+`ok=false` 时根据 `checks[].name` 路由到对应修复 skill：
+- `user_token` fail/warn → 走 [`/feishu-cli-auth`](../feishu-cli-auth/SKILL.md) 处理登录
+- `endpoint_*` fail → 提示用户检查网络
+
+---
+
+## 与其他 skill 的边界
+
+| 场景 | 用 `doctor` 还是别的？ |
+|------|------------------------|
+| 整体环境是否就绪 | `doctor` |
+| 单独验 token + scope | [`/feishu-cli-auth`](../feishu-cli-auth/SKILL.md) 的 `auth check --scope "..."`（精确到 scope 维度） |
+| 登录 / 拿 token | [`/feishu-cli-auth`](../feishu-cli-auth/SKILL.md) |
+| 业务命令报错（99991672/1069303 等） | 各业务模块 skill（msg/doc/drive/bitable 等） |
+| 新建飞书应用 | [`/feishu-cli-auth`](../feishu-cli-auth/SKILL.md) 的 `config create-app` |
+
+**doctor 的定位**：**一把验环境是否就绪**，不解决任何业务级问题。业务级问题应该已经在 doctor pass 的前提下排查。
+
+---
+
+## 实现细节（开发者参考）
+
+源文件 `cmd/doctor.go`：
+
+- `checkResult` struct 统一表达每项结果（name/status/message/hint）
+- 4 个 helper：`checkPass` / `checkFail` / `checkWarn` / `checkSkip`
+- `parseOnly` 解析 `--only` 字符串为 `map[string]bool`，空字符串返回 `nil`（表示全跑）
+- `shouldRun(name, only)`：`only == nil` 时永远 true；否则查 map
+- `checkEndpoints` 用 `sync.WaitGroup` 并发探测两个 endpoint，每个超时 10s
+- `outputJSON` / `outputPretty` 两个出口；fail 时返回 error 让 cobra exit 1
+
+单测 `cmd/doctor_test.go` 覆盖：`parseOnly` 5 case / `shouldRun` 边界 / `checkProxy` 三种 env 组合 / `checkDependencies` smoke。
+
+不引入新依赖，全部用标准库 + 已有 `internal/auth` + `internal/config`。


### PR DESCRIPTION
## 背景

补齐 lark-cli 的 `doctor` 体验：用户 / AI Agent 自检 CLI 是否处于可用状态（配置 / 认证 / 网络 / 依赖一把验），减少 maintainer issue。

## 新增命令

`feishu-cli doctor` —— 6 项检查 + pretty / JSON 输出：

- `config_file` — app_id / app_secret 是否就位
- `user_token` — token.json 状态（valid / needs_refresh / expired / 文件损坏分别报告）
- `endpoint_open` — `open.feishu.cn` HTTPS 可达性 + RTT
- `endpoint_larksuite` — `open.larksuite.com` HTTPS 可达性 + RTT
- `proxy` — `HTTPS_PROXY` 与 `NO_PROXY` 配置（缺飞书域 warn）
- `dependencies` — Go 版本 + larksuite/oapi-sdk-go 版本

flag：

- `--json` 输出 JSON（AI agent 自检友好）
- `--offline` 跳过网络检查
- `--only user_token,proxy` 仅运行指定项

退出码：0 = 全 pass，1 = 任一 fail。

## 使用示例

```bash
feishu-cli doctor                              # pretty 输出全检查
feishu-cli doctor --json                       # JSON 输出
feishu-cli doctor --offline                    # 跳过网络
feishu-cli doctor --only user_token,proxy      # 仅跑指定项
```

实测样例（offline）：

```
config_file            ✓  app_id=cli_a***00e baseURL=https://open.feishu.cn
user_token             ✓  access_token 有效
endpoint_open          -  已跳过 (--offline)
endpoint_larksuite     -  已跳过 (--offline)
proxy                  ✓  HTTPS_PROXY=http://127.0.0.1:7890，NO_PROXY 已包含飞书域
dependencies           ✓  go=go1.26.2 larksuite-sdk=v3.5.3

全部通过 ✓
```

## 测试

- 单测：`go test ./cmd -run "TestParseOnly|TestShouldRun|TestCheckProxy|TestCheckDep|TestCheckResultHelpers"` 全 ok
- 实跑 `feishu-cli doctor` 与 `feishu-cli doctor --json --offline` 验证两种输出 + 退出码

## 实现说明

- token 读取失败 vs 文件不存在分两种状态报告（fail vs warn），不混淆用户视角
- app_id 复用 `auth.MaskToken` 做脱敏，与项目内统一风格一致
- 检查项的 name 是 hardcode 字符串以保持 `--only` 参数稳定（公开 API 字符串）
- 网络探测并发跑（goroutine + sync.WaitGroup），10s 超时

## CHANGELOG

已更新到 `## 未发布` 段。

## 隐私

- 不打印 token 全文（masking 走 `auth.MaskToken`）
- 不打印 app_secret
- 默认探测公开 endpoint，没暴露内网域名