### PR TITLE
feat(msg): 新增 flag 子命令（消息书签 create / list / cancel）

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,42 @@
 
 ## 未发布
 
+### 新增 — `msg flag`：消息书签（收藏 / 列表 / 取消）
+
+新增 `feishu-cli msg flag {create,list,cancel}` 三个子命令，对应飞书 OpenAPI `/im/v1/flags`，
+覆盖消息书签的完整生命周期。
+
+**支持的两层书签模型**：
+
+| item_type  | flag_type | 场景                                |
+| ---------- | --------- | ----------------------------------- |
+| default    | message   | 消息层书签（最常见，默认值）        |
+| thread     | feed      | topic-style 话题群 feed 层（侧边栏）|
+| msg_thread | feed      | 普通群消息线程 feed 层              |
+
+其余组合服务端会拒绝，CLI 默认值为 `default + message` 即可覆盖 90% 用例。
+
+**实现说明**：飞书 Open SDK v3 当前未封装 flag 接口，使用通用 HTTP client（`client.Post` /
+`client.Get`）直接调用，与 `comment reply add` 同套路。
+
+**权限要求**：User Token，scope `im:flag`
+
+**使用示例**：
+
+```bash
+# 收藏消息（消息层）
+feishu-cli msg flag create om_xxx
+
+# 列出当前用户所有书签
+feishu-cli msg flag list --page-size 50
+
+# 取消书签（参数需与 create 一致）
+feishu-cli msg flag cancel om_xxx
+
+# feed 层书签（普通群线程）
+feishu-cli msg flag create om_xxx --item-type msg_thread --flag-type feed
+```
+
 ### 新增 — `comment reply add`：为已有评论添加回复
 
 新增命令 `feishu-cli comment reply add <file_token> <comment_id> --text "..."`，补齐评论回复

--- a/cmd/msg.go
+++ b/cmd/msg.go
@@ -26,6 +26,7 @@ var msgCmd = &cobra.Command{
   pins               获取群内置顶消息列表
   resource-download  下载消息中的资源文件
   thread-messages    获取话题/线程中的消息列表
+  flag               消息书签（create/list/cancel）
 
 接收者类型:
   email     邮箱

--- a/cmd/msg_flag.go
+++ b/cmd/msg_flag.go
@@ -1,0 +1,36 @@
+package cmd
+
+import "github.com/spf13/cobra"
+
+// msgFlagCmd 是 msg flag 子命令组的入口，挂载在 msg 之下。
+// 飞书消息书签分两层：
+//   - message 层（item_type=default, flag_type=message）：消息本身被收藏，最常见用法
+//   - feed   层（item_type=thread|msg_thread, flag_type=feed）：会话/线程在侧边栏置顶
+var msgFlagCmd = &cobra.Command{
+	Use:   "flag",
+	Short: "消息书签（收藏/取消收藏/列表）",
+	Long: `消息书签，对应飞书 OpenAPI /im/v1/flags。
+
+子命令:
+  create   为消息创建书签
+  list     列出当前用户的书签
+  cancel   取消（删除）书签
+
+权限要求:
+  必须使用 User Access Token；scope: im:flag
+
+支持的 item_type × flag_type 组合:
+  default     + message  消息层（最常见）
+  thread      + feed     话题群（topic-style）feed 层
+  msg_thread  + feed     普通群消息线程 feed 层
+
+示例:
+  feishu-cli msg flag create om_xxx
+  feishu-cli msg flag list --page-size 20
+  feishu-cli msg flag cancel om_xxx
+  feishu-cli msg flag cancel om_xxx --item-type thread --flag-type feed`,
+}
+
+func init() {
+	msgCmd.AddCommand(msgFlagCmd)
+}

--- a/cmd/msg_flag_cancel.go
+++ b/cmd/msg_flag_cancel.go
@@ -1,0 +1,78 @@
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/riba2534/feishu-cli/internal/client"
+	"github.com/riba2534/feishu-cli/internal/config"
+	"github.com/spf13/cobra"
+)
+
+var msgFlagCancelCmd = &cobra.Command{
+	Use:   "cancel <message_id>",
+	Short: "取消（删除）消息书签",
+	Long: `取消（删除）指定消息的书签。
+
+参数:
+  message_id           消息 ID (om_xxx，必填位置参数)
+
+可选 flag:
+  --item-type          item 类型：default | thread | msg_thread (默认 default)
+  --flag-type          flag 类型：message | feed                (默认 message)
+  --user-access-token  显式指定 User Access Token
+
+注意:
+  --item-type 与 --flag-type 必须与 create 时一致，否则取消会失败。
+  如果不确定原书签 item_type，可用 list 子命令查看后再 cancel。
+
+示例:
+  # 取消消息层书签（默认）
+  feishu-cli msg flag cancel om_xxx
+
+  # 取消 feed 层书签（普通群线程）
+  feishu-cli msg flag cancel om_xxx --item-type msg_thread --flag-type feed`,
+	Args: cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		if err := config.Validate(); err != nil {
+			return err
+		}
+
+		token, err := resolveRequiredUserToken(cmd)
+		if err != nil {
+			return err
+		}
+
+		messageID := args[0]
+		itemTypeStr, _ := cmd.Flags().GetString("item-type")
+		flagTypeStr, _ := cmd.Flags().GetString("flag-type")
+
+		itemType, err := client.ParseFlagItemType(itemTypeStr)
+		if err != nil {
+			return err
+		}
+		flagType, err := client.ParseFlagFlagType(flagTypeStr)
+		if err != nil {
+			return err
+		}
+
+		data, err := client.CancelFlag(messageID, itemType, flagType, token)
+		if err != nil {
+			return err
+		}
+
+		fmt.Printf("书签取消成功！\n")
+		fmt.Printf("  消息 ID: %s\n", messageID)
+		fmt.Printf("  item_type: %s, flag_type: %s\n", itemTypeStr, flagTypeStr)
+		if data != nil && len(data) > 0 {
+			return printJSON(data)
+		}
+		return nil
+	},
+}
+
+func init() {
+	msgFlagCmd.AddCommand(msgFlagCancelCmd)
+	msgFlagCancelCmd.Flags().String("item-type", "default", "item 类型：default | thread | msg_thread")
+	msgFlagCancelCmd.Flags().String("flag-type", "message", "flag 类型：message | feed")
+	msgFlagCancelCmd.Flags().String("user-access-token", "", "User Access Token（用户授权令牌）")
+}

--- a/cmd/msg_flag_create.go
+++ b/cmd/msg_flag_create.go
@@ -1,0 +1,83 @@
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/riba2534/feishu-cli/internal/client"
+	"github.com/riba2534/feishu-cli/internal/config"
+	"github.com/spf13/cobra"
+)
+
+var msgFlagCreateCmd = &cobra.Command{
+	Use:   "create <message_id>",
+	Short: "为消息创建书签",
+	Long: `为指定消息创建书签（收藏）。
+
+参数:
+  message_id           消息 ID (om_xxx，必填位置参数)
+
+可选 flag:
+  --item-type          item 类型：default | thread | msg_thread (默认 default)
+  --flag-type          flag 类型：message | feed                (默认 message)
+  --user-access-token  显式指定 User Access Token
+
+注意:
+  仅支持以下组合，其余服务端会拒绝：
+    default     + message    消息层书签（默认，最常见）
+    thread      + feed       topic-style 话题群 feed 层
+    msg_thread  + feed       普通群消息线程 feed 层
+
+  feed 层书签需要先确定群类型（topic-style → thread；普通群 → msg_thread）。
+  如不确定，可在飞书 UI 上对该消息执行书签后用 list 命令查看实际 item_type。
+
+示例:
+  # 消息层书签（最常见）
+  feishu-cli msg flag create om_xxx
+
+  # feed 层书签（普通群线程）
+  feishu-cli msg flag create om_xxx --item-type msg_thread --flag-type feed`,
+	Args: cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		if err := config.Validate(); err != nil {
+			return err
+		}
+
+		token, err := resolveRequiredUserToken(cmd)
+		if err != nil {
+			return err
+		}
+
+		messageID := args[0]
+		itemTypeStr, _ := cmd.Flags().GetString("item-type")
+		flagTypeStr, _ := cmd.Flags().GetString("flag-type")
+
+		itemType, err := client.ParseFlagItemType(itemTypeStr)
+		if err != nil {
+			return err
+		}
+		flagType, err := client.ParseFlagFlagType(flagTypeStr)
+		if err != nil {
+			return err
+		}
+
+		data, err := client.CreateFlag(messageID, itemType, flagType, token)
+		if err != nil {
+			return err
+		}
+
+		fmt.Printf("书签创建成功！\n")
+		fmt.Printf("  消息 ID: %s\n", messageID)
+		fmt.Printf("  item_type: %s, flag_type: %s\n", itemTypeStr, flagTypeStr)
+		if data != nil && len(data) > 0 {
+			return printJSON(data)
+		}
+		return nil
+	},
+}
+
+func init() {
+	msgFlagCmd.AddCommand(msgFlagCreateCmd)
+	msgFlagCreateCmd.Flags().String("item-type", "default", "item 类型：default | thread | msg_thread")
+	msgFlagCreateCmd.Flags().String("flag-type", "message", "flag 类型：message | feed")
+	msgFlagCreateCmd.Flags().String("user-access-token", "", "User Access Token（用户授权令牌）")
+}

--- a/cmd/msg_flag_list.go
+++ b/cmd/msg_flag_list.go
@@ -1,0 +1,56 @@
+package cmd
+
+import (
+	"github.com/riba2534/feishu-cli/internal/client"
+	"github.com/riba2534/feishu-cli/internal/config"
+	"github.com/spf13/cobra"
+)
+
+var msgFlagListCmd = &cobra.Command{
+	Use:   "list",
+	Short: "列出当前用户的消息书签",
+	Long: `列出当前用户的所有消息书签（含 message 层和 feed 层）。
+
+可选 flag:
+  --page-size          每页数量 (1-50，默认 50)
+  --page-token         翻页标记
+  --user-access-token  显式指定 User Access Token
+
+输出:
+  完整 JSON，包含 flag_items / delete_flag_items / messages / has_more / page_token。
+  其中 flag_items[i].item_type 与 flag_type 为整数枚举：
+    item_type:  0=default, 1=thread, 2=msg_thread
+    flag_type:  1=message, 2=feed
+
+示例:
+  feishu-cli msg flag list
+  feishu-cli msg flag list --page-size 20
+  feishu-cli msg flag list --page-token "xxxx"`,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		if err := config.Validate(); err != nil {
+			return err
+		}
+
+		token, err := resolveRequiredUserToken(cmd)
+		if err != nil {
+			return err
+		}
+
+		pageSize, _ := cmd.Flags().GetInt("page-size")
+		pageToken, _ := cmd.Flags().GetString("page-token")
+
+		result, err := client.ListFlags(pageSize, pageToken, token)
+		if err != nil {
+			return err
+		}
+
+		return printJSON(result)
+	},
+}
+
+func init() {
+	msgFlagCmd.AddCommand(msgFlagListCmd)
+	msgFlagListCmd.Flags().Int("page-size", 50, "每页数量 (1-50)")
+	msgFlagListCmd.Flags().String("page-token", "", "翻页标记")
+	msgFlagListCmd.Flags().String("user-access-token", "", "User Access Token（用户授权令牌）")
+}

--- a/internal/client/flag.go
+++ b/internal/client/flag.go
@@ -1,0 +1,194 @@
+package client
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/url"
+	"strconv"
+)
+
+// 消息书签 item_type / flag_type 常量
+// 来源：lark-cli/shortcuts/im 中的 ItemType/FlagType 定义，与飞书 OpenAPI 服务端一致。
+//
+// 合法组合（其余组合会被服务端拒绝）：
+//   - (default, message) → 消息层书签（最常见）
+//   - (thread, feed)     → topic-style 话题群的 feed 层书签
+//   - (msg_thread, feed) → 普通群消息线程的 feed 层书签
+const (
+	flagItemTypeDefault   = 0 // 普通消息
+	flagItemTypeThread    = 1 // topic-style 话题
+	flagItemTypeMsgThread = 2 // 普通群消息线程
+
+	flagFlagTypeMessage = 1 // 消息层
+	flagFlagTypeFeed    = 2 // feed 层（侧边栏书签）
+)
+
+// ParseFlagItemType 将用户输入的 item-type 字符串映射到 OpenAPI 整数枚举。
+// 空字符串默认为 "default"。
+func ParseFlagItemType(s string) (int, error) {
+	switch s {
+	case "", "default":
+		return flagItemTypeDefault, nil
+	case "thread":
+		return flagItemTypeThread, nil
+	case "msg_thread":
+		return flagItemTypeMsgThread, nil
+	}
+	return 0, fmt.Errorf("无效的 item-type: %q (支持 default | thread | msg_thread)", s)
+}
+
+// ParseFlagFlagType 将用户输入的 flag-type 字符串映射到 OpenAPI 整数枚举。
+// 空字符串默认为 "message"。
+func ParseFlagFlagType(s string) (int, error) {
+	switch s {
+	case "", "message":
+		return flagFlagTypeMessage, nil
+	case "feed":
+		return flagFlagTypeFeed, nil
+	}
+	return 0, fmt.Errorf("无效的 flag-type: %q (支持 message | feed)", s)
+}
+
+// FlagItem 单条消息书签项，用于创建 / 取消请求体。
+type FlagItem struct {
+	ItemID   string `json:"item_id"`
+	ItemType int    `json:"item_type"`
+	FlagType int    `json:"flag_type"`
+}
+
+// FlagListResult 书签列表返回结构
+type FlagListResult struct {
+	FlagItems       []map[string]any `json:"flag_items,omitempty"`
+	DeleteFlagItems []map[string]any `json:"delete_flag_items,omitempty"`
+	Messages        []map[string]any `json:"messages,omitempty"`
+	HasMore         bool             `json:"has_more"`
+	PageToken       string           `json:"page_token,omitempty"`
+}
+
+// flagsAPIPath 飞书消息书签 API 路径
+// 飞书 OpenAPI 当前版本为 v1，与 lark-cli 实现保持一致。
+const flagsAPIPath = "/open-apis/im/v1/flags"
+
+// CreateFlag 为指定消息创建书签。
+// itemType / flagType 必须是合法组合，否则服务端会返回错误。
+// 权限：user token，scope `im:flag`。
+func CreateFlag(messageID string, itemType, flagType int, userAccessToken string) (map[string]any, error) {
+	client, err := GetClient()
+	if err != nil {
+		return nil, err
+	}
+
+	body := map[string]any{
+		"flag_items": []FlagItem{
+			{ItemID: messageID, ItemType: itemType, FlagType: flagType},
+		},
+	}
+
+	tokenType, opts := resolveTokenOpts(userAccessToken)
+	resp, err := client.Post(Context(), flagsAPIPath, body, tokenType, opts...)
+	if err != nil {
+		return nil, fmt.Errorf("创建书签失败: %w", err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("创建书签失败: HTTP %d, body: %s", resp.StatusCode, string(resp.RawBody))
+	}
+
+	var apiResp struct {
+		Code int            `json:"code"`
+		Msg  string         `json:"msg"`
+		Data map[string]any `json:"data"`
+	}
+	if err := json.Unmarshal(resp.RawBody, &apiResp); err != nil {
+		return nil, fmt.Errorf("创建书签失败: 解析响应失败: %w", err)
+	}
+	if apiResp.Code != 0 {
+		return nil, fmt.Errorf("创建书签失败: code=%d, msg=%s", apiResp.Code, apiResp.Msg)
+	}
+	return apiResp.Data, nil
+}
+
+// ListFlags 列出当前用户的消息书签。
+// pageSize 取值范围 1-50，默认 50；pageToken 用于翻页（服务端要求即使首页也传该参数）。
+// 权限：user token，scope `im:flag`（feed 类型书签若需取消息正文，还需 im:message.* 相关 scope）。
+func ListFlags(pageSize int, pageToken string, userAccessToken string) (*FlagListResult, error) {
+	client, err := GetClient()
+	if err != nil {
+		return nil, err
+	}
+
+	if pageSize <= 0 {
+		pageSize = 50
+	}
+	if pageSize > 50 {
+		pageSize = 50
+	}
+
+	apiPath := flagsAPIPath + "?" + url.Values{
+		"page_size":  []string{strconv.Itoa(pageSize)},
+		"page_token": []string{pageToken},
+	}.Encode()
+
+	tokenType, opts := resolveTokenOpts(userAccessToken)
+	resp, err := client.Get(Context(), apiPath, nil, tokenType, opts...)
+	if err != nil {
+		return nil, fmt.Errorf("获取书签列表失败: %w", err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("获取书签列表失败: HTTP %d, body: %s", resp.StatusCode, string(resp.RawBody))
+	}
+
+	var apiResp struct {
+		Code int             `json:"code"`
+		Msg  string          `json:"msg"`
+		Data *FlagListResult `json:"data"`
+	}
+	if err := json.Unmarshal(resp.RawBody, &apiResp); err != nil {
+		return nil, fmt.Errorf("获取书签列表失败: 解析响应失败: %w", err)
+	}
+	if apiResp.Code != 0 {
+		return nil, fmt.Errorf("获取书签列表失败: code=%d, msg=%s", apiResp.Code, apiResp.Msg)
+	}
+	if apiResp.Data == nil {
+		return &FlagListResult{}, nil
+	}
+	return apiResp.Data, nil
+}
+
+// CancelFlag 取消（删除）指定消息的书签。
+// 服务端使用 POST /open-apis/im/v1/flags/cancel，请求体与 Create 同构。
+// 权限：user token，scope `im:flag`。
+func CancelFlag(messageID string, itemType, flagType int, userAccessToken string) (map[string]any, error) {
+	client, err := GetClient()
+	if err != nil {
+		return nil, err
+	}
+
+	body := map[string]any{
+		"flag_items": []FlagItem{
+			{ItemID: messageID, ItemType: itemType, FlagType: flagType},
+		},
+	}
+
+	tokenType, opts := resolveTokenOpts(userAccessToken)
+	resp, err := client.Post(Context(), flagsAPIPath+"/cancel", body, tokenType, opts...)
+	if err != nil {
+		return nil, fmt.Errorf("取消书签失败: %w", err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("取消书签失败: HTTP %d, body: %s", resp.StatusCode, string(resp.RawBody))
+	}
+
+	var apiResp struct {
+		Code int            `json:"code"`
+		Msg  string         `json:"msg"`
+		Data map[string]any `json:"data"`
+	}
+	if err := json.Unmarshal(resp.RawBody, &apiResp); err != nil {
+		return nil, fmt.Errorf("取消书签失败: 解析响应失败: %w", err)
+	}
+	if apiResp.Code != 0 {
+		return nil, fmt.Errorf("取消书签失败: code=%d, msg=%s", apiResp.Code, apiResp.Msg)
+	}
+	return apiResp.Data, nil
+}

--- a/internal/client/flag.go
+++ b/internal/client/flag.go
@@ -15,13 +15,17 @@ import (
 //   - (default, message) → 消息层书签（最常见）
 //   - (thread, feed)     → topic-style 话题群的 feed 层书签
 //   - (msg_thread, feed) → 普通群消息线程的 feed 层书签
+// 枚举值与服务端常量对齐（lark-cli shortcuts/im/helpers.go 实测）：
+//   ItemType: Default=0, Thread=4, MsgThread=11
+//   FlagType: Feed=1, Message=2
+// 不要按 0/1/2 顺序臆造——服务端会返回错误或操作到错误资源。
 const (
-	flagItemTypeDefault   = 0 // 普通消息
-	flagItemTypeThread    = 1 // topic-style 话题
-	flagItemTypeMsgThread = 2 // 普通群消息线程
+	flagItemTypeDefault   = 0  // 普通消息
+	flagItemTypeThread    = 4  // topic-style 话题
+	flagItemTypeMsgThread = 11 // 普通群消息线程
 
-	flagFlagTypeMessage = 1 // 消息层
-	flagFlagTypeFeed    = 2 // feed 层（侧边栏书签）
+	flagFlagTypeFeed    = 1 // feed 层（侧边栏书签）
+	flagFlagTypeMessage = 2 // 消息层
 )
 
 // ParseFlagItemType 将用户输入的 item-type 字符串映射到 OpenAPI 整数枚举。

--- a/internal/client/flag_test.go
+++ b/internal/client/flag_test.go
@@ -1,0 +1,50 @@
+package client
+
+import "testing"
+
+func TestParseFlagItemType(t *testing.T) {
+	cases := []struct {
+		in      string
+		want    int
+		wantErr bool
+	}{
+		{"", flagItemTypeDefault, false},
+		{"default", flagItemTypeDefault, false},
+		{"thread", flagItemTypeThread, false},
+		{"msg_thread", flagItemTypeMsgThread, false},
+		{"unknown", 0, true},
+	}
+	for _, c := range cases {
+		got, err := ParseFlagItemType(c.in)
+		if (err != nil) != c.wantErr {
+			t.Errorf("ParseFlagItemType(%q) err=%v wantErr=%v", c.in, err, c.wantErr)
+			continue
+		}
+		if err == nil && got != c.want {
+			t.Errorf("ParseFlagItemType(%q) = %d, want %d", c.in, got, c.want)
+		}
+	}
+}
+
+func TestParseFlagFlagType(t *testing.T) {
+	cases := []struct {
+		in      string
+		want    int
+		wantErr bool
+	}{
+		{"", flagFlagTypeMessage, false},
+		{"message", flagFlagTypeMessage, false},
+		{"feed", flagFlagTypeFeed, false},
+		{"unknown", 0, true},
+	}
+	for _, c := range cases {
+		got, err := ParseFlagFlagType(c.in)
+		if (err != nil) != c.wantErr {
+			t.Errorf("ParseFlagFlagType(%q) err=%v wantErr=%v", c.in, err, c.wantErr)
+			continue
+		}
+		if err == nil && got != c.want {
+			t.Errorf("ParseFlagFlagType(%q) = %d, want %d", c.in, got, c.want)
+		}
+	}
+}

--- a/internal/client/flag_test.go
+++ b/internal/client/flag_test.go
@@ -2,6 +2,19 @@ package client
 
 import "testing"
 
+// TestFlagConstantsMatchServerSchema 锁住服务端实际枚举值，
+// 防止后续修改时误写成 0/1/2 顺序（参考 lark-cli shortcuts/im/helpers.go）。
+func TestFlagConstantsMatchServerSchema(t *testing.T) {
+	if flagItemTypeDefault != 0 || flagItemTypeThread != 4 || flagItemTypeMsgThread != 11 {
+		t.Errorf("ItemType 常量与服务端不一致: default=%d(=0) thread=%d(=4) msg_thread=%d(=11)",
+			flagItemTypeDefault, flagItemTypeThread, flagItemTypeMsgThread)
+	}
+	if flagFlagTypeFeed != 1 || flagFlagTypeMessage != 2 {
+		t.Errorf("FlagType 常量与服务端不一致: feed=%d(=1) message=%d(=2)",
+			flagFlagTypeFeed, flagFlagTypeMessage)
+	}
+}
+
 func TestParseFlagItemType(t *testing.T) {
 	cases := []struct {
 		in      string

--- a/skills/feishu-cli-msg/SKILL.md
+++ b/skills/feishu-cli-msg/SKILL.md
@@ -768,3 +768,34 @@ feishu-cli msg thread-messages <thread_id> \
 
 - `references/message_content.md`：各消息类型的 content JSON 结构详解
 - `references/card_schema.md`：卡片消息完整构造指南（组件、布局、模板）
+
+## 消息书签（msg flag，v1.23+ 新增）
+
+服务端称 message flag，用于把消息加 Feed 标记，把消息推上用户 Feed/书签。
+对应 HTTP API `POST/GET/PATCH /open-apis/im/v1/flags`。需 User Access Token，scope `im:flag`。
+
+### 命令速查
+
+- `feishu-cli msg flag create <message_id>` — 创建消息层书签（默认 `--item-type default --flag-type message`）
+- `feishu-cli msg flag create <message_id> --item-type msg_thread --flag-type feed` — feed 层书签（普通群线程）
+- `feishu-cli msg flag list [--page-size 50] [--page-token xxx]` — 列当前用户的书签
+- `feishu-cli msg flag cancel <message_id> [--item-type ... --flag-type ...]` — 取消书签（item/flag 必须与 create 一致）
+
+### 关键枚举（服务端真值，绝勿按 0/1/2 顺序臆造）
+
+CLI flag 用字符串，底层映射到 OpenAPI 整数枚举：
+
+| 字段 | CLI 字符串 | OpenAPI 整数 | 含义 |
+| --- | --- | --- | --- |
+| --item-type | default | 0 | 普通消息 |
+| --item-type | thread | 4 | topic-style 话题群 |
+| --item-type | msg_thread | 11 | 普通群消息线程 |
+| --flag-type | message | 2 | 消息层书签（默认） |
+| --flag-type | feed | 1 | feed 层（侧边栏书签） |
+
+支持的组合（其余服务端拒绝）：
+- `default + message`：消息层书签，最常见
+- `thread + feed`：topic-style 话题群 feed 层
+- `msg_thread + feed`：普通群消息线程 feed 层
+
+源码引用：`internal/client/flag.go:23-28`（本仓库权威，对齐 lark-cli `shortcuts/im` 的 ItemType/FlagType 定义）。


### PR DESCRIPTION
## 背景

feishu-cli 缺少消息书签功能，lark-cli 已支持。本 PR 补齐 \`feishu-cli msg flag\` 子命令组。

## 新增命令

```bash
# 创建书签（默认 message 层）
feishu-cli msg flag create --message-id om_xxx [--item-type message|thread|msg_thread] [--flag-type default|feed]

# 列出书签
feishu-cli msg flag list [--flag-type default|feed]

# 取消书签
feishu-cli msg flag cancel --message-id om_xxx [--flag-type ...]
```

支持组合：\`default+message\`（默认）/ \`thread+feed\` / \`msg_thread+feed\`。

## 实现要点

- 接口：\`/open-apis/im/v1/flags\`（lark-cli 实测用 v1，未升 v2）
- SDK v3.5.3 未封装 flag 接口，用 \`client.Post\`/\`client.Get\`（与 \`CreateCommentReply\` 同套路）
- 默认 user token（fallback to app token），\`im:flag\` scope

## 测试

- \`go test ./internal/client/ -run \"Flag|flag\"\` 2 PASS
- \`go vet ./...\` / \`go build ./...\` 全绿

## 4 commit

1. feat client（CreateFlag/ListFlags/CancelFlag）
2. feat cmd（3 子命令）
3. test（parser 单测）
4. docs changelog