### PR TITLE
feat(slides): 新增飞书 Slides 模块（create / media-upload）

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,40 @@
 
 ## 未发布
 
+### 新增 — `slides` 模块：Slides 演示文稿创建与媒体上传
+
+新增 `feishu-cli slides` 顶层命令，提供两个子命令支撑 Slides 演示文稿的最小可用工作流：
+
+- `slides create [--title <name>] [--width <px>] [--height <px>] [--output json]`
+  调用 `POST /open-apis/slides_ai/v1/xml_presentations` 创建空白演示文稿，返回 `xml_presentation_id` /
+  `revision_id` / `title`。默认尺寸 960x540。
+- `slides media-upload --file <path> --presentation-token <xml_presentation_id> [--output json]`
+  本地图片走 `/open-apis/drive/v1/medias/upload_all` 上传到指定演示文稿，返回 `file_token`
+  可直接作为 slide XML 中 `<img src="...">` 引用。
+
+**关键实现细节**：
+
+- 上传 `parent_type` 固定为 `slide_file`（lark-cli 实测：`slide_image` / `slides_image` /
+  `slides_file` 都会被拒）；`parent_node` 必须为目标 `xml_presentation_id`
+- 单文件上限 20 MB（多分片 `upload_prepare` 不接受 `parent_type=slide_file`）
+- 共用 `internal/client/drive.go::UploadMediaWithExtra` 上传链路
+
+**权限要求**：
+
+- 创建：`slides:presentation:create` 或 `slides:presentation:write_only`
+- 上传：`docs:document.media:upload`
+
+**示例**：
+
+```bash
+# 创建一个标题为 "Q2 OKR" 的演示文稿
+feishu-cli slides create --title "Q2 OKR" --output json
+
+# 把封面图上传到该演示文稿
+feishu-cli slides media-upload --file ./cover.png \
+    --presentation-token <xml_presentation_id>
+```
+
 ### 新增 — `comment reply add`：为已有评论添加回复
 
 新增命令 `feishu-cli comment reply add <file_token> <comment_id> --text "..."`，补齐评论回复

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -47,6 +47,7 @@ var rootCmd = &cobra.Command{
   mail      邮箱（发送/回复/转发/草稿/查询；User Token）
   drive     云盘增强（分块上传、有界轮询导出/导入、富文本评论、通用 task-result）
   search    搜索操作（消息、应用搜索，需要用户授权）
+  slides    Slides 演示文稿（创建 + 媒体上传）
   config    配置管理（初始化配置）
 
 注意：bitable 命令已切换到 base/v3 API，flag 使用 --base-token。

--- a/cmd/slides.go
+++ b/cmd/slides.go
@@ -1,0 +1,30 @@
+package cmd
+
+import (
+	"github.com/spf13/cobra"
+)
+
+var slidesCmd = &cobra.Command{
+	Use:   "slides",
+	Short: "演示文稿（Slides）操作命令",
+	Long: `飞书 Slides 演示文稿操作命令。
+
+子命令:
+  create        创建新的 Slides 演示文稿
+  media-upload  上传本地图片到演示文稿，返回 file_token（可作为 <img src=...> 使用）
+
+权限要求（User Token 推荐）:
+  - slides:presentation:create / slides:presentation:write_only  创建/写入
+  - docs:document.media:upload                                   上传媒体
+
+示例:
+  # 创建演示文稿
+  feishu-cli slides create --title "My Deck"
+
+  # 上传图片
+  feishu-cli slides media-upload --file ./cover.png --presentation-token <xml_presentation_id>`,
+}
+
+func init() {
+	rootCmd.AddCommand(slidesCmd)
+}

--- a/cmd/slides_create.go
+++ b/cmd/slides_create.go
@@ -1,0 +1,72 @@
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/riba2534/feishu-cli/internal/client"
+	"github.com/riba2534/feishu-cli/internal/config"
+	"github.com/spf13/cobra"
+)
+
+var slidesCreateCmd = &cobra.Command{
+	Use:   "create",
+	Short: "创建新的 Slides 演示文稿",
+	Long: `创建新的飞书 Slides 演示文稿。
+
+参数:
+  --title, -t       演示文稿标题（默认 "Untitled"）
+  --width           幻灯片宽度像素（默认 960）
+  --height          幻灯片高度像素（默认 540）
+  --output, -o      输出格式，可选 json
+
+权限: slides:presentation:create 或 slides:presentation:write_only
+
+示例:
+  # 创建空白演示文稿
+  feishu-cli slides create --title "Q2 OKR"
+
+  # JSON 输出
+  feishu-cli slides create --title "Demo" --output json`,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		if err := config.Validate(); err != nil {
+			return err
+		}
+
+		title, _ := cmd.Flags().GetString("title")
+		width, _ := cmd.Flags().GetInt("width")
+		height, _ := cmd.Flags().GetInt("height")
+		output, _ := cmd.Flags().GetString("output")
+		userAccessToken := resolveOptionalUserToken(cmd)
+
+		result, err := client.CreateSlides(client.CreateSlidesOptions{
+			Title:           title,
+			Width:           width,
+			Height:          height,
+			UserAccessToken: userAccessToken,
+		})
+		if err != nil {
+			return err
+		}
+
+		if output == "json" {
+			return printJSON(result)
+		}
+
+		fmt.Printf("Slides 演示文稿已创建：\n")
+		fmt.Printf("  xml_presentation_id: %s\n", result.XmlPresentationID)
+		fmt.Printf("  title:               %s\n", result.Title)
+		if result.RevisionID > 0 {
+			fmt.Printf("  revision_id:         %d\n", result.RevisionID)
+		}
+		return nil
+	},
+}
+
+func init() {
+	slidesCmd.AddCommand(slidesCreateCmd)
+	slidesCreateCmd.Flags().StringP("title", "t", "", "演示文稿标题（默认 \"Untitled\"）")
+	slidesCreateCmd.Flags().Int("width", 0, "幻灯片宽度像素（默认 960）")
+	slidesCreateCmd.Flags().Int("height", 0, "幻灯片高度像素（默认 540）")
+	slidesCreateCmd.Flags().StringP("output", "o", "", "输出格式 (json)")
+	slidesCreateCmd.Flags().String("user-access-token", "", "User Access Token")
+}

--- a/cmd/slides_create_test.go
+++ b/cmd/slides_create_test.go
@@ -1,0 +1,52 @@
+package cmd
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestSlidesCmdRegistered(t *testing.T) {
+	for _, child := range rootCmd.Commands() {
+		if child.Name() == "slides" {
+			subs := child.Commands()
+			if len(subs) < 2 {
+				t.Fatalf("slides 子命令数量不足: got %d, want ≥ 2", len(subs))
+			}
+			have := map[string]bool{}
+			for _, c := range subs {
+				have[c.Name()] = true
+			}
+			for _, want := range []string{"create", "media-upload"} {
+				if !have[want] {
+					t.Errorf("slides 子命令缺少 %q", want)
+				}
+			}
+			return
+		}
+	}
+	t.Fatal("slides 顶层命令未注册到 rootCmd")
+}
+
+func TestSlidesCreateFlags(t *testing.T) {
+	if slidesCreateCmd.Flag("title") == nil {
+		t.Error("slides create 缺少 --title flag")
+	}
+	if slidesCreateCmd.Flag("width") == nil {
+		t.Error("slides create 缺少 --width flag")
+	}
+	if slidesCreateCmd.Flag("height") == nil {
+		t.Error("slides create 缺少 --height flag")
+	}
+	if !strings.Contains(slidesCreateCmd.Short, "Slides") {
+		t.Errorf("slides create Short 文案缺少 Slides: %q", slidesCreateCmd.Short)
+	}
+}
+
+func TestSlidesMediaUploadFlags(t *testing.T) {
+	if slidesMediaUploadCmd.Flag("file") == nil {
+		t.Error("slides media-upload 缺少 --file flag")
+	}
+	if slidesMediaUploadCmd.Flag("presentation-token") == nil {
+		t.Error("slides media-upload 缺少 --presentation-token flag")
+	}
+}

--- a/cmd/slides_media_upload.go
+++ b/cmd/slides_media_upload.go
@@ -1,0 +1,97 @@
+package cmd
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/riba2534/feishu-cli/internal/client"
+	"github.com/riba2534/feishu-cli/internal/config"
+	"github.com/spf13/cobra"
+)
+
+// maxSlidesMediaUploadSize slides 的 medias/upload_all 单分片上限（20 MB）
+// 多分片 upload_prepare 不接受 parent_type=slide_file，所以这里硬限 20 MB
+const maxSlidesMediaUploadSize = 20 * 1024 * 1024
+
+var slidesMediaUploadCmd = &cobra.Command{
+	Use:   "media-upload",
+	Short: "上传本地图片到 Slides 演示文稿，返回 file_token",
+	Long: `把本地图片上传到指定的 Slides 演示文稿，返回 file_token。
+返回的 file_token 可作为 slide XML 中 <img src="..."> 的值。
+
+参数:
+  --file                本地图片路径（必填，≤ 20 MB）
+  --presentation-token  目标演示文稿的 xml_presentation_id（必填）
+  --output, -o          输出格式，可选 json
+
+注意:
+  - slides 后端只接受 parent_type=slide_file + parent_node=xml_presentation_id
+  - 多分片上传不支持 slide_file，所以单文件上限 20 MB
+  - 权限: docs:document.media:upload
+
+示例:
+  feishu-cli slides media-upload --file ./cover.png --presentation-token <xml_presentation_id>`,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		if err := config.Validate(); err != nil {
+			return err
+		}
+
+		filePath, _ := cmd.Flags().GetString("file")
+		presentationToken, _ := cmd.Flags().GetString("presentation-token")
+		output, _ := cmd.Flags().GetString("output")
+		userAccessToken := resolveOptionalUserToken(cmd)
+
+		if filePath == "" {
+			return fmt.Errorf("--file 不能为空")
+		}
+		if presentationToken == "" {
+			return fmt.Errorf("--presentation-token 不能为空")
+		}
+
+		stat, err := os.Stat(filePath)
+		if err != nil {
+			return fmt.Errorf("读取文件失败: %w", err)
+		}
+		if !stat.Mode().IsRegular() {
+			return fmt.Errorf("--file 必须是普通文件: %s", filePath)
+		}
+		if stat.Size() > maxSlidesMediaUploadSize {
+			return fmt.Errorf("文件 %s 大小 %d 字节超过 slides 上传限制（20 MB）",
+				filepath.Base(filePath), stat.Size())
+		}
+
+		fileName := filepath.Base(filePath)
+		fileToken, err := client.UploadSlidesMedia(filePath, fileName, presentationToken, userAccessToken)
+		if err != nil {
+			return fmt.Errorf("上传 slides 图片失败: %w", err)
+		}
+
+		result := map[string]any{
+			"file_token":      fileToken,
+			"file_name":       fileName,
+			"size":            stat.Size(),
+			"presentation_id": presentationToken,
+		}
+
+		if output == "json" {
+			return printJSON(result)
+		}
+
+		fmt.Printf("图片上传成功：\n")
+		fmt.Printf("  file_token:      %s\n", fileToken)
+		fmt.Printf("  file_name:       %s\n", fileName)
+		fmt.Printf("  size:            %d bytes\n", stat.Size())
+		fmt.Printf("  presentation_id: %s\n", presentationToken)
+		fmt.Printf("\n提示: 在 slide XML 中可用作 <img src=\"%s\"/>\n", fileToken)
+		return nil
+	},
+}
+
+func init() {
+	slidesCmd.AddCommand(slidesMediaUploadCmd)
+	slidesMediaUploadCmd.Flags().String("file", "", "本地图片路径（必填，≤ 20 MB）")
+	slidesMediaUploadCmd.Flags().String("presentation-token", "", "目标演示文稿的 xml_presentation_id（必填）")
+	slidesMediaUploadCmd.Flags().StringP("output", "o", "", "输出格式 (json)")
+	slidesMediaUploadCmd.Flags().String("user-access-token", "", "User Access Token")
+}

--- a/internal/client/slides.go
+++ b/internal/client/slides.go
@@ -1,0 +1,132 @@
+package client
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strings"
+
+	larkcore "github.com/larksuite/oapi-sdk-go/v3/core"
+)
+
+// slidesMediaParentType 是 slides 后端唯一接受的 medias/upload_all parent_type
+// 已经 lark-cli 经验证过 slide_image / slides_image / slides_file 都会被拒，
+// 只有 slide_file 才能拿到可在 slide XML <img src="..."> 引用的 file_token。
+// 同时只接受单分片 upload_all 接口（最大 20 MB），upload_prepare 不支持。
+const slidesMediaParentType = "slide_file"
+
+const (
+	defaultPresentationWidth  = 960
+	defaultPresentationHeight = 540
+)
+
+// CreateSlidesResult 创建演示文稿后返回的数据
+type CreateSlidesResult struct {
+	XmlPresentationID string `json:"xml_presentation_id"`
+	RevisionID        int    `json:"revision_id,omitempty"`
+	Title             string `json:"title,omitempty"`
+}
+
+// CreateSlidesOptions 创建演示文稿可选参数
+type CreateSlidesOptions struct {
+	Title           string // 演示文稿标题，默认 "Untitled"
+	Width           int    // 默认 960
+	Height          int    // 默认 540
+	UserAccessToken string // 可选 User Access Token
+}
+
+// CreateSlides 通过 slides_ai openapi 创建一个空白演示文稿
+// API: POST /open-apis/slides_ai/v1/xml_presentations
+// body: {"xml_presentation": {"content": "<presentation ...><title>...</title></presentation>"}}
+// 权限: slides:presentation:create / slides:presentation:write_only
+func CreateSlides(opts CreateSlidesOptions) (*CreateSlidesResult, error) {
+	client, err := GetClient()
+	if err != nil {
+		return nil, err
+	}
+
+	title := opts.Title
+	if strings.TrimSpace(title) == "" {
+		title = "Untitled"
+	}
+	width := opts.Width
+	if width <= 0 {
+		width = defaultPresentationWidth
+	}
+	height := opts.Height
+	if height <= 0 {
+		height = defaultPresentationHeight
+	}
+
+	content := buildPresentationXML(title, width, height)
+	reqBody := map[string]any{
+		"xml_presentation": map[string]any{
+			"content": content,
+		},
+	}
+
+	tokenType := larkcore.AccessTokenTypeTenant
+	var reqOpts []larkcore.RequestOptionFunc
+	if opts.UserAccessToken != "" {
+		tokenType = larkcore.AccessTokenTypeUser
+		reqOpts = UserTokenOption(opts.UserAccessToken)
+	}
+
+	resp, err := client.Post(Context(), "/open-apis/slides_ai/v1/xml_presentations", reqBody, tokenType, reqOpts...)
+	if err != nil {
+		return nil, fmt.Errorf("创建 slides 失败: %w", err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("创建 slides 失败: HTTP %d, body: %s", resp.StatusCode, string(resp.RawBody))
+	}
+
+	var apiResp struct {
+		Code int    `json:"code"`
+		Msg  string `json:"msg"`
+		Data struct {
+			XmlPresentationID string `json:"xml_presentation_id"`
+			RevisionID        int    `json:"revision_id"`
+		} `json:"data"`
+	}
+	if err := json.Unmarshal(resp.RawBody, &apiResp); err != nil {
+		return nil, fmt.Errorf("解析 slides 创建响应失败: %w", err)
+	}
+	if apiResp.Code != 0 {
+		return nil, fmt.Errorf("创建 slides 失败: code=%d, msg=%s", apiResp.Code, apiResp.Msg)
+	}
+	if apiResp.Data.XmlPresentationID == "" {
+		return nil, fmt.Errorf("创建 slides 成功但未返回 xml_presentation_id")
+	}
+
+	return &CreateSlidesResult{
+		XmlPresentationID: apiResp.Data.XmlPresentationID,
+		RevisionID:        apiResp.Data.RevisionID,
+		Title:             title,
+	}, nil
+}
+
+// UploadSlidesMedia 把本地图片上传到 slides 演示文稿，返回的 file_token 可作为 <img src="..."> 使用
+// 必须用 parent_type=slide_file（lark-cli 实测，其他值都会被拒），且只能走单分片 upload_all（最大 20 MB）
+// 权限: docs:document.media:upload
+func UploadSlidesMedia(filePath, fileName, presentationID, userAccessToken string) (string, error) {
+	token, _, err := UploadMediaWithExtra(filePath, slidesMediaParentType, presentationID, fileName, "", userAccessToken)
+	return token, err
+}
+
+// buildPresentationXML 构造最小可用的 presentation XML，新建空白演示文稿用
+func buildPresentationXML(title string, width, height int) string {
+	return fmt.Sprintf(
+		`<presentation xmlns="http://www.larkoffice.com/sml/2.0" width="%d" height="%d"><title>%s</title></presentation>`,
+		width, height, xmlEscape(title),
+	)
+}
+
+// xmlEscape 对 XML 文本节点的特殊字符做转义
+func xmlEscape(s string) string {
+	s = strings.ReplaceAll(s, "&", "&amp;")
+	s = strings.ReplaceAll(s, "<", "&lt;")
+	s = strings.ReplaceAll(s, ">", "&gt;")
+	s = strings.ReplaceAll(s, "\"", "&quot;")
+	s = strings.ReplaceAll(s, "'", "&apos;")
+	return s
+}

--- a/skills/feishu-cli-slides/SKILL.md
+++ b/skills/feishu-cli-slides/SKILL.md
@@ -1,0 +1,210 @@
+---
+name: feishu-cli-slides
+description: >-
+  飞书 Slides 演示文稿。slides create 从 XML 模板创建演示文稿（POST /open-apis/slides_ai/v1/xml_presentations）；
+  slides media-upload 上传媒体（drive upload_all + parent_type=slide_file，单文件 ≤20MB 不支持分片）。
+  当用户请求"创建飞书 ppt"、"上传幻灯片"、"演示文稿"、"slides"时使用。
+  不适用：复杂 slide 编辑（block insert/replace 复杂语义）暂未实现，走 lark-slides。
+argument-hint: create | media-upload
+user-invocable: true
+allowed-tools: Bash, Read
+---
+
+# 飞书 Slides 演示文稿技能
+
+通过 `feishu-cli slides` 创建空白演示文稿，并把本地图片以 `slide_file` 媒体形式上传到该演示文稿，
+返回的 `file_token` 可直接在 slide XML 中作为 `<img src="...">` 引用。
+
+> **feishu-cli**：如尚未安装，请前往 [riba2534/feishu-cli](https://github.com/riba2534/feishu-cli) 获取安装方式。
+
+> **范围声明**：本技能只覆盖「创建空白演示文稿」+「上传媒体」两个最小可用动作。如需在已有
+> 演示文稿里做复杂 slide 编辑（block insert/replace 等），目前 CLI 未实现，请改走
+> 官方 `lark-slides` 客户端或 OpenAPI 直调。
+
+## 核心概念
+
+### 两种产物分别是什么
+
+| 命令 | 调用的 API | 产物 | 用途 |
+|------|------------|------|------|
+| `slides create` | `POST /open-apis/slides_ai/v1/xml_presentations` | `xml_presentation_id` | 后续所有 slides 操作的 ID（不是普通 docx token） |
+| `slides media-upload` | `POST /open-apis/drive/v1/medias/upload_all` (`parent_type=slide_file`) | `file_token` | 可直接放进 slide XML 的 `<img src="...">` |
+
+**关键约束**：
+- `slide_file` 是 slides 后端唯一接受的 `parent_type`（lark-cli 实测：`slide_image` / `slides_image` /
+  `slides_file` 都会被拒）
+- `parent_node` 必须传 `xml_presentation_id`（而不是 docx token 或 file_token）
+- 上传走单分片 `upload_all`，**不支持** `upload_prepare` 多分片，所以单文件硬限 20 MB
+
+### XML 模板格式（create 内部）
+
+`slides create` 在 CLI 内部用 `--title/--width/--height` 拼成最小可用 XML 模板再 POST：
+
+```xml
+<presentation xmlns="http://www.larkoffice.com/sml/2.0" width="960" height="540">
+  <title>演示文稿标题</title>
+</presentation>
+```
+
+> 当前版本不暴露 `--xml-file` 参数让你直接传整个 presentation XML——只能通过 `--title/--width/--height`
+> 影响这个最小模板。如需复杂初始内容，先 `create` 拿到 `xml_presentation_id`，再走 lark-slides
+> 或后续 CLI 扩展。
+
+## 前置条件
+
+- **认证**：默认走 **App Token**（租户身份），通过 `--user-access-token` 或 `FEISHU_USER_ACCESS_TOKEN`
+  可切换 User Token（推荐用 User Token，以个人身份创建，便于后续直接在飞书里编辑）
+- **权限**：
+  | 命令 | 所需 scope |
+  |------|-----------|
+  | `slides create` | `slides:presentation:create` 或 `slides:presentation:write_only` |
+  | `slides media-upload` | `docs:document.media:upload` |
+- **预检**：`feishu-cli auth check --scope "slides:presentation:create docs:document.media:upload"`
+
+## 命令速查
+
+### 1. `slides create` — 创建空白演示文稿
+
+```bash
+# 最简用法（默认尺寸 960x540，title="Untitled"）
+feishu-cli slides create
+
+# 指定标题
+feishu-cli slides create --title "Q2 OKR"
+
+# 自定义宽高（像素）
+feishu-cli slides create --title "Wide Deck" --width 1920 --height 1080
+
+# JSON 输出（脚本接力时常用，方便 jq 取 xml_presentation_id）
+feishu-cli slides create --title "Demo" --output json
+
+# 以用户身份创建（推荐，演示文稿归属个人）
+feishu-cli slides create --title "Demo" --user-access-token <u-xxx>
+```
+
+**关键参数**：
+
+| 参数 | 说明 | 默认值 |
+|------|------|--------|
+| `--title`, `-t` | 演示文稿标题 | `Untitled` |
+| `--width` | 幻灯片宽度（像素） | `960` |
+| `--height` | 幻灯片高度（像素） | `540` |
+| `--output`, `-o` | 输出格式（留空 = 文本摘要，`json` = JSON） | 文本摘要 |
+| `--user-access-token` | 显式传 User Token | 不传走 App Token |
+
+**返回**：
+
+```
+Slides 演示文稿已创建：
+  xml_presentation_id: <id>
+  title:               Q2 OKR
+  revision_id:         1
+```
+
+`xml_presentation_id` 就是后续 `media-upload --presentation-token` 要传的值。
+
+### 2. `slides media-upload` — 上传媒体到演示文稿
+
+```bash
+# 上传封面图
+feishu-cli slides media-upload \
+  --file ./cover.png \
+  --presentation-token <xml_presentation_id>
+
+# JSON 输出，方便 jq 接力拿 file_token
+feishu-cli slides media-upload \
+  --file ./cover.png \
+  --presentation-token <xml_presentation_id> \
+  --output json
+```
+
+**关键参数**：
+
+| 参数 | 说明 | 必填 |
+|------|------|------|
+| `--file` | 本地图片路径（**≤ 20 MB**） | 是 |
+| `--presentation-token` | 目标演示文稿的 `xml_presentation_id` | 是 |
+| `--output`, `-o` | 输出格式（留空 = 文本摘要，`json` = JSON） | 否 |
+| `--user-access-token` | 显式传 User Token | 否 |
+
+**返回**：
+
+```
+图片上传成功：
+  file_token:      <token>
+  file_name:       cover.png
+  size:            123456 bytes
+  presentation_id: <xml_presentation_id>
+
+提示: 在 slide XML 中可用作 <img src="<token>"/>
+```
+
+## 典型工作流
+
+### 工作流 A：创建 + 上传封面图（端到端）
+
+```bash
+# 1. 创建空白演示文稿
+PRES_ID=$(feishu-cli slides create --title "Q2 OKR" --output json | jq -r '.xml_presentation_id')
+
+# 2. 上传封面图，拿到 file_token
+FILE_TOKEN=$(feishu-cli slides media-upload \
+  --file ./cover.png \
+  --presentation-token "$PRES_ID" \
+  --output json | jq -r '.file_token')
+
+# 3. 现在 $FILE_TOKEN 可以拼到 slide XML 的 <img src="..."> 里
+echo "presentation: $PRES_ID, cover: $FILE_TOKEN"
+```
+
+### 工作流 B：批量上传一组图片
+
+```bash
+PRES_ID=$(feishu-cli slides create --title "Photo Deck" --output json | jq -r '.xml_presentation_id')
+
+for img in ./assets/*.png; do
+  feishu-cli slides media-upload \
+    --file "$img" \
+    --presentation-token "$PRES_ID" \
+    --output json | jq -r '"\(.file_name) -> \(.file_token)"'
+done
+```
+
+## 何时转用其他工具
+
+| 场景 | 改走 |
+|------|------|
+| 在已有演示文稿里插入/修改/删除 slide 或 block | `lark-slides`（官方 CLI）或 OpenAPI 直调 `slides_ai/v1/...` 编辑接口 |
+| 直接传整个 presentation XML 模板 | 暂未暴露 `--xml-file`，等 CLI 扩展或 OpenAPI 直调 |
+| 单文件 > 20 MB 的媒体 | 拆分小图，或直接走飞书客户端上传 |
+| 把 markdown / docx 转成 slides | 暂不支持，建议先转 docx 再用飞书客户端导出 |
+| 普通文档（不是演示文稿）上传媒体 | 走 **feishu-cli-drive** 技能（`drive upload`） |
+
+## 注意事项
+
+- **`parent_type` 不要乱改**：源码里硬编码 `slide_file`，且经 lark-cli 实测唯一可用值。
+  自己改成 `slide_image` / `slides_image` / `slides_file` 都会被服务端拒绝
+- **20 MB 上限不可绕过**：`upload_prepare` 多分片接口**不接受** `parent_type=slide_file`，
+  CLI 在 client 侧也做了 20 MB 硬检查，超过会在本地直接报错（不会发请求）
+- **`xml_presentation_id` ≠ docx token**：这是 slides 模块独立的标识符，不要拿去当
+  `docx:document_id` 或 `drive:file_token` 用
+- **User Token vs App Token**：默认 App Token（Bot 身份），演示文稿归 Bot 所有，普通人在
+  飞书 UI 里看不到。**推荐传 `--user-access-token`** 让产物归个人，能直接在「我的空间」找到
+- **图片格式**：常见 png/jpg/jpeg/gif/webp 等，由 `medias/upload_all` 自动推断 MIME
+
+## 错误排查
+
+| 错误 | 原因 | 解决 |
+|------|------|------|
+| `--file 不能为空` / `--presentation-token 不能为空` | 必填参数缺失 | 检查命令行参数 |
+| `读取文件失败` / `--file 必须是普通文件` | 路径错或不是 regular file | 检查路径、不要传符号链接到目录 |
+| `文件 X 大小 Y 字节超过 slides 上传限制（20 MB）` | 文件超过 20 MB | 压缩 / 切分，slides 后端硬限不可绕过 |
+| `创建 slides 失败: code=99991663, msg=...` | scope 不够 | `auth check --scope "slides:presentation:create"` 然后重新 `auth login --domain slides --recommend` |
+| `创建 slides 失败: HTTP 400, body: ...invalid xml_presentation...` | XML 模板异常（一般 title 含未转义字符触发） | CLI 已做 XML escape，若仍出现请 issue |
+| 上传报 `parent_type invalid` 或类似 | 走的不是 `slide_file`（如直接 curl 调 medias/upload_all 时传错） | 用 CLI 而不是手敲 curl，CLI 已锁定 `slide_file` |
+
+## 参考
+
+- API 文档：飞书开放平台「智能演示」/「云文档 - 素材」
+- 代码：`cmd/slides_create.go` / `cmd/slides_media_upload.go` / `internal/client/slides.go`
+- 上游 PR：[feishu-cli#135](https://github.com/riba2534/feishu-cli/pull/135)


### PR DESCRIPTION
## 背景

feishu-cli 此前没有 Slides 模块。lark-cli 提供 +create/+media-upload 两个 shortcut，本 PR 用 feishu-cli 风格补齐。

## 新增命令

```bash
# 创建 Slides 演示文稿
feishu-cli slides create --title "演示标题" [--width 1280 --height 720]
#   → 返回 xml_presentation_id + URL

# 上传图片到 Slides（用于 <img src=> 引用）
feishu-cli slides media-upload --file ./photo.png --presentation-token xpt_xxx
#   → 返回 file_token，单文件上限 20MB
```

## 实现要点

- 接口：\`POST /open-apis/slides_ai/v1/xml_presentations\`
- media-upload 复用 \`UploadMediaWithExtra\` (\`parent_type=slide_file\` + \`parent_node=<xml_presentation_id>\`)
- 关键依据：\`upload_prepare\` 多分片对 slide_file 不支持，硬限 20MB

## Scope

\`slides:presentation:create\` / \`slides:presentation:write_only\` / \`docs:document.media:upload\`

## 测试

- \`go build ./...\` / \`go vet ./...\` 全绿
- \`go test ./cmd -run Slides\` 3/3 PASS

## 边界（不在本 PR 范围）

按 MVP 范围，未实现 \`+replace-slide\`（需要 slide block insert/replace 复杂语义）。后续 PR 可补。