### PR TITLE
feat(calendar): suggestion / room-find / rsvp 智能日历能力

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,47 @@
 
 ## 未发布
 
+### 新增 — `calendar` 智能化三件套（suggestion / room-find / rsvp）
+
+针对 AI Agent 自动排会场景，补齐三条飞书日历开放能力，使整条「选时段 → 选会议室 → 答复邀请」
+流水线全部可在 CLI 完成。
+
+- **`calendar suggestion`**：智能时段建议。直调 `POST /open-apis/calendar/v4/freebusy/suggestion`，
+  按 `--attendee-ids ou_xxx,oc_yyy` + `--duration 30m/1h30m/90` 推荐可用时段；支持
+  `--start`/`--end` 搜索窗口（默认当天）、`--exclude start~end,...` 排除午休/已占用时段、
+  `--event-rrule` 周期性规则、`--timezone`。返回带「推荐理由」+「AI 行动指引」。
+- **`calendar room-find`**：会议室查找。直调 `POST /open-apis/calendar/v4/freebusy/room_find`，
+  支持多个 `--slot start~end` 并发查询（worker=10），可按 `--city`/`--building`/`--floor`/
+  `--room-name`（逗号分隔多个）/`--min-capacity`/`--max-capacity` 多维度过滤；可选
+  `--attendee-ids` 让服务端结合参与者位置筛选。
+- **`calendar rsvp`**：答复日程邀请。走 SDK Reply 接口，`--calendar-id`（可省略，默认主日历）+
+  `--event-id` + `--action accept|decline|tentative`。与既有的 `calendar event-reply`
+  位置参数风格互为补充——rsvp 全 flag 风格、calendar-id 可省，更适合 AI Agent 调度。
+
+**SDK 现状**：v3.5.3 暴露 `Reply` 但未暴露 `freebusy/suggestion` 和 `freebusy/room_find`，
+故 suggestion / room-find 走 `client.Post` 通用 HTTP 直调 OpenAPI；新增 client 函数集中在
+`internal/client/calendar_smart.go`，包括 `SuggestFreebusy`、`FindMeetingRoom`、
+`FindMeetingRoomBatch`（并发+排序）、`SplitAttendeeIDs`（按 `ou_`/`oc_` 前缀分流）。
+
+**权限要求**：
+- suggestion / room-find：`calendar:calendar.free_busy:read`（User Token 或 App Token 均可）
+- rsvp：`calendar:calendar.event:reply`（推荐 User Token，以本人身份答复）
+
+**典型用法**：
+
+```bash
+# 1. 先让飞书推荐可用时段
+feishu-cli calendar suggestion --attendee-ids ou_aaa,ou_bbb --duration 30m
+
+# 2. 锁定时段后查会议室
+feishu-cli calendar room-find \
+  --slot 2024-01-22T09:00:00+08:00~2024-01-22T09:30:00+08:00 \
+  --building "飞书大厦" --min-capacity 6
+
+# 3. 收到邀请后答复
+feishu-cli calendar rsvp --event-id EVENT_xxx --action accept
+```
+
 ### 新增 — `comment reply add`：为已有评论添加回复
 
 新增命令 `feishu-cli comment reply add <file_token> <comment_id> --text "..."`，补齐评论回复

--- a/cmd/calendar.go
+++ b/cmd/calendar.go
@@ -8,7 +8,7 @@ var calendarCmd = &cobra.Command{
 	Use:     "calendar",
 	Aliases: []string{"cal"},
 	Short:   "日历操作命令",
-	Long: `日历操作命令，包括列出日历、管理日程等。
+	Long: `日历操作命令，包括列出日历、管理日程、智能时段建议、会议室查找、RSVP 答复等。
 
 子命令:
   list          列出日历
@@ -17,6 +17,9 @@ var calendarCmd = &cobra.Command{
   list-events   列出日程
   update-event  更新日程
   delete-event  删除日程
+  suggestion    智能时段建议（基于参与者 freebusy 推荐可用时段）
+  room-find     查找可用会议室（按城市/楼层/容量/时段过滤，支持多时段并发）
+  rsvp          答复日程邀请（accept / tentative / decline）
 
 时间格式:
   使用 RFC3339 格式，例如：2024-01-21T14:00:00+08:00
@@ -39,7 +42,19 @@ var calendarCmd = &cobra.Command{
   feishu-cli calendar update-event CAL_ID EVENT_ID --summary "新标题"
 
   # 删除日程
-  feishu-cli calendar delete-event CAL_ID EVENT_ID`,
+  feishu-cli calendar delete-event CAL_ID EVENT_ID
+
+  # 智能时段建议（推荐 60 分钟可用时段）
+  feishu-cli calendar suggestion --search-start 2024-01-21T09:00:00+08:00 \
+    --search-end 2024-01-21T18:00:00+08:00 --duration 60 \
+    --attendee-ids ou_xxx,ou_yyy,oc_zzz
+
+  # 查找可用会议室
+  feishu-cli calendar room-find --city 北京 --min-capacity 6 \
+    --slot 2024-01-21T14:00:00+08:00/2024-01-21T15:00:00+08:00
+
+  # 答复日程邀请
+  feishu-cli calendar rsvp --event-id EVENT_ID --rsvp-status accept`,
 }
 
 func init() {

--- a/cmd/calendar_room_find.go
+++ b/cmd/calendar_room_find.go
@@ -1,0 +1,202 @@
+package cmd
+
+import (
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/riba2534/feishu-cli/internal/client"
+	"github.com/riba2534/feishu-cli/internal/config"
+	"github.com/spf13/cobra"
+)
+
+const roomFindWorkers = 10
+
+var calendarRoomFindCmd = &cobra.Command{
+	Use:   "room-find",
+	Short: "查找指定时段可用的会议室",
+	Long: `调用飞书 freebusy/room_find 接口，按城市/建筑/楼层/容量等约束，
+为一个或多个时段并发查询可用会议室候选。AI Agent 排会议时选会议室常用。
+
+参数:
+  --slot               待查时段，格式 start~end（RFC3339），可重复传入或逗号分隔多段
+  --attendee-ids       参与者 ID 列表，逗号分隔（ou_xxx / oc_xxx），可省略
+  --city               城市约束（例如 "北京"）
+  --building           建筑约束
+  --floor              楼层约束（例如 "F2"）
+  --room-name          会议室名称约束，逗号分隔可指定多个（例如 "01,02,03"）
+  --min-capacity       最小容量
+  --max-capacity       最大容量
+  --timezone           时区（例：Asia/Shanghai）
+  --event-rrule        周期性规则（rrule 字符串）
+
+权限:
+  calendar:calendar.free_busy:read（User Token 或 App Token 均可）
+
+示例:
+  # 查 2024-01-22 9-10 点的可用会议室
+  feishu-cli calendar room-find \
+    --slot 2024-01-22T09:00:00+08:00~2024-01-22T10:00:00+08:00
+
+  # 多个时段 + 容量/建筑约束
+  feishu-cli calendar room-find \
+    --slot 2024-01-22T09:00:00+08:00~2024-01-22T10:00:00+08:00 \
+    --slot 2024-01-22T14:00:00+08:00~2024-01-22T15:00:00+08:00 \
+    --building "飞书大厦" --min-capacity 6 --max-capacity 20
+
+  # 配合参与者，便于服务端筛选离参与者近的会议室
+  feishu-cli calendar room-find \
+    --slot 2024-01-22T09:00:00+08:00~2024-01-22T10:00:00+08:00 \
+    --attendee-ids ou_aaa,ou_bbb -o json`,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		if err := config.Validate(); err != nil {
+			return err
+		}
+
+		token := resolveOptionalUserToken(cmd)
+
+		// 解析 --slot 多值（StringSliceArray 支持重复传入 + 逗号分隔）
+		slotInputs, _ := cmd.Flags().GetStringSlice("slot")
+		slots, err := parseRoomFindSlots(slotInputs)
+		if err != nil {
+			return err
+		}
+
+		// 解析参与者
+		attendeeIDs, _ := cmd.Flags().GetString("attendee-ids")
+		userIDs, chatIDs, err := client.SplitAttendeeIDs(attendeeIDs)
+		if err != nil {
+			return err
+		}
+
+		city, _ := cmd.Flags().GetString("city")
+		building, _ := cmd.Flags().GetString("building")
+		floor, _ := cmd.Flags().GetString("floor")
+		roomName, _ := cmd.Flags().GetString("room-name")
+		minCap, _ := cmd.Flags().GetInt("min-capacity")
+		maxCap, _ := cmd.Flags().GetInt("max-capacity")
+		timezone, _ := cmd.Flags().GetString("timezone")
+		eventRrule, _ := cmd.Flags().GetString("event-rrule")
+		output, _ := cmd.Flags().GetString("output")
+
+		if minCap < 0 || maxCap < 0 {
+			return fmt.Errorf("--min-capacity 和 --max-capacity 必须 >= 0")
+		}
+		if minCap > 0 && maxCap > 0 && minCap > maxCap {
+			return fmt.Errorf("--min-capacity 必须 <= --max-capacity")
+		}
+
+		baseReq := &client.RoomFindRequest{
+			City:            strings.TrimSpace(city),
+			Building:        strings.TrimSpace(building),
+			Floor:           strings.TrimSpace(floor),
+			RoomName:        normalizeCommaSeparated(roomName),
+			MinCapacity:     minCap,
+			MaxCapacity:     maxCap,
+			AttendeeUserIDs: userIDs,
+			AttendeeChatIDs: chatIDs,
+			Timezone:        strings.TrimSpace(timezone),
+			EventRrule:      strings.TrimSpace(eventRrule),
+		}
+
+		result, err := client.FindMeetingRoomBatch(baseReq, slots, roomFindWorkers, token)
+		if err != nil {
+			return err
+		}
+
+		if output == "json" {
+			return printJSON(result)
+		}
+
+		if result == nil || len(result.TimeSlots) == 0 {
+			fmt.Println("未找到可用会议室")
+			return nil
+		}
+
+		for _, slot := range result.TimeSlots {
+			fmt.Printf("%s ~ %s\n", slot.Start, slot.End)
+			if len(slot.MeetingRooms) == 0 {
+				fmt.Println("  （无可用会议室）")
+				fmt.Println()
+				continue
+			}
+			for i, room := range slot.MeetingRooms {
+				fmt.Printf("  [%d] %s (id=%s, capacity=%d)\n", i+1, room.RoomName, room.RoomID, room.Capacity)
+				if room.ReserveUntilTime != "" {
+					fmt.Printf("      可预订至: %s\n", room.ReserveUntilTime)
+				}
+			}
+			fmt.Println()
+		}
+
+		return nil
+	},
+}
+
+// parseRoomFindSlots 解析 --slot 列表（每项 start~end，RFC3339）
+func parseRoomFindSlots(raws []string) ([]client.RoomFindSlot, error) {
+	if len(raws) == 0 {
+		return nil, fmt.Errorf("至少需要指定一个 --slot")
+	}
+	var out []client.RoomFindSlot
+	for _, raw := range raws {
+		raw = strings.TrimSpace(raw)
+		if raw == "" {
+			continue
+		}
+		parts := strings.Split(raw, "~")
+		if len(parts) != 2 {
+			return nil, fmt.Errorf("无效的 --slot 格式 %q，应为 start~end", raw)
+		}
+		startT, err := time.Parse(time.RFC3339, strings.TrimSpace(parts[0]))
+		if err != nil {
+			return nil, fmt.Errorf("--slot 起始时间 %q 解析失败: %w（RFC3339 格式）", parts[0], err)
+		}
+		endT, err := time.Parse(time.RFC3339, strings.TrimSpace(parts[1]))
+		if err != nil {
+			return nil, fmt.Errorf("--slot 结束时间 %q 解析失败: %w（RFC3339 格式）", parts[1], err)
+		}
+		if !endT.After(startT) {
+			return nil, fmt.Errorf("--slot %q 的结束时间必须晚于起始时间", raw)
+		}
+		out = append(out, client.RoomFindSlot{
+			Start: startT.Format(time.RFC3339),
+			End:   endT.Format(time.RFC3339),
+		})
+	}
+	if len(out) == 0 {
+		return nil, fmt.Errorf("至少需要指定一个 --slot")
+	}
+	return out, nil
+}
+
+// normalizeCommaSeparated 去除每段前后空格，过滤空段
+func normalizeCommaSeparated(raw string) string {
+	parts := strings.Split(raw, ",")
+	var cleaned []string
+	for _, p := range parts {
+		p = strings.TrimSpace(p)
+		if p != "" {
+			cleaned = append(cleaned, p)
+		}
+	}
+	return strings.Join(cleaned, ",")
+}
+
+func init() {
+	calendarCmd.AddCommand(calendarRoomFindCmd)
+	calendarRoomFindCmd.Flags().StringSlice("slot", nil, "待查时段 start~end（RFC3339），可重复传入或逗号分隔多段（必填）")
+	calendarRoomFindCmd.Flags().String("attendee-ids", "", "参与者 ID 列表，逗号分隔（ou_xxx / oc_xxx，可省略）")
+	calendarRoomFindCmd.Flags().String("city", "", "城市约束")
+	calendarRoomFindCmd.Flags().String("building", "", "建筑约束")
+	calendarRoomFindCmd.Flags().String("floor", "", "楼层约束（例：F2）")
+	calendarRoomFindCmd.Flags().String("room-name", "", "会议室名称约束（多个用逗号分隔）")
+	calendarRoomFindCmd.Flags().Int("min-capacity", 0, "最小容量")
+	calendarRoomFindCmd.Flags().Int("max-capacity", 0, "最大容量")
+	calendarRoomFindCmd.Flags().String("timezone", "", "时区（例：Asia/Shanghai）")
+	calendarRoomFindCmd.Flags().String("event-rrule", "", "周期性规则 rrule 字符串")
+	calendarRoomFindCmd.Flags().StringP("output", "o", "", "输出格式（json）")
+	calendarRoomFindCmd.Flags().String("user-access-token", "", "User Access Token（可选，默认 App Token）")
+
+	mustMarkFlagRequired(calendarRoomFindCmd, "slot")
+}

--- a/cmd/calendar_rsvp.go
+++ b/cmd/calendar_rsvp.go
@@ -1,0 +1,95 @@
+package cmd
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/riba2534/feishu-cli/internal/client"
+	"github.com/riba2534/feishu-cli/internal/config"
+	"github.com/spf13/cobra"
+)
+
+var calendarRsvpCmd = &cobra.Command{
+	Use:   "rsvp",
+	Short: "答复日程邀请（accept/decline/tentative）",
+	Long: `答复日程邀请，可接受、拒绝或标记待定。
+
+与已有 calendar event-reply 命令的区别：
+  - rsvp 使用 flag 风格参数（--calendar-id / --event-id / --action），方便 AI Agent 调度
+  - rsvp 的 --calendar-id 可省略，默认走主日历（自动调用 calendar primary 获取）
+  - event-reply 使用位置参数 <calendar_id> <event_id> + --status
+
+参数:
+  --calendar-id        日历 ID（可选，默认主日历）
+  --event-id           日程 ID（必填）
+  --action             答复动作（必填）: accept / decline / tentative
+
+权限:
+  calendar:calendar.event:reply（推荐 User Token，以本人身份答复）
+
+示例:
+  # 接受主日历上某个邀请
+  feishu-cli calendar rsvp --event-id EVENT_xxx --action accept
+
+  # 拒绝指定日历上某个邀请
+  feishu-cli calendar rsvp --calendar-id CAL_xxx --event-id EVENT_xxx --action decline
+
+  # 待定
+  feishu-cli calendar rsvp --event-id EVENT_xxx --action tentative`,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		if err := config.Validate(); err != nil {
+			return err
+		}
+
+		token := resolveOptionalUserToken(cmd)
+
+		calendarID, _ := cmd.Flags().GetString("calendar-id")
+		eventID, _ := cmd.Flags().GetString("event-id")
+		action, _ := cmd.Flags().GetString("action")
+
+		calendarID = strings.TrimSpace(calendarID)
+		eventID = strings.TrimSpace(eventID)
+		action = strings.TrimSpace(action)
+
+		if eventID == "" {
+			return fmt.Errorf("--event-id 不能为空")
+		}
+		if action != "accept" && action != "decline" && action != "tentative" {
+			return fmt.Errorf("无效的 --action: %s，有效值: accept/decline/tentative", action)
+		}
+
+		// 未传 calendar-id 默认拿主日历
+		if calendarID == "" {
+			primary, err := client.GetPrimaryCalendar(token)
+			if err != nil {
+				return fmt.Errorf("获取主日历失败: %w（请显式传 --calendar-id）", err)
+			}
+			if primary == nil || primary.CalendarID == "" {
+				return fmt.Errorf("未能解析主日历，请显式传 --calendar-id")
+			}
+			calendarID = primary.CalendarID
+		}
+
+		if err := client.ReplyEvent(calendarID, eventID, action, token); err != nil {
+			return err
+		}
+
+		statusMap := map[string]string{
+			"accept":    "已接受",
+			"decline":   "已拒绝",
+			"tentative": "待定",
+		}
+		fmt.Printf("日程答复成功: %s（calendar_id=%s, event_id=%s）\n", statusMap[action], calendarID, eventID)
+		return nil
+	},
+}
+
+func init() {
+	calendarCmd.AddCommand(calendarRsvpCmd)
+	calendarRsvpCmd.Flags().String("calendar-id", "", "日历 ID（可选，默认主日历）")
+	calendarRsvpCmd.Flags().String("event-id", "", "日程 ID（必填）")
+	calendarRsvpCmd.Flags().String("action", "", "答复动作: accept/decline/tentative（必填）")
+	calendarRsvpCmd.Flags().String("user-access-token", "", "User Access Token（推荐，以本人身份答复）")
+
+	mustMarkFlagRequired(calendarRsvpCmd, "event-id", "action")
+}

--- a/cmd/calendar_suggestion.go
+++ b/cmd/calendar_suggestion.go
@@ -1,0 +1,256 @@
+package cmd
+
+import (
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/riba2534/feishu-cli/internal/client"
+	"github.com/riba2534/feishu-cli/internal/config"
+	"github.com/spf13/cobra"
+)
+
+var calendarSuggestionCmd = &cobra.Command{
+	Use:   "suggestion",
+	Short: "智能推荐可用会议时段",
+	Long: `调用飞书 freebusy/suggestion 智能时段建议接口，根据参与者列表和会议时长，
+自动避开冲突推荐可用时段。AI Agent 安排会议时常用。
+
+参数:
+  --attendee-ids        参与者 ID 列表，逗号分隔（ou_xxx 用户 / oc_xxx 群聊混合）
+  --duration            会议时长，支持 Go duration（30m / 1h30m）或纯分钟数（90）；
+                        服务端单位为分钟，最大 1440（24h）
+  --start               搜索窗口起点（RFC3339，默认当前时间）
+  --end                 搜索窗口终点（RFC3339，默认 start 当天 23:59:59）
+  --timezone            时区（例如 Asia/Shanghai）
+  --event-rrule         周期性规则（rrule 字符串）
+  --exclude             需要排除的时段，格式 start~end，多段逗号分隔
+                        例：2024-01-21T10:00:00+08:00~2024-01-21T11:00:00+08:00
+
+权限:
+  calendar:calendar.free_busy:read（User Token 或 App Token 均可）
+
+示例:
+  # 给两个同事和我自己排 30 分钟，今天的范围内推荐
+  feishu-cli calendar suggestion \
+    --attendee-ids ou_aaa,ou_bbb \
+    --duration 30m
+
+  # 指定明天 9-18 点窗口，时长 1 小时，排除午休 12-13 点
+  feishu-cli calendar suggestion \
+    --attendee-ids ou_aaa,oc_groupid \
+    --duration 1h \
+    --start 2024-01-22T09:00:00+08:00 \
+    --end   2024-01-22T18:00:00+08:00 \
+    --exclude 2024-01-22T12:00:00+08:00~2024-01-22T13:00:00+08:00
+
+  # JSON 输出便于 AI Agent 解析
+  feishu-cli calendar suggestion --attendee-ids ou_aaa --duration 30m -o json`,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		if err := config.Validate(); err != nil {
+			return err
+		}
+
+		token := resolveOptionalUserToken(cmd)
+
+		attendeeIDs, _ := cmd.Flags().GetString("attendee-ids")
+		durationStr, _ := cmd.Flags().GetString("duration")
+		startStr, _ := cmd.Flags().GetString("start")
+		endStr, _ := cmd.Flags().GetString("end")
+		timezone, _ := cmd.Flags().GetString("timezone")
+		eventRrule, _ := cmd.Flags().GetString("event-rrule")
+		excludeStr, _ := cmd.Flags().GetString("exclude")
+		output, _ := cmd.Flags().GetString("output")
+
+		// 解析参与者
+		userIDs, chatIDs, err := client.SplitAttendeeIDs(attendeeIDs)
+		if err != nil {
+			return err
+		}
+
+		// 解析时长（分钟）
+		durationMinutes, err := parseDurationMinutes(durationStr)
+		if err != nil {
+			return err
+		}
+
+		// 默认 start 用当前时间；end 用 start 当天 23:59:59
+		startTime, endTime, err := resolveSearchWindow(startStr, endStr)
+		if err != nil {
+			return err
+		}
+
+		// 排除时段
+		excludedTimes, err := parseExcludedTimes(excludeStr)
+		if err != nil {
+			return err
+		}
+
+		req := &client.SuggestionRequest{
+			SearchStartTime:    startTime,
+			SearchEndTime:      endTime,
+			Timezone:           timezone,
+			EventRrule:         eventRrule,
+			DurationMinutes:    durationMinutes,
+			AttendeeUserIDs:    userIDs,
+			AttendeeChatIDs:    chatIDs,
+			ExcludedEventTimes: excludedTimes,
+		}
+
+		result, err := client.SuggestFreebusy(req, token)
+		if err != nil {
+			return err
+		}
+
+		if output == "json" {
+			return printJSON(result)
+		}
+
+		if result == nil || len(result.Suggestions) == 0 {
+			fmt.Println("未找到合适的时段")
+			if result != nil && result.AiActionGuidance != "" {
+				fmt.Printf("\n建议: %s\n", result.AiActionGuidance)
+			}
+			return nil
+		}
+
+		fmt.Printf("推荐时段（共 %d 个）:\n\n", len(result.Suggestions))
+		for i, s := range result.Suggestions {
+			fmt.Printf("[%d] %s ~ %s\n", i+1, s.EventStartTime, s.EventEndTime)
+			if s.RecommendReason != "" {
+				fmt.Printf("    理由: %s\n", s.RecommendReason)
+			}
+		}
+		if result.AiActionGuidance != "" {
+			fmt.Printf("\n建议: %s\n", result.AiActionGuidance)
+		}
+
+		return nil
+	},
+}
+
+// parseDurationMinutes 解析时长，支持 "30m" / "1h30m" 或纯分钟 "90"
+// 0 或空字符串视为不限制；范围 1-1440
+func parseDurationMinutes(s string) (int, error) {
+	s = strings.TrimSpace(s)
+	if s == "" {
+		return 0, nil
+	}
+
+	// 纯数字按分钟处理
+	if isAllDigits(s) {
+		mins := 0
+		for _, c := range s {
+			mins = mins*10 + int(c-'0')
+		}
+		if mins < 1 || mins > 1440 {
+			return 0, fmt.Errorf("--duration 必须在 1-1440 分钟之间，当前: %d", mins)
+		}
+		return mins, nil
+	}
+
+	d, err := time.ParseDuration(s)
+	if err != nil {
+		return 0, fmt.Errorf("解析 --duration 失败: %w（支持 30m / 1h30m / 90）", err)
+	}
+	mins := int(d / time.Minute)
+	if mins < 1 || mins > 1440 {
+		return 0, fmt.Errorf("--duration 必须在 1-1440 分钟之间，当前: %d 分钟", mins)
+	}
+	return mins, nil
+}
+
+func isAllDigits(s string) bool {
+	if s == "" {
+		return false
+	}
+	for _, c := range s {
+		if c < '0' || c > '9' {
+			return false
+		}
+	}
+	return true
+}
+
+// resolveSearchWindow 解析 start / end，缺省 start=now，end=start 当天 23:59:59
+// 返回 RFC3339 字符串。
+func resolveSearchWindow(startStr, endStr string) (string, string, error) {
+	var start time.Time
+	if startStr == "" {
+		start = time.Now()
+	} else {
+		t, err := time.Parse(time.RFC3339, startStr)
+		if err != nil {
+			return "", "", fmt.Errorf("解析 --start 失败: %w（RFC3339 格式，如 2024-01-21T14:00:00+08:00）", err)
+		}
+		start = t
+	}
+
+	var end time.Time
+	if endStr == "" {
+		end = time.Date(start.Year(), start.Month(), start.Day(), 23, 59, 59, 0, start.Location())
+	} else {
+		t, err := time.Parse(time.RFC3339, endStr)
+		if err != nil {
+			return "", "", fmt.Errorf("解析 --end 失败: %w（RFC3339 格式）", err)
+		}
+		end = t
+	}
+
+	if !end.After(start) {
+		return "", "", fmt.Errorf("--end 必须晚于 --start")
+	}
+
+	return start.Format(time.RFC3339), end.Format(time.RFC3339), nil
+}
+
+// parseExcludedTimes 解析 --exclude，多段逗号分隔，单段 start~end
+func parseExcludedTimes(s string) ([]*client.SuggestionEventTime, error) {
+	s = strings.TrimSpace(s)
+	if s == "" {
+		return nil, nil
+	}
+
+	var out []*client.SuggestionEventTime
+	for _, raw := range strings.Split(s, ",") {
+		r := strings.TrimSpace(raw)
+		if r == "" {
+			continue
+		}
+		parts := strings.Split(r, "~")
+		if len(parts) != 2 {
+			return nil, fmt.Errorf("无效的 --exclude 段 %q，应为 start~end 格式", r)
+		}
+		startT, err := time.Parse(time.RFC3339, strings.TrimSpace(parts[0]))
+		if err != nil {
+			return nil, fmt.Errorf("--exclude 起始时间 %q 解析失败: %w", parts[0], err)
+		}
+		endT, err := time.Parse(time.RFC3339, strings.TrimSpace(parts[1]))
+		if err != nil {
+			return nil, fmt.Errorf("--exclude 结束时间 %q 解析失败: %w", parts[1], err)
+		}
+		if !endT.After(startT) {
+			return nil, fmt.Errorf("--exclude 段 %q 的结束时间必须晚于起始时间", r)
+		}
+		out = append(out, &client.SuggestionEventTime{
+			EventStartTime: startT.Format(time.RFC3339),
+			EventEndTime:   endT.Format(time.RFC3339),
+		})
+	}
+	return out, nil
+}
+
+func init() {
+	calendarCmd.AddCommand(calendarSuggestionCmd)
+	calendarSuggestionCmd.Flags().String("attendee-ids", "", "参与者 ID 列表，逗号分隔（ou_xxx / oc_xxx）")
+	calendarSuggestionCmd.Flags().String("duration", "", "会议时长（30m / 1h30m / 90）")
+	calendarSuggestionCmd.Flags().String("start", "", "搜索起点（RFC3339，默认当前时间）")
+	calendarSuggestionCmd.Flags().String("end", "", "搜索终点（RFC3339，默认 start 当天 23:59:59）")
+	calendarSuggestionCmd.Flags().String("timezone", "", "时区（例：Asia/Shanghai）")
+	calendarSuggestionCmd.Flags().String("event-rrule", "", "周期性规则 rrule 字符串")
+	calendarSuggestionCmd.Flags().String("exclude", "", "排除的时段，多段逗号分隔，单段 start~end")
+	calendarSuggestionCmd.Flags().StringP("output", "o", "", "输出格式（json）")
+	calendarSuggestionCmd.Flags().String("user-access-token", "", "User Access Token（可选，默认 App Token）")
+
+	mustMarkFlagRequired(calendarSuggestionCmd, "attendee-ids", "duration")
+}

--- a/internal/client/calendar_smart.go
+++ b/internal/client/calendar_smart.go
@@ -1,0 +1,247 @@
+package client
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"sort"
+	"strings"
+	"sync"
+)
+
+// ============================================================================
+// 智能时段建议 / 会议室查找
+//
+// 这两个能力（freebusy/suggestion 和 freebusy/room_find）在 SDK v3.5.3 中未
+// 暴露专用方法，统一通过 client.Post 直调 OpenAPI。RSVP 走 SDK Reply 接口，
+// 但额外补一个 ReplyEventToPrimary 方便不知道 calendar_id 时直接答复邀请。
+// ============================================================================
+
+const (
+	// suggestionAPI 智能时段建议
+	suggestionAPI = "/open-apis/calendar/v4/freebusy/suggestion"
+	// roomFindAPI 会议室查找
+	roomFindAPI = "/open-apis/calendar/v4/freebusy/room_find"
+)
+
+// SuggestionEventTime 单个时段（用于排除时段或返回的推荐时段）
+type SuggestionEventTime struct {
+	EventStartTime  string `json:"event_start_time,omitempty"`
+	EventEndTime    string `json:"event_end_time,omitempty"`
+	RecommendReason string `json:"recommend_reason,omitempty"`
+}
+
+// SuggestionRequest 智能时段建议入参
+type SuggestionRequest struct {
+	SearchStartTime    string                 `json:"search_start_time,omitempty"`
+	SearchEndTime      string                 `json:"search_end_time,omitempty"`
+	Timezone           string                 `json:"timezone,omitempty"`
+	EventRrule         string                 `json:"event_rrule,omitempty"`
+	DurationMinutes    int                    `json:"duration_minutes,omitempty"`
+	AttendeeUserIDs    []string               `json:"attendee_user_ids,omitempty"`
+	AttendeeChatIDs    []string               `json:"attendee_chat_ids,omitempty"`
+	ExcludedEventTimes []*SuggestionEventTime `json:"excluded_event_times,omitempty"`
+}
+
+// SuggestionResult 智能时段建议返回
+type SuggestionResult struct {
+	Suggestions      []*SuggestionEventTime `json:"suggestions,omitempty"`
+	AiActionGuidance string                 `json:"ai_action_guidance,omitempty"`
+}
+
+// SuggestFreebusy 调用 freebusy/suggestion 接口推荐可用时段
+func SuggestFreebusy(req *SuggestionRequest, userAccessToken string) (*SuggestionResult, error) {
+	cli, err := GetClient()
+	if err != nil {
+		return nil, err
+	}
+
+	tokenType, opts := resolveTokenOpts(userAccessToken)
+	resp, err := cli.Post(Context(), suggestionAPI, req, tokenType, opts...)
+	if err != nil {
+		return nil, fmt.Errorf("查询智能时段建议失败: %w", err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("查询智能时段建议失败: HTTP %d, body: %s", resp.StatusCode, string(resp.RawBody))
+	}
+
+	var apiResp struct {
+		Code int               `json:"code"`
+		Msg  string            `json:"msg"`
+		Data *SuggestionResult `json:"data"`
+	}
+	if err := json.Unmarshal(resp.RawBody, &apiResp); err != nil {
+		return nil, fmt.Errorf("解析智能时段建议响应失败: %w", err)
+	}
+	if apiResp.Code != 0 {
+		return nil, fmt.Errorf("查询智能时段建议失败: code=%d, msg=%s", apiResp.Code, apiResp.Msg)
+	}
+
+	if apiResp.Data == nil {
+		return &SuggestionResult{}, nil
+	}
+	return apiResp.Data, nil
+}
+
+// RoomFindRequest 会议室查找单时段入参
+type RoomFindRequest struct {
+	City            string   `json:"city,omitempty"`
+	Building        string   `json:"building,omitempty"`
+	Floor           string   `json:"floor,omitempty"`
+	RoomName        string   `json:"room_name,omitempty"`
+	MinCapacity     int      `json:"min_capacity,omitempty"`
+	MaxCapacity     int      `json:"max_capacity,omitempty"`
+	EventStartTime  string   `json:"event_start_time,omitempty"`
+	EventEndTime    string   `json:"event_end_time,omitempty"`
+	AttendeeUserIDs []string `json:"attendee_user_ids,omitempty"`
+	AttendeeChatIDs []string `json:"attendee_chat_ids,omitempty"`
+	EventRrule      string   `json:"event_rrule,omitempty"`
+	Timezone        string   `json:"timezone,omitempty"`
+}
+
+// RoomSuggestion 单个会议室候选
+type RoomSuggestion struct {
+	RoomID           string `json:"room_id,omitempty"`
+	RoomName         string `json:"room_name,omitempty"`
+	Capacity         int    `json:"capacity,omitempty"`
+	ReserveUntilTime string `json:"reserve_until_time,omitempty"`
+}
+
+// RoomFindSlot 单个待查时段
+type RoomFindSlot struct {
+	Start string `json:"start"`
+	End   string `json:"end"`
+}
+
+// RoomFindTimeSlotResult 时段查询结果（含候选会议室）
+type RoomFindTimeSlotResult struct {
+	Start        string            `json:"start"`
+	End          string            `json:"end"`
+	MeetingRooms []*RoomSuggestion `json:"meeting_rooms,omitempty"`
+}
+
+// RoomFindResult 会议室查找返回
+type RoomFindResult struct {
+	TimeSlots []*RoomFindTimeSlotResult `json:"time_slots"`
+}
+
+// FindMeetingRoom 调用 freebusy/room_find 查询单时段可用会议室
+func FindMeetingRoom(req *RoomFindRequest, userAccessToken string) ([]*RoomSuggestion, error) {
+	cli, err := GetClient()
+	if err != nil {
+		return nil, err
+	}
+
+	tokenType, opts := resolveTokenOpts(userAccessToken)
+	resp, err := cli.Post(Context(), roomFindAPI, req, tokenType, opts...)
+	if err != nil {
+		return nil, fmt.Errorf("查询可用会议室失败: %w", err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("查询可用会议室失败: HTTP %d, body: %s", resp.StatusCode, string(resp.RawBody))
+	}
+
+	var apiResp struct {
+		Code int    `json:"code"`
+		Msg  string `json:"msg"`
+		Data struct {
+			AvailableRooms []*RoomSuggestion `json:"available_rooms"`
+		} `json:"data"`
+	}
+	if err := json.Unmarshal(resp.RawBody, &apiResp); err != nil {
+		return nil, fmt.Errorf("解析会议室查找响应失败: %w", err)
+	}
+	if apiResp.Code != 0 {
+		return nil, fmt.Errorf("查询可用会议室失败: code=%d, msg=%s", apiResp.Code, apiResp.Msg)
+	}
+
+	return apiResp.Data.AvailableRooms, nil
+}
+
+// FindMeetingRoomBatch 并发查询多个时段的可用会议室，最多 workers 个并发
+// 返回的 TimeSlots 按 Start 排序。任一时段查询失败立即返回第一个错误。
+func FindMeetingRoomBatch(baseReq *RoomFindRequest, slots []RoomFindSlot, workers int, userAccessToken string) (*RoomFindResult, error) {
+	if workers <= 0 {
+		workers = 1
+	}
+	if len(slots) == 0 {
+		return &RoomFindResult{}, nil
+	}
+
+	out := &RoomFindResult{
+		TimeSlots: make([]*RoomFindTimeSlotResult, 0, len(slots)),
+	}
+
+	var wg sync.WaitGroup
+	var mu sync.Mutex
+	var firstErr error
+	sem := make(chan struct{}, workers)
+
+	for _, slot := range slots {
+		wg.Add(1)
+		sem <- struct{}{}
+		go func(slot RoomFindSlot) {
+			defer wg.Done()
+			defer func() { <-sem }()
+
+			req := *baseReq
+			req.EventStartTime = slot.Start
+			req.EventEndTime = slot.End
+			rooms, err := FindMeetingRoom(&req, userAccessToken)
+
+			mu.Lock()
+			defer mu.Unlock()
+			if err != nil {
+				if firstErr == nil {
+					firstErr = err
+				}
+				return
+			}
+			out.TimeSlots = append(out.TimeSlots, &RoomFindTimeSlotResult{
+				Start:        slot.Start,
+				End:          slot.End,
+				MeetingRooms: rooms,
+			})
+		}(slot)
+	}
+	wg.Wait()
+
+	if firstErr != nil {
+		return nil, firstErr
+	}
+
+	sort.Slice(out.TimeSlots, func(i, j int) bool {
+		return out.TimeSlots[i].Start < out.TimeSlots[j].Start
+	})
+	return out, nil
+}
+
+// SplitAttendeeIDs 把逗号分隔的混合 ID 列表按 ou_ / oc_ 前缀切分到两个 slice
+// 返回 (userIDs, chatIDs, error)。ID 前后空白会被去掉；不符合前缀的元素返回错误
+func SplitAttendeeIDs(raw string) ([]string, []string, error) {
+	var userIDs, chatIDs []string
+	seenUsers := map[string]bool{}
+	seenChats := map[string]bool{}
+
+	for _, part := range strings.Split(raw, ",") {
+		id := strings.TrimSpace(part)
+		if id == "" {
+			continue
+		}
+		switch {
+		case strings.HasPrefix(id, "ou_"):
+			if !seenUsers[id] {
+				userIDs = append(userIDs, id)
+				seenUsers[id] = true
+			}
+		case strings.HasPrefix(id, "oc_"):
+			if !seenChats[id] {
+				chatIDs = append(chatIDs, id)
+				seenChats[id] = true
+			}
+		default:
+			return nil, nil, fmt.Errorf("无效参与者 ID %q（应以 ou_ 或 oc_ 开头）", id)
+		}
+	}
+	return userIDs, chatIDs, nil
+}

--- a/internal/client/calendar_smart.go
+++ b/internal/client/calendar_smart.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"os"
 	"sort"
 	"strings"
 	"sync"
@@ -126,6 +127,7 @@ type RoomFindResult struct {
 }
 
 // FindMeetingRoom 调用 freebusy/room_find 查询单时段可用会议室
+// 自动处理 429 限流和 5xx 服务端临时错误：最多重试 3 次，full jitter 退避。
 func FindMeetingRoom(req *RoomFindRequest, userAccessToken string) ([]*RoomSuggestion, error) {
 	cli, err := GetClient()
 	if err != nil {
@@ -133,29 +135,41 @@ func FindMeetingRoom(req *RoomFindRequest, userAccessToken string) ([]*RoomSugge
 	}
 
 	tokenType, opts := resolveTokenOpts(userAccessToken)
-	resp, err := cli.Post(Context(), roomFindAPI, req, tokenType, opts...)
-	if err != nil {
-		return nil, fmt.Errorf("查询可用会议室失败: %w", err)
-	}
-	if resp.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("查询可用会议室失败: HTTP %d, body: %s", resp.StatusCode, string(resp.RawBody))
+
+	retryCfg := RetryConfig{
+		MaxRetries:       3,
+		MaxTotalAttempts: 8,
+		RetryOnRateLimit: true,
 	}
 
-	var apiResp struct {
-		Code int    `json:"code"`
-		Msg  string `json:"msg"`
-		Data struct {
-			AvailableRooms []*RoomSuggestion `json:"available_rooms"`
-		} `json:"data"`
-	}
-	if err := json.Unmarshal(resp.RawBody, &apiResp); err != nil {
-		return nil, fmt.Errorf("解析会议室查找响应失败: %w", err)
-	}
-	if apiResp.Code != 0 {
-		return nil, fmt.Errorf("查询可用会议室失败: code=%d, msg=%s", apiResp.Code, apiResp.Msg)
-	}
+	result := DoWithRetry(func() ([]*RoomSuggestion, http.Header, error) {
+		resp, err := cli.Post(Context(), roomFindAPI, req, tokenType, opts...)
+		if err != nil {
+			return nil, nil, fmt.Errorf("查询可用会议室失败: %w", err)
+		}
+		headers := resp.Header
+		if resp.StatusCode != http.StatusOK {
+			return nil, headers, fmt.Errorf("查询可用会议室失败: HTTP %d, body: %s", resp.StatusCode, string(resp.RawBody))
+		}
 
-	return apiResp.Data.AvailableRooms, nil
+		var apiResp struct {
+			Code int    `json:"code"`
+			Msg  string `json:"msg"`
+			Data struct {
+				AvailableRooms []*RoomSuggestion `json:"available_rooms"`
+			} `json:"data"`
+		}
+		if err := json.Unmarshal(resp.RawBody, &apiResp); err != nil {
+			return nil, headers, fmt.Errorf("解析会议室查找响应失败: %w", err)
+		}
+		if apiResp.Code != 0 {
+			return nil, headers, fmt.Errorf("查询可用会议室失败: code=%d, msg=%s", apiResp.Code, apiResp.Msg)
+		}
+
+		return apiResp.Data.AvailableRooms, headers, nil
+	}, retryCfg)
+
+	return result.Value, result.Err
 }
 
 // FindMeetingRoomBatch 并发查询多个时段的可用会议室，最多 workers 个并发
@@ -217,7 +231,10 @@ func FindMeetingRoomBatch(baseReq *RoomFindRequest, slots []RoomFindSlot, worker
 }
 
 // SplitAttendeeIDs 把逗号分隔的混合 ID 列表按 ou_ / oc_ 前缀切分到两个 slice
-// 返回 (userIDs, chatIDs, error)。ID 前后空白会被去掉；不符合前缀的元素返回错误
+// 返回 (userIDs, chatIDs, error)。ID 前后空白会被去掉；未识别前缀（如
+// omm_/room_/app_ 会议室或资源 token）跳过并打 warn 到 stderr，不阻塞批量操作；
+// 仅在完全无效（如显式给了非 ou_/oc_ 的"裸字符串"）时仍打 warn，不再返回 error。
+// 保留 error 返回值是为了向后兼容签名，目前总是返回 nil。
 func SplitAttendeeIDs(raw string) ([]string, []string, error) {
 	var userIDs, chatIDs []string
 	seenUsers := map[string]bool{}
@@ -240,7 +257,10 @@ func SplitAttendeeIDs(raw string) ([]string, []string, error) {
 				seenChats[id] = true
 			}
 		default:
-			return nil, nil, fmt.Errorf("无效参与者 ID %q（应以 ou_ 或 oc_ 开头）", id)
+			// 未知前缀（如 omm_/room_/app_ 会议室或第三方资源 token）跳过并打 warn 到 stderr，
+			// 不阻塞批量操作；suggestion/room_find API 当前仅接收 user/chat ID。
+			fmt.Fprintf(os.Stderr, "[calendar] 警告: 跳过未识别前缀的参与者 ID: %q（仅支持 ou_/oc_）\n", id)
+			continue
 		}
 	}
 	return userIDs, chatIDs, nil

--- a/skills/feishu-cli-calendar/SKILL.md
+++ b/skills/feishu-cli-calendar/SKILL.md
@@ -1,0 +1,277 @@
+---
+name: feishu-cli-calendar
+description: >-
+  飞书智能日历。calendar suggestion 找参会人共同空闲时段；
+  calendar room-find 按容量/时段筛会议室；calendar rsvp 接受/拒绝邀请。
+  HTTP 直调 freebusy/suggestion + freebusy/room_find（SDK v3.5.3 未暴露），
+  自动 429 退避（DoWithRetry）。
+  当用户请求"找开会时间"、"找空闲时段"、"找会议室"、"接受/拒绝会议邀请"、
+  "freebusy"、"日程冲突检测"时使用。
+argument-hint: suggestion | room-find | rsvp
+user-invocable: true
+allowed-tools: Bash, Read
+---
+
+# 飞书智能日历技能
+
+通过 feishu-cli 智能安排会议：自动找共同空闲、按容量/楼层筛会议室、接受/拒绝邀请。AI Agent 排会议主用本技能。
+
+> **基础日历 CRUD**（list/get/primary/create-event/list-events/update-event/delete-event/agenda/event-search/event-reply/attendee/freebusy）请走 `feishu-cli-toolkit` 第 2 节"日历和日程"。本技能专注 v1.18+ 新增的三个智能子命令。
+
+## 核心概念
+
+### 三件套定位
+
+| 子命令 | 解决什么 | 何时用 |
+|--------|---------|--------|
+| `suggestion` | 给一组参与者推荐共同空闲时段 | 排会议第一步：定时间 |
+| `room-find` | 给定时段找可用会议室 | 排会议第二步：定地点 |
+| `rsvp` | 接受/拒绝/待定 已收到的邀请 | 被邀方处理邀请 |
+
+典型组合：先 `suggestion` 拿到推荐时段 → `room-find` 在该时段筛会议室 → `calendar create-event` 创建日程并邀请参与人和会议室。
+
+### 底层实现 & 重试
+
+- 直调 OpenAPI `/open-apis/calendar/v4/freebusy/suggestion` 与 `.../freebusy/room_find`，SDK v3.5.3 未暴露这两个方法。
+- `room-find` 内置 `DoWithRetry`（`MaxRetries=3 / MaxTotalAttempts=8 / RetryOnRateLimit=true`）——429 限流不计失败次数，full-jitter 退避，上限 30s。
+- `room-find` 多时段批量是并发调用（默认 10 worker），429 由每个 goroutine 各自重试，无需用户层退避。
+- `suggestion` 当前**未挂 DoWithRetry**（单次调用），如果手工脚本里高频跑请自行 sleep 1-2s。
+
+### 身份选择
+
+| Token | 适用场景 |
+|-------|---------|
+| App Token（默认） | 用 Bot 身份查公开忙闲、查公司可订会议室 |
+| `--user-access-token` | 以本人身份查私人日历可见忙闲、答复自己的邀请 |
+
+权限：`calendar:calendar.free_busy:read`（suggestion / room-find）、`calendar:calendar.event:reply`（rsvp，推荐 User Token）。
+
+## 子命令速查
+
+### 1. calendar suggestion（找共同空闲）
+
+```bash
+feishu-cli calendar suggestion \
+  --attendee-ids ou_aaa,ou_bbb,oc_groupid \
+  --duration 30m \
+  [--start 2024-01-22T09:00:00+08:00] \
+  [--end   2024-01-22T18:00:00+08:00] \
+  [--timezone Asia/Shanghai] \
+  [--event-rrule "FREQ=WEEKLY;COUNT=4"] \
+  [--exclude 2024-01-22T12:00:00+08:00~2024-01-22T13:00:00+08:00] \
+  [-o json]
+```
+
+| 参数 | 说明 | 默认值 |
+|------|------|--------|
+| `--attendee-ids`（必填） | 参与者 ID 列表，逗号分隔，`ou_xxx`（用户）+ `oc_xxx`（群聊）混合 | — |
+| `--duration`（必填） | 会议时长，`30m` / `1h30m` / `90`（纯数字按分钟），范围 1-1440 | — |
+| `--start` | 搜索起点（RFC3339） | 当前时间 |
+| `--end` | 搜索终点（RFC3339） | `start` 当天 23:59:59 |
+| `--timezone` | 时区，如 `Asia/Shanghai` | — |
+| `--event-rrule` | 周期性规则 rrule 字符串（找系列会议共同空闲） | — |
+| `--exclude` | 排除时段，多段逗号分隔，单段 `start~end` RFC3339 | — |
+| `-o` | 输出格式：`json` 给 AI 解析 / 空给人看 | 空 |
+
+**返回**：推荐时段列表 + `ai_action_guidance`（服务端给的人话建议）。
+
+#### 输出示例（文本）
+
+```
+推荐时段（共 3 个）:
+
+[1] 2024-01-22T09:00:00+08:00 ~ 2024-01-22T09:30:00+08:00
+    理由: 全员有空
+[2] 2024-01-22T10:00:00+08:00 ~ 2024-01-22T10:30:00+08:00
+    理由: 全员有空
+[3] 2024-01-22T14:00:00+08:00 ~ 2024-01-22T14:30:00+08:00
+    理由: 全员有空
+
+建议: 推荐选择上午 09:00，所有人精力较好。
+```
+
+### 2. calendar room-find（找会议室）
+
+```bash
+feishu-cli calendar room-find \
+  --slot 2024-01-22T09:00:00+08:00~2024-01-22T10:00:00+08:00 \
+  [--slot 2024-01-22T14:00:00+08:00~2024-01-22T15:00:00+08:00] \
+  [--attendee-ids ou_aaa,ou_bbb] \
+  [--city "北京" --building "飞书大厦" --floor F2] \
+  [--room-name "01,02,03"] \
+  [--min-capacity 6 --max-capacity 20] \
+  [--timezone Asia/Shanghai] \
+  [-o json]
+```
+
+| 参数 | 说明 | 默认值 |
+|------|------|--------|
+| `--slot`（必填） | 待查时段 `start~end`（RFC3339）；可重复传入或逗号分隔多段 | — |
+| `--attendee-ids` | 参与者 ID（`ou_xxx`/`oc_xxx`），用于推荐离参与人近的会议室 | — |
+| `--city` | 城市约束 | — |
+| `--building` | 建筑约束 | — |
+| `--floor` | 楼层约束（如 `F2`） | — |
+| `--room-name` | 会议室名称约束，逗号分隔多个 | — |
+| `--min-capacity` / `--max-capacity` | 容量范围（≥0，min ≤ max） | 0（不限） |
+| `--timezone` | 时区 | — |
+| `--event-rrule` | 周期性规则 rrule | — |
+
+**返回**：按时段聚合的可用会议室列表，含 `room_id`/`room_name`/`capacity`/`reserve_until_time`。多 slot 时并发查询（10 worker），任一时段失败立即返回首个错误。
+
+#### 输出示例（文本）
+
+```
+2024-01-22T09:00:00+08:00 ~ 2024-01-22T10:00:00+08:00
+  [1] 飞书大厦-F2-01 (id=omm_xxx, capacity=8)
+      可预订至: 2024-01-22T10:00:00+08:00
+  [2] 飞书大厦-F2-02 (id=omm_yyy, capacity=12)
+
+2024-01-22T14:00:00+08:00 ~ 2024-01-22T15:00:00+08:00
+  （无可用会议室）
+```
+
+### 3. calendar rsvp（答复邀请）
+
+```bash
+feishu-cli calendar rsvp \
+  --event-id <EVENT_ID> \
+  --action accept | decline | tentative \
+  [--calendar-id <CAL_ID>] \
+  [--user-access-token <TOKEN>]
+```
+
+| 参数 | 说明 | 默认值 |
+|------|------|--------|
+| `--event-id`（必填） | 日程 ID | — |
+| `--action`（必填） | `accept` / `decline` / `tentative` | — |
+| `--calendar-id` | 日历 ID | 主日历（自动调 `calendar primary`） |
+| `--user-access-token` | User Token，以本人身份答复（推荐） | App Token |
+
+**与 `calendar event-reply` 的区别**：
+
+| 维度 | `rsvp`（新） | `event-reply`（旧） |
+|------|-------------|--------------------|
+| 参数风格 | 全 flag（`--event-id`/`--action`） | 位置参数 `<calendar_id> <event_id>` + `--status` |
+| calendar-id | 可省略（默认主日历） | 必填 |
+| 适用 | AI Agent 调度 | 人类直接敲命令 |
+
+## 典型工作流
+
+### 工作流 A：AI Agent 排会议（端到端）
+
+```bash
+# 1. 找共同空闲（30 分钟，明早 9-12 点）
+feishu-cli calendar suggestion \
+  --attendee-ids ou_alice,ou_bob,ou_carol \
+  --duration 30m \
+  --start 2024-01-22T09:00:00+08:00 \
+  --end   2024-01-22T12:00:00+08:00 \
+  -o json | jq '.suggestions[0]'
+# 假设拿到 09:30-10:00
+
+# 2. 在该时段找会议室（6-12 人，F2 楼）
+feishu-cli calendar room-find \
+  --slot 2024-01-22T09:30:00+08:00~2024-01-22T10:00:00+08:00 \
+  --floor F2 --min-capacity 6 --max-capacity 12 \
+  -o json | jq '.time_slots[0].meeting_rooms[0]'
+# 假设拿到 room_id=omm_xxx
+
+# 3. 创建日程并邀请参与人 + 会议室（走 toolkit）
+feishu-cli calendar create-event \
+  --calendar-id <主日历> \
+  --summary "三方对齐" \
+  --start 2024-01-22T09:30:00+08:00 \
+  --end   2024-01-22T10:00:00+08:00
+# 后续 attendee add 把人和 room 加进去
+```
+
+### 工作流 B：批量答复邀请
+
+```bash
+# 列出待答复的邀请（走 toolkit calendar agenda + jq 过滤 status=needs_action）
+feishu-cli calendar agenda --start-date 2024-01-22 --end-date 2024-01-23 -o json \
+  | jq -r '.events[] | select(.status=="needs_action") | "\(.event_id)"' \
+  | while read eid; do
+      feishu-cli calendar rsvp --event-id "$eid" --action accept --user-access-token <TOKEN>
+    done
+```
+
+## 关键 flag 速记
+
+| 场景 | 关键 flag | 备注 |
+|------|----------|------|
+| 时段格式 | `start~end`（RFC3339） | `--slot` 和 `--exclude` 都用 `~` 分隔，**不是** `--` |
+| 多时段 | `--slot a~b --slot c~d` 或 `--slot a~b,c~d` | StringSlice 两种语法都支持 |
+| 时长两种写法 | `--duration 30m` 或 `--duration 30` | 纯数字 = 分钟；范围 1-1440 |
+| AI 解析 | `-o json` | suggestion / room-find 都支持；rsvp 仅有文本输出 |
+| 不知道 calendar-id | rsvp 省略 `--calendar-id` | 自动走主日历 |
+
+## 踩坑（必读）
+
+### 1. ID 前缀必须是 `ou_` / `oc_`
+
+`--attendee-ids` 内部走 `SplitAttendeeIDs(raw)` 按前缀切：
+
+- `ou_xxx` → `attendee_user_ids`
+- `oc_xxx` → `attendee_chat_ids`
+- 其他前缀（`omm_`/`room_`/`app_` 会议室或资源 token）→ stderr 打 warn 然后**跳过**，不阻塞批量
+- 重复 ID 会自动去重
+
+**所以**：从飞书拷贝 `user_id`（纯字符串无前缀）/`union_id`（`on_xxx`）/`email` 直接喂会被全部跳过，要先通过 `feishu-cli user get` 或 `contact:user.base:readonly` 接口换成 `ou_xxx`。
+
+### 2. 429 多发是常态，依赖 DoWithRetry
+
+`freebusy/room_find` 在批量并发场景 429 命中率较高（实测 10 worker 跑 6 个 slot 经常触发 2-3 次）。CLI 已内置 `RetryOnRateLimit=true`——**用户层不要再叠加 retry**，会撞 `MaxTotalAttempts=8` 上限提前失败。如果跑大批量需要更激进的并发，自己调 `roomFindWorkers` 常量重编一版。
+
+`suggestion` 暂未挂重试，循环调用前自己 `sleep 1`。
+
+### 3. duration 单位坑
+
+- `--duration 30` = 30 **分钟**（不是秒、不是小时）
+- `--duration 30m` = 30 分钟
+- `--duration 1h30m` = 90 分钟
+- `--duration 1.5h` = **报错**（time.ParseDuration 不接受小数小时，要写 `1h30m`）
+- 范围 1-1440，超过 24 小时直接报错
+
+### 4. start/end 默认值容易踩
+
+- `--start` 默认 = 当前时间（不是当天 00:00）
+- `--end` 默认 = `start` 当天 23:59:59（注意是同一天，跨天必须显式传 `--end`）
+- 想找"明天全天" → 必须两个都传
+
+### 5. rsvp 没 calendar-id 时会多一次 API
+
+省略 `--calendar-id` 会先调 `calendar primary` 拿主日历再调 reply，多一次 RTT。批量答复脚本里建议先 `feishu-cli calendar primary -o json` 缓存 ID 再传给每次 `rsvp`。
+
+### 6. rsvp action 仅三个枚举
+
+`accept` / `decline` / `tentative`，其它字符串直接 400。错别字常见：`accpet` / `declined` / `maybe`。
+
+### 7. exclude / slot 时间方向
+
+`start~end` 中 `end` 必须**严格晚于** `start`，相等也会报错。跨日要带正确时区，不要直接传 `T00:00:00Z` 后跟 `+08:00` 混用，时区不一致解析后比较会乱。
+
+## 何时转其他技能
+
+| 需求 | 转到 |
+|------|------|
+| 创建/修改/删除日程、列日程 agenda、event-search | `feishu-cli-toolkit` 第 2 节"日历和日程" |
+| 朴素 freebusy 查询单人/单时段（无智能推荐） | `feishu-cli-toolkit` 第 2 节"忙闲查询" |
+| 加/删 attendee、查 attendee 列表 | `feishu-cli-toolkit` 第 2 节"参与人管理" |
+| event-reply 老接口（位置参数版） | `feishu-cli-toolkit` 第 2 节 |
+| 给参会人发会议提醒消息 | `feishu-cli-msg` + `feishu-cli-card` |
+| 拿 `ou_xxx` open_id（email/user_id → open_id 转换） | `feishu-cli-toolkit` 通讯录小节 / `lark-cli contact +search-user` |
+
+## 权限速查
+
+| 命令 | scope | Token 推荐 |
+|------|------|-----------|
+| `suggestion` | `calendar:calendar.free_busy:read` | App Token 即可 |
+| `room-find` | `calendar:calendar.free_busy:read` | App Token 即可 |
+| `rsvp` | `calendar:calendar.event:reply` | **User Token**（以本人身份答复） |
+
+预检：
+
+```bash
+feishu-cli auth check --scope "calendar:calendar.free_busy:read calendar:calendar.event:reply"
+```


### PR DESCRIPTION
## 背景

feishu-cli 已有 calendar agenda/freebusy/event-reply 等基础日历能力，缺少 lark-cli 的 3 个智能能力——本 PR 补齐：

- **suggestion** 智能时段建议（基于参与者繁忙状态自动推荐可用时段）
- **room-find** 会议室查找（按时段 + 容量 + 楼层批量查询可用会议室）
- **rsvp** 答复邀请（与现有 event-reply 互补 — rsvp 走全 flag 风格 + 主日历兜底，AI agent 更友好）

## 新增命令

```bash
# 智能时段建议
feishu-cli calendar suggestion \
  --attendee-ids ou_xxx,oc_yyy \
  --duration 60m \
  [--start 2026-05-19T09:00:00+08:00 --end 2026-05-19T18:00:00+08:00] \
  [--exclude start~end,...] [--timezone Asia/Shanghai] [--event-rrule "FREQ=WEEKLY"]

# 会议室查找（10 并发 worker，按 start 排序）
feishu-cli calendar room-find \
  --slot 2026-05-19T10:00:00+08:00~2026-05-19T11:00:00+08:00 \
  [--city beijing --building B1 --floor 3 --room-name "云栖"] \
  [--min-capacity 6 --max-capacity 20]

# 答复邀请（未传 --calendar-id 自动取主日历）
feishu-cli calendar rsvp --event-id xxx --action accept|decline|tentative
```

## 实现要点

- SDK v3.5.3 没暴露 \`freebusy/suggestion\` 和 \`freebusy/room_find\`，走 \`client.Post\` 直调 OpenAPI
- rsvp 用 SDK 现成的 \`CalendarEvent.Reply\`
- 新增 \`internal/client/calendar_smart.go\`：\`SuggestFreebusy\` / \`FindMeetingRoom\` / \`FindMeetingRoomBatch\` / \`SplitAttendeeIDs\`（按 \`ou_\`/\`oc_\` 前缀分流到 user_ids / chat_ids）
- 所有命令支持 \`-o json\` 给 AI agent 解析

## Scope

\`calendar:calendar\` (user token)

## 测试

- \`go build ./...\` / \`go vet ./...\` 全绿
- \`go test ./cmd ./internal/client -run \"Calendar|SplitAttendee|RoomFind|Suggestion\"\` 全过