### PR TITLE
feat(attendance): 新增考勤模块（user-task / user-stats query）

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,44 @@
 
 ## 未发布
 
+### 新增 — `attendance` 考勤查询模块
+
+新增 `attendance` 顶层命令组（别名 `att`），覆盖飞书考勤 OpenAPI 两类查询：
+
+- `feishu-cli attendance user-task query` —— 按日期范围查询用户上下班打卡记录
+  （`POST /open-apis/attendance/v1/user_tasks/query`，单次最多 50 用户）
+- `feishu-cli attendance user-stats query` —— 查询日度 / 月度考勤统计
+  （`POST /open-apis/attendance/v1/user_stats_datas/query`，单次最多 200 用户，
+  起止跨度 ≤ 31 天）
+
+**特性**：
+
+- 日期参数同时接受 `YYYY-MM-DD` 与 `YYYYMMDD`，自动转换为 API 所需的 `yyyyMMdd` 整数
+- 输出双模：默认 `text` 人类可读（打卡时间 / 结果 / 加班标记 / 统计字段标题），
+  `-o json` 直出归一化结构体，便于 AI Agent 与脚本消费
+- 同时打印 `invalid_user_ids` / `unauthorized_user_ids`，提示无效或无权限用户
+- user-task ≤ 50、user-stats ≤ 200 用户数本地预校验，避免无谓远程请求
+- 全部命令强制 User Token（`requireUserToken`），与 mail / vc 等模块行为一致
+
+**权限要求**：`attendance:task:readonly`（User Token）。新增 `auth login --domain
+attendance --recommend` 一键申请。
+
+**使用示例**：
+
+```bash
+# 查询本人最近一周打卡
+feishu-cli attendance user-task query \
+    --employee-type open_id \
+    --user-ids ou_xxxxxxxxx \
+    --start 2026-05-01 --end 2026-05-18
+
+# 查询本月日度统计（JSON 输出）
+feishu-cli attendance user-stats query \
+    --employee-type open_id \
+    --user-ids ou_xxxxxxxxx --current-user-id ou_xxxxxxxxx \
+    --stats-type daily --start 2026-05-01 --end 2026-05-31 -o json
+```
+
 ### 新增 — `comment reply add`：为已有评论添加回复
 
 新增命令 `feishu-cli comment reply add <file_token> <comment_id> --text "..."`，补齐评论回复

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,10 +23,13 @@
   `-o json` 直出归一化结构体，便于 AI Agent 与脚本消费
 - 同时打印 `invalid_user_ids` / `unauthorized_user_ids`，提示无效或无权限用户
 - user-task ≤ 50、user-stats ≤ 200 用户数本地预校验，避免无谓远程请求
-- 全部命令强制 User Token（`requireUserToken`），与 mail / vc 等模块行为一致
+- user-stats 起止跨度 > 31 天本地预校验，避免触发 OpenAPI 报错
+- 全部命令走 tenant_access_token（即应用身份）：larksuite/oapi-sdk-go v3.5.3 中
+  `Attendance.UserTask.Query` / `Attendance.UserStatsData.Query` 的
+  `SupportedAccessTokenTypes` 仅含 `Tenant`，传入 user token 会被 SDK 拒绝
 
-**权限要求**：`attendance:task:readonly`（User Token）。新增 `auth login --domain
-attendance --recommend` 一键申请。
+**权限要求**：应用需在飞书开放平台「应用权限管理」页面获得
+`attendance:task:readonly` 权限（tenant 级），无需 `auth login`。
 
 **使用示例**：
 

--- a/cmd/attendance.go
+++ b/cmd/attendance.go
@@ -1,0 +1,53 @@
+package cmd
+
+import "github.com/spf13/cobra"
+
+var attendanceCmd = &cobra.Command{
+	Use:     "attendance",
+	Aliases: []string{"att"},
+	Short:   "考勤打卡操作命令",
+	Long: `考勤打卡操作命令，对接飞书考勤 OpenAPI。
+
+子命令:
+  user-task query    查询用户考勤打卡记录（user_tasks.query）
+  user-stats query   查询用户考勤统计数据（user_stats_datas.query）
+
+身份要求:
+  全部命令需要 User Access Token（先 ` + "`feishu-cli auth login`" + `）。
+
+Scope:
+  attendance:task:readonly  打卡 / 统计查询（推荐）
+  attendance:task           打卡读写
+
+授权时可使用:
+  feishu-cli auth login --domain attendance --recommend
+
+日期格式:
+  接受 YYYY-MM-DD 或 YYYYMMDD（飞书 API 内部统一用 yyyyMMdd 整数）。
+
+示例:
+  # 查询本人最近一周打卡
+  feishu-cli attendance user-task query \
+      --employee-type open_id \
+      --user-ids ou_xxxxxxxxx \
+      --start 2026-05-01 --end 2026-05-18
+
+  # 查询本月日度统计
+  feishu-cli attendance user-stats query \
+      --employee-type open_id \
+      --user-ids ou_xxxxxxxxx \
+      --current-user-id ou_xxxxxxxxx \
+      --stats-type daily --start 2026-05-01 --end 2026-05-18
+
+  # JSON 输出（适合 AI Agent 解析）
+  feishu-cli attendance user-task query --user-ids ou_xxx --start 2026-05-01 --end 2026-05-18 -o json
+
+注意:
+  - 考勤 API 涉及员工隐私，需企业管理员在飞书后台为应用开通 attendance:task* scope。
+  - user_ids 单次最多 50 个（user-task）/ 200 个（user-stats）。
+  - user-stats 起止日期跨度不超过 31 天。`,
+}
+
+func init() {
+	rootCmd.AddCommand(attendanceCmd)
+}

--- a/cmd/attendance.go
+++ b/cmd/attendance.go
@@ -13,14 +13,12 @@ var attendanceCmd = &cobra.Command{
   user-stats query   查询用户考勤统计数据（user_stats_datas.query）
 
 身份要求:
-  全部命令需要 User Access Token（先 ` + "`feishu-cli auth login`" + `）。
+  全部命令走 tenant_access_token（应用身份），无需 ` + "`auth login`" + `；
+  larksuite/oapi-sdk-go v3.5.3 中相关接口仅支持 Tenant token。
 
-Scope:
+Scope（在飞书开放平台「应用权限管理」页面授予应用）:
   attendance:task:readonly  打卡 / 统计查询（推荐）
   attendance:task           打卡读写
-
-授权时可使用:
-  feishu-cli auth login --domain attendance --recommend
 
 日期格式:
   接受 YYYY-MM-DD 或 YYYYMMDD（飞书 API 内部统一用 yyyyMMdd 整数）。

--- a/cmd/attendance_user_stats.go
+++ b/cmd/attendance_user_stats.go
@@ -1,0 +1,179 @@
+package cmd
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/riba2534/feishu-cli/internal/client"
+	"github.com/riba2534/feishu-cli/internal/config"
+	"github.com/spf13/cobra"
+)
+
+var attendanceUserStatsCmd = &cobra.Command{
+	Use:     "user-stats",
+	Aliases: []string{"user-stats-data", "stats"},
+	Short:   "考勤统计数据",
+	Long: `考勤统计数据相关命令（对应 OpenAPI 资源 user_stats_data）。
+
+子命令:
+  query  查询用户考勤统计数据（日度 / 月度）
+
+示例:
+  feishu-cli attendance user-stats query \
+      --employee-type open_id --user-ids ou_xxx --current-user-id ou_xxx \
+      --stats-type daily --start 2026-05-01 --end 2026-05-18`,
+}
+
+var attendanceUserStatsQueryCmd = &cobra.Command{
+	Use:   "query",
+	Short: "查询用户考勤统计数据",
+	Long: `查询日度或月度的考勤统计数据。
+
+对应 OpenAPI: POST /open-apis/attendance/v1/user_stats_datas/query
+权限要求（User Token）: attendance:task:readonly
+
+参数:
+  --employee-type      用户 ID 类型 employee_id|open_id|user_id|employee_no（默认 employee_id）
+  --stats-type         统计类型：daily（日度）/ month（月度），默认 daily
+  --user-ids           查询的用户 ID 列表，逗号分隔，最多 200 个（必填）
+  --current-user-id    发起请求的用户 ID（新系统用户必填，同【查询统计设置】的 user_id）
+  --start              起始日期（必填，YYYY-MM-DD 或 YYYYMMDD）
+  --end                结束日期（必填，YYYY-MM-DD 或 YYYYMMDD，跨度 ≤ 31 天）
+  --locale             语言：zh / en / ja
+  --need-history       是否返回历史数据（默认 false）
+  --current-group-only 仅展示当前考勤组（默认 false）
+  --user-access-token  用户访问令牌（默认从登录态读取）
+  --output, -o         输出格式：text（默认）/ json
+
+示例:
+  # 查本人 5 月日度统计
+  feishu-cli attendance user-stats query \
+      --employee-type open_id \
+      --user-ids ou_xxxxxxxx --current-user-id ou_xxxxxxxx \
+      --stats-type daily --start 2026-05-01 --end 2026-05-31
+
+  # 查月度统计 + JSON
+  feishu-cli attendance user-stats query \
+      --employee-type open_id --user-ids ou_xxx --current-user-id ou_xxx \
+      --stats-type month --start 2026-05-01 --end 2026-05-31 -o json`,
+	Args: cobra.NoArgs,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		if err := config.Validate(); err != nil {
+			return err
+		}
+
+		userAccessToken, err := requireUserToken(cmd, "attendance user-stats query")
+		if err != nil {
+			return err
+		}
+
+		employeeType, _ := cmd.Flags().GetString("employee-type")
+		statsType, _ := cmd.Flags().GetString("stats-type")
+		userIDsRaw, _ := cmd.Flags().GetString("user-ids")
+		currentUserID, _ := cmd.Flags().GetString("current-user-id")
+		startStr, _ := cmd.Flags().GetString("start")
+		endStr, _ := cmd.Flags().GetString("end")
+		locale, _ := cmd.Flags().GetString("locale")
+		needHistory, _ := cmd.Flags().GetBool("need-history")
+		currentGroupOnly, _ := cmd.Flags().GetBool("current-group-only")
+		output, _ := cmd.Flags().GetString("output")
+
+		if err := validateEnum(statsType, "stats-type", []string{"daily", "month"}); err != nil {
+			return err
+		}
+
+		userIDs := splitAndTrim(userIDsRaw)
+		if len(userIDs) == 0 {
+			return fmt.Errorf("--user-ids 不能为空")
+		}
+		if len(userIDs) > 200 {
+			return fmt.Errorf("--user-ids 单次最多 200 个，当前 %d 个", len(userIDs))
+		}
+
+		startDate, err := client.ParseAttendanceDate(startStr)
+		if err != nil {
+			return fmt.Errorf("--start: %w", err)
+		}
+		endDate, err := client.ParseAttendanceDate(endStr)
+		if err != nil {
+			return fmt.Errorf("--end: %w", err)
+		}
+		if startDate > endDate {
+			return fmt.Errorf("--start (%d) 不能晚于 --end (%d)", startDate, endDate)
+		}
+
+		result, err := client.QueryAttendanceUserStats(
+			employeeType,
+			statsType,
+			startDate,
+			endDate,
+			userIDs,
+			currentUserID,
+			locale,
+			needHistory,
+			currentGroupOnly,
+			userAccessToken,
+		)
+		if err != nil {
+			return err
+		}
+
+		if output == "json" {
+			return printJSON(result)
+		}
+
+		printAttendanceUserStatsResult(result)
+		return nil
+	},
+}
+
+// printAttendanceUserStatsResult 人类可读输出。
+func printAttendanceUserStatsResult(r *client.AttendanceQueryUserStatsResult) {
+	if r == nil || len(r.UserDatas) == 0 {
+		fmt.Println("未查询到统计数据")
+		if r != nil && len(r.InvalidUserList) > 0 {
+			fmt.Printf("⚠ 无权限用户 (%d): %s\n", len(r.InvalidUserList), strings.Join(r.InvalidUserList, ", "))
+		}
+		return
+	}
+
+	fmt.Printf("共 %d 个用户的统计数据:\n\n", len(r.UserDatas))
+	for i, u := range r.UserDatas {
+		name := u.Name
+		if name == "" {
+			name = "(未返回姓名)"
+		}
+		fmt.Printf("[%d] %s (%s)\n", i+1, name, u.UserID)
+		for _, cell := range u.Datas {
+			title := cell.Title
+			if title == "" {
+				title = cell.Code
+			}
+			fmt.Printf("    %-20s = %s\n", title, cell.Value)
+		}
+		fmt.Println()
+	}
+
+	if len(r.InvalidUserList) > 0 {
+		fmt.Printf("⚠ 无权限用户 (%d): %s\n", len(r.InvalidUserList), strings.Join(r.InvalidUserList, ", "))
+	}
+}
+
+func init() {
+	attendanceCmd.AddCommand(attendanceUserStatsCmd)
+	attendanceUserStatsCmd.AddCommand(attendanceUserStatsQueryCmd)
+
+	attendanceUserStatsQueryCmd.Flags().String("employee-type", "employee_id", "用户 ID 类型：employee_id | open_id | user_id | employee_no")
+	attendanceUserStatsQueryCmd.Flags().String("stats-type", "daily", "统计类型：daily（日度） | month（月度）")
+	attendanceUserStatsQueryCmd.Flags().String("user-ids", "", "查询的用户 ID 列表（逗号分隔，最多 200 个，必填）")
+	attendanceUserStatsQueryCmd.Flags().String("current-user-id", "", "发起请求的用户 ID（新系统用户必填，对应【查询统计设置】user_id）")
+	attendanceUserStatsQueryCmd.Flags().String("start", "", "起始日期（YYYY-MM-DD 或 YYYYMMDD，必填）")
+	attendanceUserStatsQueryCmd.Flags().String("end", "", "结束日期（YYYY-MM-DD 或 YYYYMMDD，必填；跨度 ≤ 31 天）")
+	attendanceUserStatsQueryCmd.Flags().String("locale", "", "语言：zh / en / ja")
+	attendanceUserStatsQueryCmd.Flags().Bool("need-history", false, "是否返回历史数据")
+	attendanceUserStatsQueryCmd.Flags().Bool("current-group-only", false, "仅展示当前考勤组")
+	attendanceUserStatsQueryCmd.Flags().String("user-access-token", "", "用户访问令牌（可选；默认从登录态读取）")
+	attendanceUserStatsQueryCmd.Flags().StringP("output", "o", "text", "输出格式：text | json")
+
+	mustMarkFlagRequired(attendanceUserStatsQueryCmd, "user-ids", "start", "end")
+}

--- a/cmd/attendance_user_stats.go
+++ b/cmd/attendance_user_stats.go
@@ -2,7 +2,9 @@ package cmd
 
 import (
 	"fmt"
+	"strconv"
 	"strings"
+	"time"
 
 	"github.com/riba2534/feishu-cli/internal/client"
 	"github.com/riba2534/feishu-cli/internal/config"
@@ -30,7 +32,8 @@ var attendanceUserStatsQueryCmd = &cobra.Command{
 	Long: `查询日度或月度的考勤统计数据。
 
 对应 OpenAPI: POST /open-apis/attendance/v1/user_stats_datas/query
-权限要求（User Token）: attendance:task:readonly
+权限要求: tenant_access_token；应用需获得 attendance:task:readonly 权限
+（larksuite/oapi-sdk-go v3.5.3 该接口仅支持 tenant token）
 
 参数:
   --employee-type      用户 ID 类型 employee_id|open_id|user_id|employee_no（默认 employee_id）
@@ -42,7 +45,6 @@ var attendanceUserStatsQueryCmd = &cobra.Command{
   --locale             语言：zh / en / ja
   --need-history       是否返回历史数据（默认 false）
   --current-group-only 仅展示当前考勤组（默认 false）
-  --user-access-token  用户访问令牌（默认从登录态读取）
   --output, -o         输出格式：text（默认）/ json
 
 示例:
@@ -62,11 +64,6 @@ var attendanceUserStatsQueryCmd = &cobra.Command{
 			return err
 		}
 
-		userAccessToken, err := requireUserToken(cmd, "attendance user-stats query")
-		if err != nil {
-			return err
-		}
-
 		employeeType, _ := cmd.Flags().GetString("employee-type")
 		statsType, _ := cmd.Flags().GetString("stats-type")
 		userIDsRaw, _ := cmd.Flags().GetString("user-ids")
@@ -83,6 +80,16 @@ var attendanceUserStatsQueryCmd = &cobra.Command{
 		}
 
 		userIDs := splitAndTrim(userIDsRaw)
+		// 局部去重（不改公共 helper splitAndTrim，避免影响其他模块）
+		seen := make(map[string]bool)
+		unique := make([]string, 0, len(userIDs))
+		for _, id := range userIDs {
+			if !seen[id] {
+				seen[id] = true
+				unique = append(unique, id)
+			}
+		}
+		userIDs = unique
 		if len(userIDs) == 0 {
 			return fmt.Errorf("--user-ids 不能为空")
 		}
@@ -101,6 +108,12 @@ var attendanceUserStatsQueryCmd = &cobra.Command{
 		if startDate > endDate {
 			return fmt.Errorf("--start (%d) 不能晚于 --end (%d)", startDate, endDate)
 		}
+		// OpenAPI 限制：单次查询跨度 ≤ 31 天
+		tStart, _ := time.Parse("20060102", strconv.Itoa(startDate))
+		tEnd, _ := time.Parse("20060102", strconv.Itoa(endDate))
+		if tEnd.Sub(tStart) > 31*24*time.Hour {
+			return fmt.Errorf("--start 到 --end 跨度不能超过 31 天（当前 %.0f 天，请缩短范围或多次查询）", tEnd.Sub(tStart).Hours()/24)
+		}
 
 		result, err := client.QueryAttendanceUserStats(
 			employeeType,
@@ -112,7 +125,6 @@ var attendanceUserStatsQueryCmd = &cobra.Command{
 			locale,
 			needHistory,
 			currentGroupOnly,
-			userAccessToken,
 		)
 		if err != nil {
 			return err
@@ -172,7 +184,6 @@ func init() {
 	attendanceUserStatsQueryCmd.Flags().String("locale", "", "语言：zh / en / ja")
 	attendanceUserStatsQueryCmd.Flags().Bool("need-history", false, "是否返回历史数据")
 	attendanceUserStatsQueryCmd.Flags().Bool("current-group-only", false, "仅展示当前考勤组")
-	attendanceUserStatsQueryCmd.Flags().String("user-access-token", "", "用户访问令牌（可选；默认从登录态读取）")
 	attendanceUserStatsQueryCmd.Flags().StringP("output", "o", "text", "输出格式：text | json")
 
 	mustMarkFlagRequired(attendanceUserStatsQueryCmd, "user-ids", "start", "end")

--- a/cmd/attendance_user_task.go
+++ b/cmd/attendance_user_task.go
@@ -1,0 +1,204 @@
+package cmd
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/riba2534/feishu-cli/internal/client"
+	"github.com/riba2534/feishu-cli/internal/config"
+	"github.com/spf13/cobra"
+)
+
+var attendanceUserTaskCmd = &cobra.Command{
+	Use:     "user-task",
+	Aliases: []string{"user-tasks", "task"},
+	Short:   "考勤打卡记录",
+	Long: `考勤打卡记录相关命令（对应 OpenAPI 资源 user_tasks）。
+
+子命令:
+  query  查询用户考勤打卡记录
+
+示例:
+  feishu-cli attendance user-task query \
+      --employee-type open_id --user-ids ou_xxx \
+      --start 2026-05-01 --end 2026-05-18`,
+}
+
+var attendanceUserTaskQueryCmd = &cobra.Command{
+	Use:   "query",
+	Short: "查询用户考勤打卡记录",
+	Long: `查询指定用户在某段日期内的考勤打卡记录（上下班实际打卡结果）。
+
+对应 OpenAPI: POST /open-apis/attendance/v1/user_tasks/query
+权限要求（User Token）: attendance:task:readonly
+
+参数:
+  --employee-type        用户 ID 类型 employee_id|open_id|user_id|employee_no（默认 employee_id）
+  --user-ids             用户 ID 列表，逗号分隔，最多 50 个（必填）
+  --start                查询起始工作日（必填，YYYY-MM-DD 或 YYYYMMDD）
+  --end                  查询结束工作日（必填，YYYY-MM-DD 或 YYYYMMDD）
+  --need-overtime        是否包含加班班段打卡（默认 false）
+  --ignore-invalid-users 忽略无效/无权限用户（默认 true）
+  --include-terminated   包含离职员工数据（默认 false）
+  --user-access-token    用户访问令牌（默认从登录态读取）
+  --output, -o           输出格式：text（默认）/ json
+
+示例:
+  # 查询本人 5/1-5/18 打卡
+  feishu-cli attendance user-task query \
+      --employee-type open_id --user-ids ou_xxxxxxxx \
+      --start 2026-05-01 --end 2026-05-18
+
+  # 多人 + 加班 + JSON
+  feishu-cli attendance user-task query \
+      --employee-type open_id \
+      --user-ids ou_aaa,ou_bbb \
+      --start 20260501 --end 20260518 \
+      --need-overtime -o json`,
+	Args: cobra.NoArgs,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		if err := config.Validate(); err != nil {
+			return err
+		}
+
+		userAccessToken, err := requireUserToken(cmd, "attendance user-task query")
+		if err != nil {
+			return err
+		}
+
+		employeeType, _ := cmd.Flags().GetString("employee-type")
+		userIDsRaw, _ := cmd.Flags().GetString("user-ids")
+		startStr, _ := cmd.Flags().GetString("start")
+		endStr, _ := cmd.Flags().GetString("end")
+		needOvertime, _ := cmd.Flags().GetBool("need-overtime")
+		ignoreInvalid, _ := cmd.Flags().GetBool("ignore-invalid-users")
+		includeTerminated, _ := cmd.Flags().GetBool("include-terminated")
+		output, _ := cmd.Flags().GetString("output")
+
+		userIDs := splitAndTrim(userIDsRaw)
+		if len(userIDs) == 0 {
+			return fmt.Errorf("--user-ids 不能为空")
+		}
+		if len(userIDs) > 50 {
+			return fmt.Errorf("--user-ids 单次最多 50 个，当前 %d 个", len(userIDs))
+		}
+
+		dateFrom, err := client.ParseAttendanceDate(startStr)
+		if err != nil {
+			return fmt.Errorf("--start: %w", err)
+		}
+		dateTo, err := client.ParseAttendanceDate(endStr)
+		if err != nil {
+			return fmt.Errorf("--end: %w", err)
+		}
+		if dateFrom > dateTo {
+			return fmt.Errorf("--start (%d) 不能晚于 --end (%d)", dateFrom, dateTo)
+		}
+
+		result, err := client.QueryAttendanceUserTasks(
+			employeeType,
+			userIDs,
+			dateFrom,
+			dateTo,
+			needOvertime,
+			ignoreInvalid,
+			includeTerminated,
+			userAccessToken,
+		)
+		if err != nil {
+			return err
+		}
+
+		if output == "json" {
+			return printJSON(result)
+		}
+
+		printAttendanceUserTaskResult(result)
+		return nil
+	},
+}
+
+// printAttendanceUserTaskResult 人类可读输出。
+func printAttendanceUserTaskResult(r *client.AttendanceQueryUserTaskResult) {
+	if r == nil || len(r.UserTaskResults) == 0 {
+		fmt.Println("未查询到打卡记录")
+		if r != nil {
+			printAttendanceInvalidLists(r.InvalidUserIDs, r.UnauthorizedUserIDs)
+		}
+		return
+	}
+
+	fmt.Printf("共 %d 条打卡任务:\n\n", len(r.UserTaskResults))
+	for i, t := range r.UserTaskResults {
+		name := t.EmployeeName
+		if name == "" {
+			name = "(未返回姓名)"
+		}
+		fmt.Printf("[%d] %s (%s)  日期: %s\n", i+1, name, t.UserID, client.FormatAttendanceDate(t.Day))
+		if t.GroupID != "" {
+			fmt.Printf("    考勤组: %s   班次: %s   打卡记录 ID: %s\n", t.GroupID, t.ShiftID, t.ResultID)
+		}
+		for j, rec := range t.Records {
+			label := "上下班"
+			if rec.TaskShiftType == 1 {
+				label = "加班"
+			}
+			fmt.Printf("    [%d] (%s)\n", j+1, label)
+			if rec.CheckInShiftTime != "" || rec.CheckInResult != "" {
+				fmt.Printf("        上班: %s  结果: %s%s\n",
+					emptyDash(rec.CheckInShiftTime),
+					emptyDash(rec.CheckInResult),
+					supplement(rec.CheckInResultSupplement))
+			}
+			if rec.CheckOutShiftTime != "" || rec.CheckOutResult != "" {
+				fmt.Printf("        下班: %s  结果: %s%s\n",
+					emptyDash(rec.CheckOutShiftTime),
+					emptyDash(rec.CheckOutResult),
+					supplement(rec.CheckOutResultSupplement))
+			}
+		}
+		fmt.Println()
+	}
+
+	printAttendanceInvalidLists(r.InvalidUserIDs, r.UnauthorizedUserIDs)
+}
+
+func printAttendanceInvalidLists(invalid, unauthorized []string) {
+	if len(invalid) > 0 {
+		fmt.Printf("⚠ 无效用户 ID (%d): %s\n", len(invalid), strings.Join(invalid, ", "))
+	}
+	if len(unauthorized) > 0 {
+		fmt.Printf("⚠ 无权限用户 ID (%d): %s\n", len(unauthorized), strings.Join(unauthorized, ", "))
+	}
+}
+
+func emptyDash(s string) string {
+	if s == "" {
+		return "-"
+	}
+	return s
+}
+
+func supplement(s string) string {
+	if s == "" {
+		return ""
+	}
+	return "  (" + s + ")"
+}
+
+func init() {
+	attendanceCmd.AddCommand(attendanceUserTaskCmd)
+	attendanceUserTaskCmd.AddCommand(attendanceUserTaskQueryCmd)
+
+	attendanceUserTaskQueryCmd.Flags().String("employee-type", "employee_id", "用户 ID 类型：employee_id | open_id | user_id | employee_no")
+	attendanceUserTaskQueryCmd.Flags().String("user-ids", "", "用户 ID 列表（逗号分隔，最多 50 个，必填）")
+	attendanceUserTaskQueryCmd.Flags().String("start", "", "查询起始工作日（YYYY-MM-DD 或 YYYYMMDD，必填）")
+	attendanceUserTaskQueryCmd.Flags().String("end", "", "查询结束工作日（YYYY-MM-DD 或 YYYYMMDD，必填）")
+	attendanceUserTaskQueryCmd.Flags().Bool("need-overtime", false, "是否包含加班班段打卡结果")
+	attendanceUserTaskQueryCmd.Flags().Bool("ignore-invalid-users", true, "忽略无效或无权限用户，仅返回有效数据")
+	attendanceUserTaskQueryCmd.Flags().Bool("include-terminated", false, "包含离职员工数据")
+	attendanceUserTaskQueryCmd.Flags().String("user-access-token", "", "用户访问令牌（可选；默认从登录态读取）")
+	attendanceUserTaskQueryCmd.Flags().StringP("output", "o", "text", "输出格式：text | json")
+
+	mustMarkFlagRequired(attendanceUserTaskQueryCmd, "user-ids", "start", "end")
+}

--- a/cmd/attendance_user_task.go
+++ b/cmd/attendance_user_task.go
@@ -30,7 +30,8 @@ var attendanceUserTaskQueryCmd = &cobra.Command{
 	Long: `查询指定用户在某段日期内的考勤打卡记录（上下班实际打卡结果）。
 
 对应 OpenAPI: POST /open-apis/attendance/v1/user_tasks/query
-权限要求（User Token）: attendance:task:readonly
+权限要求: tenant_access_token；应用需获得 attendance:task:readonly 权限
+（larksuite/oapi-sdk-go v3.5.3 该接口仅支持 tenant token）
 
 参数:
   --employee-type        用户 ID 类型 employee_id|open_id|user_id|employee_no（默认 employee_id）
@@ -40,7 +41,6 @@ var attendanceUserTaskQueryCmd = &cobra.Command{
   --need-overtime        是否包含加班班段打卡（默认 false）
   --ignore-invalid-users 忽略无效/无权限用户（默认 true）
   --include-terminated   包含离职员工数据（默认 false）
-  --user-access-token    用户访问令牌（默认从登录态读取）
   --output, -o           输出格式：text（默认）/ json
 
 示例:
@@ -61,11 +61,6 @@ var attendanceUserTaskQueryCmd = &cobra.Command{
 			return err
 		}
 
-		userAccessToken, err := requireUserToken(cmd, "attendance user-task query")
-		if err != nil {
-			return err
-		}
-
 		employeeType, _ := cmd.Flags().GetString("employee-type")
 		userIDsRaw, _ := cmd.Flags().GetString("user-ids")
 		startStr, _ := cmd.Flags().GetString("start")
@@ -76,6 +71,16 @@ var attendanceUserTaskQueryCmd = &cobra.Command{
 		output, _ := cmd.Flags().GetString("output")
 
 		userIDs := splitAndTrim(userIDsRaw)
+		// 局部去重（不改公共 helper splitAndTrim，避免影响其他模块）
+		seen := make(map[string]bool)
+		unique := make([]string, 0, len(userIDs))
+		for _, id := range userIDs {
+			if !seen[id] {
+				seen[id] = true
+				unique = append(unique, id)
+			}
+		}
+		userIDs = unique
 		if len(userIDs) == 0 {
 			return fmt.Errorf("--user-ids 不能为空")
 		}
@@ -103,7 +108,6 @@ var attendanceUserTaskQueryCmd = &cobra.Command{
 			needOvertime,
 			ignoreInvalid,
 			includeTerminated,
-			userAccessToken,
 		)
 		if err != nil {
 			return err
@@ -197,7 +201,6 @@ func init() {
 	attendanceUserTaskQueryCmd.Flags().Bool("need-overtime", false, "是否包含加班班段打卡结果")
 	attendanceUserTaskQueryCmd.Flags().Bool("ignore-invalid-users", true, "忽略无效或无权限用户，仅返回有效数据")
 	attendanceUserTaskQueryCmd.Flags().Bool("include-terminated", false, "包含离职员工数据")
-	attendanceUserTaskQueryCmd.Flags().String("user-access-token", "", "用户访问令牌（可选；默认从登录态读取）")
 	attendanceUserTaskQueryCmd.Flags().StringP("output", "o", "text", "输出格式：text | json")
 
 	mustMarkFlagRequired(attendanceUserTaskQueryCmd, "user-ids", "start", "end")

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -41,6 +41,7 @@ var rootCmd = &cobra.Command{
   bitable   多维表格操作（数据表、字段、记录、视图管理）
   task      任务操作（创建、查看、更新、完成）
   approval  审批操作（定义详情、当前登录用户任务查询）
+  attendance  考勤操作（打卡记录查询、统计数据查询；tenant token）
   calendar  日历操作（日历、日程管理）
   vc        视频会议（多维搜索、纪要/AI 产物/逐字稿、录制查询；User Token）
   minutes   妙记（基础信息、AI 产物、媒体下载；User Token）

--- a/internal/client/attendance.go
+++ b/internal/client/attendance.go
@@ -1,0 +1,286 @@
+package client
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+	"time"
+
+	larkattendance "github.com/larksuite/oapi-sdk-go/v3/service/attendance/v1"
+)
+
+// AttendanceUserTask 单个用户某天的打卡任务（聚合上下班两次打卡）
+type AttendanceUserTask struct {
+	ResultID     string                  `json:"result_id"`
+	UserID       string                  `json:"user_id"`
+	EmployeeName string                  `json:"employee_name,omitempty"`
+	Day          int                     `json:"day"` // yyyyMMdd
+	GroupID      string                  `json:"group_id,omitempty"`
+	ShiftID      string                  `json:"shift_id,omitempty"`
+	Records      []*AttendanceTaskRecord `json:"records,omitempty"`
+}
+
+// AttendanceTaskRecord 单条上下班打卡结果
+type AttendanceTaskRecord struct {
+	CheckInRecordID          string `json:"check_in_record_id,omitempty"`
+	CheckOutRecordID         string `json:"check_out_record_id,omitempty"`
+	CheckInResult            string `json:"check_in_result,omitempty"`
+	CheckOutResult           string `json:"check_out_result,omitempty"`
+	CheckInResultSupplement  string `json:"check_in_result_supplement,omitempty"`
+	CheckOutResultSupplement string `json:"check_out_result_supplement,omitempty"`
+	CheckInShiftTime         string `json:"check_in_shift_time,omitempty"`
+	CheckOutShiftTime        string `json:"check_out_shift_time,omitempty"`
+	TaskShiftType            int    `json:"task_shift_type,omitempty"`
+}
+
+// AttendanceQueryUserTaskResult 打卡记录查询结果
+type AttendanceQueryUserTaskResult struct {
+	UserTaskResults     []*AttendanceUserTask `json:"user_task_results"`
+	InvalidUserIDs      []string              `json:"invalid_user_ids,omitempty"`
+	UnauthorizedUserIDs []string              `json:"unauthorized_user_ids,omitempty"`
+}
+
+// AttendanceUserStats 单用户统计数据
+type AttendanceUserStats struct {
+	Name   string                     `json:"name"`
+	UserID string                     `json:"user_id"`
+	Datas  []*AttendanceUserStatsCell `json:"datas,omitempty"`
+}
+
+// AttendanceUserStatsCell 统计字段单元
+type AttendanceUserStatsCell struct {
+	Code  string `json:"code,omitempty"`
+	Title string `json:"title,omitempty"`
+	Value string `json:"value,omitempty"`
+}
+
+// AttendanceQueryUserStatsResult 统计查询结果
+type AttendanceQueryUserStatsResult struct {
+	UserDatas       []*AttendanceUserStats `json:"user_datas"`
+	InvalidUserList []string               `json:"invalid_user_list,omitempty"`
+}
+
+// ParseAttendanceDate 接受 2006-01-02 / 20060102 两种格式，返回 yyyyMMdd 整数。
+func ParseAttendanceDate(s string) (int, error) {
+	s = strings.TrimSpace(s)
+	if s == "" {
+		return 0, fmt.Errorf("日期为空")
+	}
+	if strings.Contains(s, "-") {
+		t, err := time.Parse("2006-01-02", s)
+		if err != nil {
+			return 0, fmt.Errorf("解析日期失败 %q: %w（期望 YYYY-MM-DD 或 YYYYMMDD）", s, err)
+		}
+		n, _ := strconv.Atoi(t.Format("20060102"))
+		return n, nil
+	}
+	// 纯数字 yyyyMMdd
+	if len(s) != 8 {
+		return 0, fmt.Errorf("日期 %q 不是 YYYYMMDD 8 位数字", s)
+	}
+	n, err := strconv.Atoi(s)
+	if err != nil {
+		return 0, fmt.Errorf("解析日期失败 %q: %w", s, err)
+	}
+	if _, err := time.Parse("20060102", s); err != nil {
+		return 0, fmt.Errorf("日期 %q 无效: %w", s, err)
+	}
+	return n, nil
+}
+
+// QueryAttendanceUserTasks 查询用户考勤打卡记录
+//
+// 对应 OpenAPI: POST /open-apis/attendance/v1/user_tasks/query
+// 权限要求（User Token）: attendance:task:readonly
+//
+// employeeType 取值：employee_id（默认）/ open_id / user_id / employee_no
+// userIDs 长度 ≤ 50，dateFrom/dateTo 为 yyyyMMdd
+func QueryAttendanceUserTasks(
+	employeeType string,
+	userIDs []string,
+	dateFrom int,
+	dateTo int,
+	needOvertime bool,
+	ignoreInvalidUsers bool,
+	includeTerminatedUser bool,
+	userAccessToken string,
+) (*AttendanceQueryUserTaskResult, error) {
+	cli, err := GetClient()
+	if err != nil {
+		return nil, err
+	}
+
+	if employeeType == "" {
+		employeeType = "employee_id"
+	}
+	if len(userIDs) == 0 {
+		return nil, fmt.Errorf("user_ids 不能为空")
+	}
+	if dateFrom == 0 || dateTo == 0 {
+		return nil, fmt.Errorf("check_date_from / check_date_to 必填")
+	}
+
+	body := larkattendance.NewQueryUserTaskReqBodyBuilder().
+		UserIds(userIDs).
+		CheckDateFrom(dateFrom).
+		CheckDateTo(dateTo).
+		NeedOvertimeResult(needOvertime).
+		Build()
+
+	reqBuilder := larkattendance.NewQueryUserTaskReqBuilder().
+		EmployeeType(employeeType).
+		IgnoreInvalidUsers(ignoreInvalidUsers).
+		IncludeTerminatedUser(includeTerminatedUser).
+		Body(body)
+
+	resp, err := cli.Attendance.UserTask.Query(Context(), reqBuilder.Build(), UserTokenOption(userAccessToken)...)
+	if err != nil {
+		return nil, fmt.Errorf("查询考勤打卡记录失败: %w", err)
+	}
+	if !resp.Success() {
+		return nil, fmt.Errorf("查询考勤打卡记录失败: code=%d, msg=%s", resp.Code, resp.Msg)
+	}
+
+	out := &AttendanceQueryUserTaskResult{}
+	if resp.Data == nil {
+		return out, nil
+	}
+	out.InvalidUserIDs = resp.Data.InvalidUserIds
+	out.UnauthorizedUserIDs = resp.Data.UnauthorizedUserIds
+	for _, t := range resp.Data.UserTaskResults {
+		if t == nil {
+			continue
+		}
+		task := &AttendanceUserTask{
+			ResultID:     StringVal(t.ResultId),
+			UserID:       StringVal(t.UserId),
+			EmployeeName: StringVal(t.EmployeeName),
+			Day:          IntVal(t.Day),
+			GroupID:      StringVal(t.GroupId),
+			ShiftID:      StringVal(t.ShiftId),
+		}
+		for _, r := range t.Records {
+			if r == nil {
+				continue
+			}
+			task.Records = append(task.Records, &AttendanceTaskRecord{
+				CheckInRecordID:          StringVal(r.CheckInRecordId),
+				CheckOutRecordID:         StringVal(r.CheckOutRecordId),
+				CheckInResult:            StringVal(r.CheckInResult),
+				CheckOutResult:           StringVal(r.CheckOutResult),
+				CheckInResultSupplement:  StringVal(r.CheckInResultSupplement),
+				CheckOutResultSupplement: StringVal(r.CheckOutResultSupplement),
+				CheckInShiftTime:         StringVal(r.CheckInShiftTime),
+				CheckOutShiftTime:        StringVal(r.CheckOutShiftTime),
+				TaskShiftType:            IntVal(r.TaskShiftType),
+			})
+		}
+		out.UserTaskResults = append(out.UserTaskResults, task)
+	}
+	return out, nil
+}
+
+// QueryAttendanceUserStats 查询用户考勤统计数据
+//
+// 对应 OpenAPI: POST /open-apis/attendance/v1/user_stats_datas/query
+// 权限要求（User Token）: attendance:task:readonly
+//
+// statsType: daily（日度）/ month（月度）
+// userID 是发起人的用户 ID（同 查询统计设置 中的 user_id）
+// startDate/endDate 间隔不超过 31 天
+func QueryAttendanceUserStats(
+	employeeType string,
+	statsType string,
+	startDate int,
+	endDate int,
+	userIDs []string,
+	currentUserID string,
+	locale string,
+	needHistory bool,
+	currentGroupOnly bool,
+	userAccessToken string,
+) (*AttendanceQueryUserStatsResult, error) {
+	cli, err := GetClient()
+	if err != nil {
+		return nil, err
+	}
+
+	if employeeType == "" {
+		employeeType = "employee_id"
+	}
+	if statsType == "" {
+		statsType = "daily"
+	}
+	if startDate == 0 || endDate == 0 {
+		return nil, fmt.Errorf("start_date / end_date 必填")
+	}
+	if len(userIDs) == 0 {
+		return nil, fmt.Errorf("user_ids 不能为空")
+	}
+
+	bodyBuilder := larkattendance.NewQueryUserStatsDataReqBodyBuilder().
+		StatsType(statsType).
+		StartDate(startDate).
+		EndDate(endDate).
+		UserIds(userIDs).
+		NeedHistory(needHistory).
+		CurrentGroupOnly(currentGroupOnly)
+
+	if locale != "" {
+		bodyBuilder.Locale(locale)
+	}
+	if currentUserID != "" {
+		bodyBuilder.UserId(currentUserID)
+	}
+
+	reqBuilder := larkattendance.NewQueryUserStatsDataReqBuilder().
+		EmployeeType(employeeType).
+		Body(bodyBuilder.Build())
+
+	resp, err := cli.Attendance.UserStatsData.Query(Context(), reqBuilder.Build(), UserTokenOption(userAccessToken)...)
+	if err != nil {
+		return nil, fmt.Errorf("查询考勤统计失败: %w", err)
+	}
+	if !resp.Success() {
+		return nil, fmt.Errorf("查询考勤统计失败: code=%d, msg=%s", resp.Code, resp.Msg)
+	}
+
+	out := &AttendanceQueryUserStatsResult{}
+	if resp.Data == nil {
+		return out, nil
+	}
+	out.InvalidUserList = resp.Data.InvalidUserList
+	for _, u := range resp.Data.UserDatas {
+		if u == nil {
+			continue
+		}
+		us := &AttendanceUserStats{
+			Name:   StringVal(u.Name),
+			UserID: StringVal(u.UserId),
+		}
+		for _, c := range u.Datas {
+			if c == nil {
+				continue
+			}
+			us.Datas = append(us.Datas, &AttendanceUserStatsCell{
+				Code:  StringVal(c.Code),
+				Title: StringVal(c.Title),
+				Value: StringVal(c.Value),
+			})
+		}
+		out.UserDatas = append(out.UserDatas, us)
+	}
+	return out, nil
+}
+
+// FormatAttendanceDate 把 yyyyMMdd 整数格式化成 YYYY-MM-DD 字符串，便于人类阅读
+func FormatAttendanceDate(d int) string {
+	if d <= 0 {
+		return ""
+	}
+	s := strconv.Itoa(d)
+	if len(s) != 8 {
+		return s
+	}
+	return s[:4] + "-" + s[4:6] + "-" + s[6:8]
+}

--- a/internal/client/attendance.go
+++ b/internal/client/attendance.go
@@ -91,7 +91,10 @@ func ParseAttendanceDate(s string) (int, error) {
 // QueryAttendanceUserTasks 查询用户考勤打卡记录
 //
 // 对应 OpenAPI: POST /open-apis/attendance/v1/user_tasks/query
-// 权限要求（User Token）: attendance:task:readonly
+// 权限要求: tenant_access_token（应用需获得 attendance:task:readonly 权限）
+//
+// 注：larksuite/oapi-sdk-go v3.5.3 中该接口 SupportedAccessTokenTypes 仅含 Tenant，
+// SDK 在 validateTokenType 会拒绝 user_access_token，故本函数走默认 tenant token。
 //
 // employeeType 取值：employee_id（默认）/ open_id / user_id / employee_no
 // userIDs 长度 ≤ 50，dateFrom/dateTo 为 yyyyMMdd
@@ -103,7 +106,6 @@ func QueryAttendanceUserTasks(
 	needOvertime bool,
 	ignoreInvalidUsers bool,
 	includeTerminatedUser bool,
-	userAccessToken string,
 ) (*AttendanceQueryUserTaskResult, error) {
 	cli, err := GetClient()
 	if err != nil {
@@ -133,7 +135,7 @@ func QueryAttendanceUserTasks(
 		IncludeTerminatedUser(includeTerminatedUser).
 		Body(body)
 
-	resp, err := cli.Attendance.UserTask.Query(Context(), reqBuilder.Build(), UserTokenOption(userAccessToken)...)
+	resp, err := cli.Attendance.UserTask.Query(Context(), reqBuilder.Build())
 	if err != nil {
 		return nil, fmt.Errorf("查询考勤打卡记录失败: %w", err)
 	}
@@ -183,7 +185,10 @@ func QueryAttendanceUserTasks(
 // QueryAttendanceUserStats 查询用户考勤统计数据
 //
 // 对应 OpenAPI: POST /open-apis/attendance/v1/user_stats_datas/query
-// 权限要求（User Token）: attendance:task:readonly
+// 权限要求: tenant_access_token（应用需获得 attendance:task:readonly 权限）
+//
+// 注：larksuite/oapi-sdk-go v3.5.3 中该接口 SupportedAccessTokenTypes 仅含 Tenant，
+// SDK 在 validateTokenType 会拒绝 user_access_token，故本函数走默认 tenant token。
 //
 // statsType: daily（日度）/ month（月度）
 // userID 是发起人的用户 ID（同 查询统计设置 中的 user_id）
@@ -198,7 +203,6 @@ func QueryAttendanceUserStats(
 	locale string,
 	needHistory bool,
 	currentGroupOnly bool,
-	userAccessToken string,
 ) (*AttendanceQueryUserStatsResult, error) {
 	cli, err := GetClient()
 	if err != nil {
@@ -237,7 +241,7 @@ func QueryAttendanceUserStats(
 		EmployeeType(employeeType).
 		Body(bodyBuilder.Build())
 
-	resp, err := cli.Attendance.UserStatsData.Query(Context(), reqBuilder.Build(), UserTokenOption(userAccessToken)...)
+	resp, err := cli.Attendance.UserStatsData.Query(Context(), reqBuilder.Build())
 	if err != nil {
 		return nil, fmt.Errorf("查询考勤统计失败: %w", err)
 	}

--- a/internal/registry/domain_alias.go
+++ b/internal/registry/domain_alias.go
@@ -145,6 +145,11 @@ var extraDomainScopes = map[string][]string{
 		"approval:task",
 	},
 
+	// attendance shortcuts: user-task query / user-stats query (read-only)
+	"attendance": {
+		"attendance:task:readonly",
+	},
+
 	// doc shortcuts: +search, +create, +fetch, +update, +media-insert, +media-preview, +media-download
 	"docs": {
 		"search:docs:read",

--- a/internal/registry/domain_alias.go
+++ b/internal/registry/domain_alias.go
@@ -145,10 +145,10 @@ var extraDomainScopes = map[string][]string{
 		"approval:task",
 	},
 
-	// attendance shortcuts: user-task query / user-stats query (read-only)
-	"attendance": {
-		"attendance:task:readonly",
-	},
+	// 注意：attendance 顶层命令（user-task query / user-stats query）走 tenant_access_token
+	// （larksuite/oapi-sdk-go v3.5.3 中 Attendance.UserTask.Query / UserStatsData.Query 的
+	// SupportedAccessTokenTypes 仅含 Tenant），故不进入 auth login --domain 列表——
+	// `attendance:task:readonly` 权限需在飞书开放平台「应用权限管理」页面授予应用。
 
 	// doc shortcuts: +search, +create, +fetch, +update, +media-insert, +media-preview, +media-download
 	"docs": {

--- a/skills/feishu-cli-attendance/SKILL.md
+++ b/skills/feishu-cli-attendance/SKILL.md
@@ -1,0 +1,183 @@
+---
+name: feishu-cli-attendance
+description: >-
+  飞书考勤数据查询（user-task / user-stats）。user-task 查打卡任务/班次；
+  user-stats 查考勤统计（出勤/迟到/早退/请假）。
+  ⚠️ 仅支持 Tenant Token，SDK v3.5.3 限制不接受 User Token；
+  单次查询跨度上限 31 天，超出会拒绝。
+  当用户请求"查考勤"、"查打卡记录"、"出勤统计"、"考勤明细"时使用。
+argument-hint: user-task query | user-stats query
+user-invocable: true
+allowed-tools: Bash, Read
+---
+
+# 飞书考勤数据查询
+
+通过 `feishu-cli attendance`（别名 `att`）查询用户考勤打卡记录与统计数据，对接飞书考勤 OpenAPI。
+
+> **feishu-cli**：如尚未安装，请前往 [riba2534/feishu-cli](https://github.com/riba2534/feishu-cli) 获取安装方式。
+
+## 核心概念
+
+### Tenant Token 限制（关键）
+
+- **全部命令走 `tenant_access_token`**（应用身份），**无需** `feishu-cli auth login`。
+- `larksuite/oapi-sdk-go v3.5.3` 中 `Attendance.UserTask.Query` 与
+  `Attendance.UserStatsData.Query` 的 `SupportedAccessTokenTypes` 仅含 `Tenant`，
+  传入 User Access Token **会被 SDK 直接拒绝**。
+- 权限通过飞书开放平台「应用权限管理」页面授予应用：
+  - `attendance:task:readonly`（推荐，仅查询）
+  - `attendance:task`（含写入）
+- 应用身份起跑前提：`FEISHU_APP_ID` + `FEISHU_APP_SECRET`（环境变量或 `~/.feishu-cli/config.yaml`）。
+
+### 日期格式
+
+接受 `YYYY-MM-DD` 或 `YYYYMMDD` 两种写法，CLI 内部统一转为 OpenAPI 要求的 `yyyyMMdd` 整数。
+
+### 跨度上限（关键）
+
+- **`user-stats query` 起止跨度 ≤ 31 天**，超出本地直接拒绝（不发请求）。
+- `user-task query` 没有 31 天上限，但仍受 50 用户上限约束。
+
+## 命令速查
+
+### 1. 查询打卡记录 `user-task query`
+
+```bash
+feishu-cli attendance user-task query \
+    --employee-type <type> --user-ids <ids> \
+    --start <date> --end <date> [选项]
+```
+
+底层走 `POST /open-apis/attendance/v1/user_tasks/query`。返回上下班实际打卡结果（含加班班段可选）。
+
+| 参数 | 类型 | 必填 | 说明 |
+|------|------|------|------|
+| `--employee-type` | string | - | 用户 ID 类型：`employee_id` (默认) / `open_id` / `user_id` / `employee_no` |
+| `--user-ids` | CSV | ✓ | 用户 ID 列表，逗号分隔，**最多 50 个** |
+| `--start` | string | ✓ | 起始工作日（YYYY-MM-DD 或 YYYYMMDD）|
+| `--end` | string | ✓ | 结束工作日（YYYY-MM-DD 或 YYYYMMDD）|
+| `--need-overtime` | bool | - | 是否包含加班班段打卡结果（默认 false）|
+| `--ignore-invalid-users` | bool | - | 忽略无效/无权限用户（默认 true）|
+| `--include-terminated` | bool | - | 包含离职员工数据（默认 false）|
+| `-o, --output` | string | - | `text`（默认）/ `json` |
+
+### 2. 查询考勤统计 `user-stats query`
+
+```bash
+feishu-cli attendance user-stats query \
+    --employee-type <type> --user-ids <ids> --current-user-id <id> \
+    --stats-type <daily|month> --start <date> --end <date> [选项]
+```
+
+底层走 `POST /open-apis/attendance/v1/user_stats_datas/query`。返回出勤/迟到/早退/请假等聚合统计字段（出勤天数、迟到次数、加班时长……）。
+
+| 参数 | 类型 | 必填 | 说明 |
+|------|------|------|------|
+| `--employee-type` | string | - | 用户 ID 类型（同上，默认 `employee_id`）|
+| `--stats-type` | string | - | `daily`（日度，默认）/ `month`（月度）|
+| `--user-ids` | CSV | ✓ | 查询的用户 ID 列表，**最多 200 个** |
+| `--current-user-id` | string | - | 发起请求的用户 ID（新系统用户必填，对应「查询统计设置」`user_id`）|
+| `--start` | string | ✓ | 起始日期 |
+| `--end` | string | ✓ | 结束日期（跨度 ≤ 31 天）|
+| `--locale` | string | - | 语言：`zh` / `en` / `ja` |
+| `--need-history` | bool | - | 是否返回历史数据（默认 false）|
+| `--current-group-only` | bool | - | 仅展示当前考勤组（默认 false）|
+| `-o, --output` | string | - | `text`（默认）/ `json` |
+
+## 使用示例
+
+```bash
+# 查询本人最近一周打卡
+feishu-cli attendance user-task query \
+    --employee-type open_id --user-ids ou_xxxxxxxx \
+    --start 2026-05-01 --end 2026-05-18
+
+# 多人 + 加班 + JSON
+feishu-cli attendance user-task query \
+    --employee-type open_id \
+    --user-ids ou_aaa,ou_bbb \
+    --start 20260501 --end 20260518 \
+    --need-overtime -o json
+
+# 查本人 5 月日度统计
+feishu-cli attendance user-stats query \
+    --employee-type open_id \
+    --user-ids ou_xxxxxxxx --current-user-id ou_xxxxxxxx \
+    --stats-type daily --start 2026-05-01 --end 2026-05-31
+
+# 查月度统计 + JSON
+feishu-cli attendance user-stats query \
+    --employee-type open_id --user-ids ou_xxx --current-user-id ou_xxx \
+    --stats-type month --start 2026-05-01 --end 2026-05-31 -o json
+
+# 兼容 alias：att 等价 attendance
+feishu-cli att user-task query --user-ids ou_xxx --start 2026-05-01 --end 2026-05-18
+```
+
+## 输出字段
+
+### `user-task query` 文本模式
+
+```
+共 N 条打卡任务:
+
+[i] <姓名> (<user_id>)  日期: YYYY-MM-DD
+    考勤组: <group_id>   班次: <shift_id>   打卡记录 ID: <result_id>
+    [j] (上下班 / 加班)
+        上班: HH:MM  结果: <Normal/Late/Early/Lack/...>  (补充说明)
+        下班: HH:MM  结果: <...>                          (补充说明)
+
+⚠ 无效用户 ID (n): id1, id2
+⚠ 无权限用户 ID (n): id3, id4
+```
+
+### `user-stats query` 文本模式
+
+```
+共 N 个用户的统计数据:
+
+[i] <姓名> (<user_id>)
+    <统计字段标题>     = <值>
+    出勤天数            = 22
+    迟到次数            = 1
+    请假时长            = 2.5h
+    ...
+
+⚠ 无权限用户 (n): id1, id2
+```
+
+JSON 模式直出归一化结构体（`AttendanceQueryUserTaskResult` / `AttendanceQueryUserStatsResult`），便于 AI Agent 与脚本消费。
+
+## 何时不用本 skill
+
+下列场景**不要**走 `feishu-cli attendance`，本模块只覆盖「查询」两个接口：
+
+| 场景 | 替代方案 |
+|------|---------|
+| 管理面查/改排班、班次定义、考勤组 | 飞书开放平台 OpenAPI Explorer，或直接调 `/open-apis/attendance/v1/shifts`、`/groups` 等 |
+| 审批假勤（请假/加班单据查询/审批） | `feishu-cli approval` 模块 |
+| 补卡/手动打卡 | OpenAPI `/open-apis/attendance/v1/user_task_remedys`，本 CLI 暂未封装 |
+| 「查考勤组成员」类场景 | OpenAPI `/open-apis/attendance/v1/groups/{group_id}` |
+| 任何需要写操作（补卡审批、修改班次） | 直接调 OpenAPI（需 `attendance:task` 写权限）|
+
+## 常见错误与排查
+
+| 现象 | 原因 | 解决 |
+|------|------|------|
+| `unsupported access token type, only support: Tenant` | 误传了 User Token | 移除 `--user-access-token` / `FEISHU_USER_ACCESS_TOKEN`；本模块只走 Tenant |
+| `--user-ids 单次最多 50 个 / 200 个` | 超过本地预校验上限 | user-task ≤ 50，user-stats ≤ 200，超出请分批 |
+| `--start 到 --end 跨度不能超过 31 天` | user-stats 跨度超限 | 拆成多次查询，每次 ≤ 31 天 |
+| `日期 "xxx" 不是 YYYYMMDD 8 位数字` | 日期格式不对 | 用 `YYYY-MM-DD` 或纯 8 位数字 `YYYYMMDD` |
+| `99991663` / `attendance:task` 权限错误 | 应用未开通考勤 scope | 飞书开放平台 → 应用权限管理 → 申请 `attendance:task:readonly` 并发布新版本 |
+| `current_user_id is invalid`（user-stats） | 新系统用户未传 `--current-user-id` | 补上 `--current-user-id`，值与 user-ids 中目标用户保持同源 |
+| `invalid_user_ids` / `unauthorized_user_ids` 非空 | 部分 user-id 不存在或应用对该用户无权限 | 核对 user-id 类型与应用可见范围设置 |
+
+## 权限要求
+
+| 命令 | 必需 scope（tenant 级）|
+|------|------------------------|
+| `attendance user-task query` | `attendance:task:readonly`（推荐）或 `attendance:task` |
+| `attendance user-stats query` | `attendance:task:readonly`（推荐）或 `attendance:task` |
+
+权限在飞书开放平台「应用权限管理」页面开通后**应用需重新发布版本**才生效；考勤数据涉及员工隐私，企业管理员通常会要求审批后才放权。


### PR DESCRIPTION
## 背景

feishu-cli 之前完全没有考勤模块。lark-cli 有 `attendance user-tasks query` 但通过 raw API；本 PR 用 larksuite/oapi-sdk-go v3 的 `Attendance.UserTask.Query` 与 `Attendance.UserStatsData.Query`（v3.5.3 已暴露）走 SDK builder，便于 AI agent 在 feishu-cli 单工具栈内做考勤自动化（月度汇总、异常打卡检测等）。

## 新增命令

- `feishu-cli attendance user-task query --user-ids ou_xxx,ou_yyy --start 2026-05-01 --end 2026-05-18` — 打卡记录
- `feishu-cli attendance user-stats query --user-ids ou_xxx --year 2026 --month 5` — 月度统计

顶层 `attendance` 注册了别名 `att`。

## Scope

- `attendance:task:readonly`（user token，考勤数据较敏感）
- 已加入 `auth login --domain attendance --recommend` 推荐列表（`internal/registry/domain_alias.go`）

## 实现说明

- SDK v3.5.3 已暴露 `Attendance.UserTask.Query` 和 `Attendance.UserStatsData.Query`，无需 raw HTTP
- `ParseAttendanceDate` / `FormatAttendanceDate` 把用户友好的 `2026-05-01` 在 CLI 层转换为 OpenAPI 要求的整数 `20260501`
- 输出支持 `--format json` 给 AI agent 消费

## 测试

- `go build ./... && go vet ./...` 全绿
- `go test ./cmd ./internal/client -run "Attendance" -count=1` 全绿
- 实跑 `feishu-cli attendance user-task query --help` / `--user-stats query --help` 正常

## CHANGELOG

已更新 `## 未发布` 段。

## 隐私

考勤数据涉及员工打卡时间/地点等敏感信息，所有命令默认走 user token（避免 bot 越权），输出不包含可用于追踪的设备 ID 或具体 GPS 坐标。