### PR TITLE
feat(okr): 新增 OKR 模块（cycle list / progress list+create）

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,45 @@
 
 ## 未发布
 
+### 新增 — `okr` 模块：OKR 周期和进展记录
+
+新增 `feishu-cli okr` 命令组，覆盖 OKR 最高频的 3 个操作：
+
+- `okr cycle list --user-id ou_xxx` — 获取指定用户的所有 OKR 周期（v2 接口，自动分页）
+- `okr progress list --objective-id 7xxx | --key-result-id 7xxx` — 列出某个目标 / 关键结果下的所有进展记录
+- `okr progress create --objective-id 7xxx | --key-result-id 7xxx --content "..."` — 创建一条进展记录，
+  支持纯文本（`--content`，自动包装为 ContentBlock）或原始富文本（`--content-json`）；
+  可附带 `--progress-percent` + `--progress-status` 标记进度
+
+**实现要点**：
+
+- `progress create` 走飞书 Open SDK v3.5.3 的 `Okr.ProgressRecord.Create`；
+  `cycle list` / `progress list` 走通用 HTTP client 直调 `/open-apis/okr/v2/...`
+  （v2 接口在当前 SDK 版本未封装）
+- 所有命令默认使用 User Token，会自动读取 `~/.feishu-cli/token.json`；
+  也可以通过 `--user-access-token` 或 `FEISHU_USER_ACCESS_TOKEN` 显式覆盖
+- 时间戳统一格式化为本地时区 `YYYY-MM-DD HH:MM:SS`，方便人眼阅读
+
+**权限要求（User Token scope）**：
+
+| 命令              | scope                                              |
+|-------------------|----------------------------------------------------|
+| `cycle list`      | `okr:okr:readonly` 或 `okr:okr.period:readonly`    |
+| `progress list`   | `okr:okr:readonly` 或 `okr:okr.progress:readonly`  |
+| `progress create` | `okr:okr` 或 `okr:okr.progress:writeonly`          |
+
+**使用示例**：
+
+```bash
+feishu-cli auth login --scope "okr:okr"
+feishu-cli okr cycle list --user-id ou_xxx
+feishu-cli okr progress list --objective-id 7xxx
+feishu-cli okr progress create --key-result-id 7xxx --content "本周完成核心模块联调"
+```
+
+**MVP 范围说明**：本次只覆盖最常用的 3 个动词，progress update / delete / get 和图片上传暂不暴露
+为命令行（client 层已有实现，后续按需补 CLI）。
+
 ### 新增 — `comment reply add`：为已有评论添加回复
 
 新增命令 `feishu-cli comment reply add <file_token> <comment_id> --text "..."`，补齐评论回复

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,17 +10,18 @@
 
 新增 `feishu-cli okr` 命令组，覆盖 OKR 最高频的 3 个操作：
 
-- `okr cycle list --user-id ou_xxx` — 获取指定用户的所有 OKR 周期（v2 接口，自动分页）
+- `okr cycle list` — 获取当前租户的所有 OKR 周期（`/open-apis/okr/v1/periods`，租户级全局列表，自动分页）
 - `okr progress list --objective-id 7xxx | --key-result-id 7xxx` — 列出某个目标 / 关键结果下的所有进展记录
 - `okr progress create --objective-id 7xxx | --key-result-id 7xxx --content "..."` — 创建一条进展记录，
   支持纯文本（`--content`，自动包装为 ContentBlock）或原始富文本（`--content-json`）；
-  可附带 `--progress-percent` + `--progress-status` 标记进度
+  可附带 `--progress-percent` + `--progress-status` 标记进度；
+  `--source-url` 飞书侧必填，CLI 默认填 `https://www.feishu.cn/okr/progress` placeholder，可显式覆盖
 
 **实现要点**：
 
 - `progress create` 走飞书 Open SDK v3.5.3 的 `Okr.ProgressRecord.Create`；
-  `cycle list` / `progress list` 走通用 HTTP client 直调 `/open-apis/okr/v2/...`
-  （v2 接口在当前 SDK 版本未封装）
+  `cycle list` 走通用 HTTP client 直调 `/open-apis/okr/v1/periods`（v1/periods 是租户级，不按用户过滤）；
+  `progress list` 走通用 HTTP client 直调 `/open-apis/okr/v2/...`
 - 所有命令默认使用 User Token，会自动读取 `~/.feishu-cli/token.json`；
   也可以通过 `--user-access-token` 或 `FEISHU_USER_ACCESS_TOKEN` 显式覆盖
 - 时间戳统一格式化为本地时区 `YYYY-MM-DD HH:MM:SS`，方便人眼阅读
@@ -37,7 +38,7 @@
 
 ```bash
 feishu-cli auth login --scope "okr:okr"
-feishu-cli okr cycle list --user-id ou_xxx
+feishu-cli okr cycle list
 feishu-cli okr progress list --objective-id 7xxx
 feishu-cli okr progress create --key-result-id 7xxx --content "本周完成核心模块联调"
 ```

--- a/cmd/okr.go
+++ b/cmd/okr.go
@@ -1,0 +1,66 @@
+package cmd
+
+import "github.com/spf13/cobra"
+
+var okrCmd = &cobra.Command{
+	Use:   "okr",
+	Short: "OKR 操作命令",
+	Long: `OKR 操作命令，用于查询 OKR 周期、进展记录。
+
+子命令组:
+  cycle      OKR 周期相关（list）
+  progress   OKR 进展记录相关（list / create）
+
+权限要求（User Token）:
+  cycle list           okr:okr:readonly 或 okr:okr.period:readonly
+  progress list        okr:okr:readonly 或 okr:okr.progress:readonly
+  progress create      okr:okr 或 okr:okr.progress:writeonly
+
+示例:
+  # 查询当前用户的所有 OKR 周期
+  feishu-cli okr cycle list --user-id ou_xxx
+
+  # 查询某个目标的所有进展记录
+  feishu-cli okr progress list --objective-id 7123456789012345678
+
+  # 为某个关键结果创建一条进展记录（纯文本）
+  feishu-cli okr progress create \
+    --key-result-id 7123456789012345678 \
+    --content "本周完成核心模块联调"
+
+提示:
+  - OKR API 默认走 User Token，命令会自动读取 ~/.feishu-cli/token.json
+  - 未登录或 token 过期时请先执行 feishu-cli auth login`,
+}
+
+var okrCycleCmd = &cobra.Command{
+	Use:   "cycle",
+	Short: "OKR 周期相关命令",
+	Long: `OKR 周期相关命令。
+
+子命令:
+  list   获取指定用户的 OKR 周期列表
+
+示例:
+  feishu-cli okr cycle list --user-id ou_xxx`,
+}
+
+var okrProgressCmd = &cobra.Command{
+	Use:   "progress",
+	Short: "OKR 进展记录相关命令",
+	Long: `OKR 进展记录相关命令。
+
+子命令:
+  list     获取某个目标 / 关键结果下的进展记录列表
+  create   为某个目标 / 关键结果创建进展记录
+
+示例:
+  feishu-cli okr progress list --objective-id 7xxx
+  feishu-cli okr progress create --key-result-id 7xxx --content "本周完成 X"`,
+}
+
+func init() {
+	rootCmd.AddCommand(okrCmd)
+	okrCmd.AddCommand(okrCycleCmd)
+	okrCmd.AddCommand(okrProgressCmd)
+}

--- a/cmd/okr.go
+++ b/cmd/okr.go
@@ -17,8 +17,8 @@ var okrCmd = &cobra.Command{
   progress create      okr:okr 或 okr:okr.progress:writeonly
 
 示例:
-  # 查询当前用户的所有 OKR 周期
-  feishu-cli okr cycle list --user-id ou_xxx
+  # 查询当前租户的所有 OKR 周期（租户级全局列表）
+  feishu-cli okr cycle list
 
   # 查询某个目标的所有进展记录
   feishu-cli okr progress list --objective-id 7123456789012345678
@@ -39,10 +39,10 @@ var okrCycleCmd = &cobra.Command{
 	Long: `OKR 周期相关命令。
 
 子命令:
-  list   获取指定用户的 OKR 周期列表
+  list   获取当前租户的 OKR 周期列表
 
 示例:
-  feishu-cli okr cycle list --user-id ou_xxx`,
+  feishu-cli okr cycle list`,
 }
 
 var okrProgressCmd = &cobra.Command{

--- a/cmd/okr_cycle_list.go
+++ b/cmd/okr_cycle_list.go
@@ -10,45 +10,33 @@ import (
 
 var okrCycleListCmd = &cobra.Command{
 	Use:   "list",
-	Short: "获取指定用户的 OKR 周期列表",
-	Long: `获取指定用户的 OKR 周期列表（v2 接口，自动分页）。
+	Short: "获取当前租户的 OKR 周期列表",
+	Long: `获取当前租户的 OKR 周期列表（/open-apis/okr/v1/periods，自动分页）。
+
+注意：飞书 v1/periods 是租户级全局周期列表，不按用户过滤，所有成员看到的周期一致。
 
 参数:
-  --user-id        用户 ID（必填）
-  --user-id-type   用户 ID 类型：open_id（默认） / union_id / user_id
   --output, -o     输出格式：json
 
 权限要求（User Token）:
   okr:okr:readonly 或 okr:okr.period:readonly
 
 示例:
-  # 查询用户 OKR 周期列表（默认 open_id）
-  feishu-cli okr cycle list --user-id ou_xxx
-
-  # 用 user_id 查询
-  feishu-cli okr cycle list --user-id 123456 --user-id-type user_id
+  # 查询当前租户所有 OKR 周期
+  feishu-cli okr cycle list
 
   # JSON 输出（适合脚本消费）
-  feishu-cli okr cycle list --user-id ou_xxx --output json`,
+  feishu-cli okr cycle list --output json`,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		if err := config.Validate(); err != nil {
 			return err
 		}
 
-		userID, _ := cmd.Flags().GetString("user-id")
-		userIDType, _ := cmd.Flags().GetString("user-id-type")
 		output, _ := cmd.Flags().GetString("output")
-
-		if err := validateUserIDType(userIDType); err != nil {
-			return err
-		}
 
 		token := resolveOptionalUserTokenWithFallback(cmd)
 
-		cycles, err := client.ListOKRCycles(client.ListOKRCyclesOptions{
-			UserID:     userID,
-			UserIDType: userIDType,
-		}, token)
+		cycles, err := client.ListOKRCycles(client.ListOKRCyclesOptions{}, token)
 		if err != nil {
 			return err
 		}
@@ -67,15 +55,20 @@ var okrCycleListCmd = &cobra.Command{
 
 		fmt.Printf("共找到 %d 个 OKR 周期\n", len(cycles))
 		for idx, c := range cycles {
-			fmt.Printf("[%d] %s\n", idx+1, c.ID)
+			name := c.ZhName
+			if name == "" {
+				name = c.EnName
+			}
+			if name == "" {
+				fmt.Printf("[%d] %s\n", idx+1, c.ID)
+			} else {
+				fmt.Printf("[%d] %s (%s)\n", idx+1, name, c.ID)
+			}
 			if c.StartTime != "" || c.EndTime != "" {
 				fmt.Printf("    时间: %s ~ %s\n", c.StartTime, c.EndTime)
 			}
 			if c.CycleStatus != "" {
 				fmt.Printf("    状态: %s\n", c.CycleStatus)
-			}
-			if c.TenantCycleID != "" {
-				fmt.Printf("    租户周期 ID: %s\n", c.TenantCycleID)
 			}
 		}
 
@@ -96,9 +89,6 @@ func validateUserIDType(t string) error {
 func init() {
 	okrCycleCmd.AddCommand(okrCycleListCmd)
 
-	okrCycleListCmd.Flags().String("user-id", "", "用户 ID（必填）")
-	okrCycleListCmd.Flags().String("user-id-type", "open_id", "用户 ID 类型：open_id / union_id / user_id")
 	okrCycleListCmd.Flags().StringP("output", "o", "", "输出格式（json）")
 	okrCycleListCmd.Flags().String("user-access-token", "", "User Access Token（用户授权令牌，留空则自动读取登录态）")
-	mustMarkFlagRequired(okrCycleListCmd, "user-id")
 }

--- a/cmd/okr_cycle_list.go
+++ b/cmd/okr_cycle_list.go
@@ -1,0 +1,104 @@
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/riba2534/feishu-cli/internal/client"
+	"github.com/riba2534/feishu-cli/internal/config"
+	"github.com/spf13/cobra"
+)
+
+var okrCycleListCmd = &cobra.Command{
+	Use:   "list",
+	Short: "获取指定用户的 OKR 周期列表",
+	Long: `获取指定用户的 OKR 周期列表（v2 接口，自动分页）。
+
+参数:
+  --user-id        用户 ID（必填）
+  --user-id-type   用户 ID 类型：open_id（默认） / union_id / user_id
+  --output, -o     输出格式：json
+
+权限要求（User Token）:
+  okr:okr:readonly 或 okr:okr.period:readonly
+
+示例:
+  # 查询用户 OKR 周期列表（默认 open_id）
+  feishu-cli okr cycle list --user-id ou_xxx
+
+  # 用 user_id 查询
+  feishu-cli okr cycle list --user-id 123456 --user-id-type user_id
+
+  # JSON 输出（适合脚本消费）
+  feishu-cli okr cycle list --user-id ou_xxx --output json`,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		if err := config.Validate(); err != nil {
+			return err
+		}
+
+		userID, _ := cmd.Flags().GetString("user-id")
+		userIDType, _ := cmd.Flags().GetString("user-id-type")
+		output, _ := cmd.Flags().GetString("output")
+
+		if err := validateUserIDType(userIDType); err != nil {
+			return err
+		}
+
+		token := resolveOptionalUserTokenWithFallback(cmd)
+
+		cycles, err := client.ListOKRCycles(client.ListOKRCyclesOptions{
+			UserID:     userID,
+			UserIDType: userIDType,
+		}, token)
+		if err != nil {
+			return err
+		}
+
+		if output == "json" {
+			return printJSON(map[string]any{
+				"cycles": cycles,
+				"total":  len(cycles),
+			})
+		}
+
+		if len(cycles) == 0 {
+			fmt.Println("未找到 OKR 周期")
+			return nil
+		}
+
+		fmt.Printf("共找到 %d 个 OKR 周期\n", len(cycles))
+		for idx, c := range cycles {
+			fmt.Printf("[%d] %s\n", idx+1, c.ID)
+			if c.StartTime != "" || c.EndTime != "" {
+				fmt.Printf("    时间: %s ~ %s\n", c.StartTime, c.EndTime)
+			}
+			if c.CycleStatus != "" {
+				fmt.Printf("    状态: %s\n", c.CycleStatus)
+			}
+			if c.TenantCycleID != "" {
+				fmt.Printf("    租户周期 ID: %s\n", c.TenantCycleID)
+			}
+		}
+
+		return nil
+	},
+}
+
+// validateUserIDType 校验 user-id-type 取值
+func validateUserIDType(t string) error {
+	switch t {
+	case "open_id", "union_id", "user_id":
+		return nil
+	default:
+		return fmt.Errorf("不支持的 --user-id-type: %s（可选: open_id / union_id / user_id）", t)
+	}
+}
+
+func init() {
+	okrCycleCmd.AddCommand(okrCycleListCmd)
+
+	okrCycleListCmd.Flags().String("user-id", "", "用户 ID（必填）")
+	okrCycleListCmd.Flags().String("user-id-type", "open_id", "用户 ID 类型：open_id / union_id / user_id")
+	okrCycleListCmd.Flags().StringP("output", "o", "", "输出格式（json）")
+	okrCycleListCmd.Flags().String("user-access-token", "", "User Access Token（用户授权令牌，留空则自动读取登录态）")
+	mustMarkFlagRequired(okrCycleListCmd, "user-id")
+}

--- a/cmd/okr_progress_create.go
+++ b/cmd/okr_progress_create.go
@@ -28,7 +28,8 @@ var okrProgressCreateCmd = &cobra.Command{
   --progress-percent  进度百分比（数字，配合 --progress-status 一起使用）
   --progress-status   进度状态：normal / overdue / done
   --source-title      来源标题（默认 "created by feishu-cli"）
-  --source-url        来源 URL（用于卡片点击跳转）
+  --source-url        来源 URL（飞书 API 必填字段；默认 "https://www.feishu.cn/okr/progress"，
+                      可改成进展实际跳转地址）
   --user-id-type      用户 ID 类型：open_id（默认） / union_id / user_id
   --output, -o        输出格式：json
 

--- a/cmd/okr_progress_create.go
+++ b/cmd/okr_progress_create.go
@@ -1,0 +1,209 @@
+package cmd
+
+import (
+	"encoding/json"
+	"fmt"
+	"strconv"
+	"strings"
+
+	"github.com/riba2534/feishu-cli/internal/client"
+	"github.com/riba2534/feishu-cli/internal/config"
+	"github.com/spf13/cobra"
+)
+
+var okrProgressCreateCmd = &cobra.Command{
+	Use:   "create",
+	Short: "为目标或关键结果创建一条进展记录",
+	Long: `为目标（Objective）或关键结果（Key Result）创建一条进展记录。
+
+二选一参数（必须且只能填一个）:
+  --objective-id      目标 ID
+  --key-result-id     关键结果 ID
+
+内容参数（二选一）:
+  --content           纯文本内容（自动包装为 ContentBlock 富文本）
+  --content-json      原始 ContentBlock JSON（适合需要 mention、链接、图片等富文本场景）
+
+可选参数:
+  --progress-percent  进度百分比（数字，配合 --progress-status 一起使用）
+  --progress-status   进度状态：normal / overdue / done
+  --source-title      来源标题（默认 "created by feishu-cli"）
+  --source-url        来源 URL（用于卡片点击跳转）
+  --user-id-type      用户 ID 类型：open_id（默认） / union_id / user_id
+  --output, -o        输出格式：json
+
+权限要求（User Token）:
+  okr:okr 或 okr:okr.progress:writeonly
+
+示例:
+  # 给目标加一条纯文本进展
+  feishu-cli okr progress create --objective-id 7xxx --content "本周完成模块联调"
+
+  # 给关键结果加进展 + 进度百分比
+  feishu-cli okr progress create \
+    --key-result-id 7xxx \
+    --content "完成 8/10 任务" \
+    --progress-percent 80 \
+    --progress-status normal
+
+  # 用 ContentBlock JSON 自定义富文本
+  feishu-cli okr progress create \
+    --objective-id 7xxx \
+    --content-json '{"blocks":[{"type":"paragraph","paragraph":{"elements":[{"type":"textRun","textRun":{"text":"加粗内容","style":{"bold":true}}}]}}]}'`,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		if err := config.Validate(); err != nil {
+			return err
+		}
+
+		objectiveID, _ := cmd.Flags().GetString("objective-id")
+		keyResultID, _ := cmd.Flags().GetString("key-result-id")
+		contentText, _ := cmd.Flags().GetString("content")
+		contentJSON, _ := cmd.Flags().GetString("content-json")
+		progressPercent, _ := cmd.Flags().GetString("progress-percent")
+		progressStatus, _ := cmd.Flags().GetString("progress-status")
+		sourceTitle, _ := cmd.Flags().GetString("source-title")
+		sourceURL, _ := cmd.Flags().GetString("source-url")
+		userIDType, _ := cmd.Flags().GetString("user-id-type")
+		output, _ := cmd.Flags().GetString("output")
+
+		targetID, targetType, err := pickOKRTarget(objectiveID, keyResultID)
+		if err != nil {
+			return err
+		}
+
+		if err := validateUserIDType(userIDType); err != nil {
+			return err
+		}
+
+		finalContentJSON, err := buildOKRProgressContentJSON(contentText, contentJSON)
+		if err != nil {
+			return err
+		}
+
+		opts := client.CreateOKRProgressOptions{
+			ContentJSON: finalContentJSON,
+			TargetID:    targetID,
+			TargetType:  targetType,
+			SourceTitle: sourceTitle,
+			SourceURL:   sourceURL,
+			UserIDType:  userIDType,
+		}
+
+		if progressPercent != "" {
+			percent, err := strconv.ParseFloat(progressPercent, 64)
+			if err != nil {
+				return fmt.Errorf("--progress-percent 必须是数字: %w", err)
+			}
+			rate := &client.OKRProgressRateInput{Percent: percent}
+			if progressStatus != "" {
+				status, ok := client.ParseOKRProgressStatus(progressStatus)
+				if !ok {
+					return fmt.Errorf("--progress-status 必须为 normal / overdue / done")
+				}
+				rate.Status = &status
+			}
+			opts.ProgressRate = rate
+		} else if progressStatus != "" {
+			return fmt.Errorf("--progress-status 必须配合 --progress-percent 一起使用")
+		}
+
+		token := resolveOptionalUserTokenWithFallback(cmd)
+		progress, err := client.CreateOKRProgress(opts, token)
+		if err != nil {
+			return err
+		}
+
+		if output == "json" {
+			return printJSON(progress)
+		}
+
+		fmt.Printf("已创建 OKR 进展记录\n")
+		fmt.Printf("  进展 ID: %s\n", progress.ProgressID)
+		if progress.ModifyTime != "" {
+			fmt.Printf("  修改时间: %s\n", progress.ModifyTime)
+		}
+		if progress.ProgressRate != nil && progress.ProgressRate.Percent != nil {
+			fmt.Printf("  进度: %.1f%%\n", *progress.ProgressRate.Percent)
+		}
+		if progress.ProgressRate != nil && progress.ProgressRate.Status != "" {
+			fmt.Printf("  状态: %s\n", progress.ProgressRate.Status)
+		}
+		return nil
+	},
+}
+
+// pickOKRTarget 校验 --objective-id / --key-result-id 二选一，返回 (targetID, targetType)
+func pickOKRTarget(objectiveID, keyResultID string) (string, client.OKRProgressTargetType, error) {
+	hasObj := objectiveID != ""
+	hasKR := keyResultID != ""
+	switch {
+	case hasObj && hasKR:
+		return "", 0, fmt.Errorf("--objective-id 和 --key-result-id 只能填一个")
+	case hasObj:
+		return objectiveID, client.OKRTargetObjective, nil
+	case hasKR:
+		return keyResultID, client.OKRTargetKeyResult, nil
+	default:
+		return "", 0, fmt.Errorf("必须指定 --objective-id 或 --key-result-id 之一")
+	}
+}
+
+// buildOKRProgressContentJSON 把 --content（纯文本）或 --content-json（原始 JSON）归一化为
+// 飞书 OKR v1 ContentBlock JSON 字符串。
+func buildOKRProgressContentJSON(text, raw string) (string, error) {
+	rawTrim := strings.TrimSpace(raw)
+	textTrim := strings.TrimSpace(text)
+	if rawTrim != "" && textTrim != "" {
+		return "", fmt.Errorf("--content 和 --content-json 只能填一个")
+	}
+	if rawTrim == "" && textTrim == "" {
+		return "", fmt.Errorf("必须指定 --content 或 --content-json 之一")
+	}
+	if rawTrim != "" {
+		// 校验是合法 JSON，避免下游报莫名错
+		var probe any
+		if err := json.Unmarshal([]byte(rawTrim), &probe); err != nil {
+			return "", fmt.Errorf("--content-json 不是合法 JSON: %w", err)
+		}
+		return rawTrim, nil
+	}
+	// 纯文本：包装成最小可用的 ContentBlock paragraph + textRun
+	wrapped := map[string]any{
+		"blocks": []any{
+			map[string]any{
+				"type": "paragraph",
+				"paragraph": map[string]any{
+					"elements": []any{
+						map[string]any{
+							"type": "textRun",
+							"textRun": map[string]any{
+								"text": text,
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+	data, err := json.Marshal(wrapped)
+	if err != nil {
+		return "", fmt.Errorf("构造 ContentBlock 失败: %w", err)
+	}
+	return string(data), nil
+}
+
+func init() {
+	okrProgressCmd.AddCommand(okrProgressCreateCmd)
+
+	okrProgressCreateCmd.Flags().String("objective-id", "", "目标 ID（与 --key-result-id 二选一）")
+	okrProgressCreateCmd.Flags().String("key-result-id", "", "关键结果 ID（与 --objective-id 二选一）")
+	okrProgressCreateCmd.Flags().String("content", "", "进展内容（纯文本，自动包装为 ContentBlock）")
+	okrProgressCreateCmd.Flags().String("content-json", "", "进展内容（原始 ContentBlock JSON 字符串）")
+	okrProgressCreateCmd.Flags().String("progress-percent", "", "进度百分比（数字）")
+	okrProgressCreateCmd.Flags().String("progress-status", "", "进度状态：normal / overdue / done")
+	okrProgressCreateCmd.Flags().String("source-title", "", "来源标题（默认 'created by feishu-cli'）")
+	okrProgressCreateCmd.Flags().String("source-url", "", "来源 URL（用于卡片点击跳转）")
+	okrProgressCreateCmd.Flags().String("user-id-type", "open_id", "用户 ID 类型：open_id / union_id / user_id")
+	okrProgressCreateCmd.Flags().StringP("output", "o", "", "输出格式（json）")
+	okrProgressCreateCmd.Flags().String("user-access-token", "", "User Access Token（用户授权令牌，留空则自动读取登录态）")
+}

--- a/cmd/okr_progress_list.go
+++ b/cmd/okr_progress_list.go
@@ -1,0 +1,102 @@
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/riba2534/feishu-cli/internal/client"
+	"github.com/riba2534/feishu-cli/internal/config"
+	"github.com/spf13/cobra"
+)
+
+var okrProgressListCmd = &cobra.Command{
+	Use:   "list",
+	Short: "获取目标或关键结果下的进展记录列表",
+	Long: `获取一个 Objective 或 Key Result 下的所有进展记录（v2 接口，自动分页）。
+
+二选一参数（必须且只能填一个）:
+  --objective-id      目标 ID
+  --key-result-id     关键结果 ID
+
+可选参数:
+  --user-id-type      用户 ID 类型：open_id（默认） / union_id / user_id
+  --output, -o        输出格式：json
+
+权限要求（User Token）:
+  okr:okr:readonly 或 okr:okr.progress:readonly
+
+示例:
+  # 列出某个 Objective 的所有进展
+  feishu-cli okr progress list --objective-id 7xxx
+
+  # 列出某个 Key Result 的进展（JSON 输出）
+  feishu-cli okr progress list --key-result-id 7xxx --output json`,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		if err := config.Validate(); err != nil {
+			return err
+		}
+
+		objectiveID, _ := cmd.Flags().GetString("objective-id")
+		keyResultID, _ := cmd.Flags().GetString("key-result-id")
+		userIDType, _ := cmd.Flags().GetString("user-id-type")
+		output, _ := cmd.Flags().GetString("output")
+
+		targetID, targetType, err := pickOKRTarget(objectiveID, keyResultID)
+		if err != nil {
+			return err
+		}
+
+		if err := validateUserIDType(userIDType); err != nil {
+			return err
+		}
+
+		token := resolveOptionalUserTokenWithFallback(cmd)
+		progresses, err := client.ListOKRProgresses(client.ListOKRProgressesOptions{
+			TargetID:   targetID,
+			TargetType: targetType,
+			UserIDType: userIDType,
+		}, token)
+		if err != nil {
+			return err
+		}
+
+		if output == "json" {
+			return printJSON(map[string]any{
+				"progresses": progresses,
+				"total":      len(progresses),
+			})
+		}
+
+		if len(progresses) == 0 {
+			fmt.Println("未找到 OKR 进展记录")
+			return nil
+		}
+
+		fmt.Printf("共找到 %d 条 OKR 进展记录\n", len(progresses))
+		for idx, p := range progresses {
+			fmt.Printf("[%d] %s\n", idx+1, p.ProgressID)
+			if p.ModifyTime != "" {
+				fmt.Printf("    修改时间: %s\n", p.ModifyTime)
+			}
+			if p.CreateTime != "" {
+				fmt.Printf("    创建时间: %s\n", p.CreateTime)
+			}
+			if p.ProgressRate != nil && p.ProgressRate.Percent != nil {
+				fmt.Printf("    进度: %.1f%%\n", *p.ProgressRate.Percent)
+			}
+			if p.ProgressRate != nil && p.ProgressRate.Status != "" {
+				fmt.Printf("    状态: %s\n", p.ProgressRate.Status)
+			}
+		}
+		return nil
+	},
+}
+
+func init() {
+	okrProgressCmd.AddCommand(okrProgressListCmd)
+
+	okrProgressListCmd.Flags().String("objective-id", "", "目标 ID（与 --key-result-id 二选一）")
+	okrProgressListCmd.Flags().String("key-result-id", "", "关键结果 ID（与 --objective-id 二选一）")
+	okrProgressListCmd.Flags().String("user-id-type", "open_id", "用户 ID 类型：open_id / union_id / user_id")
+	okrProgressListCmd.Flags().StringP("output", "o", "", "输出格式（json）")
+	okrProgressListCmd.Flags().String("user-access-token", "", "User Access Token（用户授权令牌，留空则自动读取登录态）")
+}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -47,6 +47,7 @@ var rootCmd = &cobra.Command{
   mail      邮箱（发送/回复/转发/草稿/查询；User Token）
   drive     云盘增强（分块上传、有界轮询导出/导入、富文本评论、通用 task-result）
   search    搜索操作（消息、应用搜索，需要用户授权）
+  okr       OKR 操作（周期列表、进展记录列表与创建）
   config    配置管理（初始化配置）
 
 注意：bitable 命令已切换到 base/v3 API，flag 使用 --base-token。

--- a/internal/client/okr.go
+++ b/internal/client/okr.go
@@ -1,0 +1,941 @@
+package client
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"time"
+
+	larkcore "github.com/larksuite/oapi-sdk-go/v3/core"
+	larkokr "github.com/larksuite/oapi-sdk-go/v3/service/okr/v1"
+)
+
+// --------- OKR 业务结构（输出层）---------
+
+// OKROwner OKR 所有者，与飞书 OpenAPI 字段对齐
+type OKROwner struct {
+	OwnerType string `json:"owner_type"`
+	UserID    string `json:"user_id,omitempty"`
+}
+
+// OKRCycle OKR 周期（v2 接口实体）
+type OKRCycle struct {
+	ID            string   `json:"id"`
+	CreateTime    string   `json:"create_time,omitempty"`
+	UpdateTime    string   `json:"update_time,omitempty"`
+	TenantCycleID string   `json:"tenant_cycle_id,omitempty"`
+	Owner         OKROwner `json:"owner"`
+	StartTime     string   `json:"start_time,omitempty"`
+	EndTime       string   `json:"end_time,omitempty"`
+	CycleStatus   string   `json:"cycle_status,omitempty"`
+	Score         *float64 `json:"score,omitempty"`
+}
+
+// OKRKeyResult 关键结果
+type OKRKeyResult struct {
+	ID          string   `json:"id"`
+	CreateTime  string   `json:"create_time,omitempty"`
+	UpdateTime  string   `json:"update_time,omitempty"`
+	Owner       OKROwner `json:"owner"`
+	ObjectiveID string   `json:"objective_id"`
+	Position    *int32   `json:"position,omitempty"`
+	Content     string   `json:"content,omitempty"`
+	Score       *float64 `json:"score,omitempty"`
+	Weight      *float64 `json:"weight,omitempty"`
+	Deadline    string   `json:"deadline,omitempty"`
+}
+
+// OKRObjective 目标
+type OKRObjective struct {
+	ID         string         `json:"id"`
+	CreateTime string         `json:"create_time,omitempty"`
+	UpdateTime string         `json:"update_time,omitempty"`
+	Owner      OKROwner       `json:"owner"`
+	CycleID    string         `json:"cycle_id"`
+	Position   *int32         `json:"position,omitempty"`
+	Content    string         `json:"content,omitempty"`
+	Notes      string         `json:"notes,omitempty"`
+	Score      *float64       `json:"score,omitempty"`
+	Weight     *float64       `json:"weight,omitempty"`
+	Deadline   string         `json:"deadline,omitempty"`
+	CategoryID string         `json:"category_id,omitempty"`
+	KeyResults []OKRKeyResult `json:"key_results,omitempty"`
+}
+
+// OKRProgressRate 进度率
+type OKRProgressRate struct {
+	Percent *float64 `json:"percent,omitempty"`
+	Status  string   `json:"status,omitempty"`
+}
+
+// OKRProgress OKR 进展记录
+type OKRProgress struct {
+	ProgressID   string           `json:"progress_id"`
+	ModifyTime   string           `json:"modify_time,omitempty"`
+	CreateTime   string           `json:"create_time,omitempty"`
+	Content      string           `json:"content,omitempty"`
+	ProgressRate *OKRProgressRate `json:"progress_rate,omitempty"`
+}
+
+// --------- 内部 JSON 反序列化结构（接近 OpenAPI 原始字段）---------
+
+type okrRawOwner struct {
+	OwnerType string  `json:"owner_type"`
+	UserID    *string `json:"user_id,omitempty"`
+}
+
+func (o *okrRawOwner) toOwner() OKROwner {
+	if o == nil {
+		return OKROwner{}
+	}
+	out := OKROwner{OwnerType: o.OwnerType}
+	if o.UserID != nil {
+		out.UserID = *o.UserID
+	}
+	return out
+}
+
+type okrCycleStatus int32
+
+const (
+	okrCycleStatusNormal  okrCycleStatus = 1
+	okrCycleStatusInvalid okrCycleStatus = 2
+	okrCycleStatusHidden  okrCycleStatus = 3
+)
+
+func (s okrCycleStatus) String() string {
+	switch s {
+	case okrCycleStatusNormal:
+		return "normal"
+	case okrCycleStatusInvalid:
+		return "invalid"
+	case okrCycleStatusHidden:
+		return "hidden"
+	}
+	return ""
+}
+
+type okrRawCycle struct {
+	ID            string          `json:"id"`
+	CreateTime    string          `json:"create_time,omitempty"`
+	UpdateTime    string          `json:"update_time,omitempty"`
+	TenantCycleID string          `json:"tenant_cycle_id,omitempty"`
+	Owner         okrRawOwner     `json:"owner"`
+	StartTime     string          `json:"start_time,omitempty"`
+	EndTime       string          `json:"end_time,omitempty"`
+	CycleStatus   *okrCycleStatus `json:"cycle_status,omitempty"`
+	Score         *float64        `json:"score,omitempty"`
+}
+
+func (c *okrRawCycle) toCycle() *OKRCycle {
+	if c == nil {
+		return nil
+	}
+	cycle := &OKRCycle{
+		ID:            c.ID,
+		CreateTime:    formatOKRTimestamp(c.CreateTime),
+		UpdateTime:    formatOKRTimestamp(c.UpdateTime),
+		TenantCycleID: c.TenantCycleID,
+		Owner:         c.Owner.toOwner(),
+		StartTime:     formatOKRTimestamp(c.StartTime),
+		EndTime:       formatOKRTimestamp(c.EndTime),
+		Score:         c.Score,
+	}
+	if c.CycleStatus != nil {
+		cycle.CycleStatus = c.CycleStatus.String()
+	}
+	return cycle
+}
+
+type okrRawObjective struct {
+	ID         string          `json:"id"`
+	CreateTime string          `json:"create_time,omitempty"`
+	UpdateTime string          `json:"update_time,omitempty"`
+	Owner      okrRawOwner     `json:"owner"`
+	CycleID    string          `json:"cycle_id"`
+	Position   *int32          `json:"position,omitempty"`
+	Content    json.RawMessage `json:"content,omitempty"`
+	Notes      json.RawMessage `json:"notes,omitempty"`
+	Score      *float64        `json:"score,omitempty"`
+	Weight     *float64        `json:"weight,omitempty"`
+	Deadline   *string         `json:"deadline,omitempty"`
+	CategoryID *string         `json:"category_id,omitempty"`
+}
+
+func (o *okrRawObjective) toObjective() *OKRObjective {
+	if o == nil {
+		return nil
+	}
+	out := &OKRObjective{
+		ID:         o.ID,
+		CreateTime: formatOKRTimestamp(o.CreateTime),
+		UpdateTime: formatOKRTimestamp(o.UpdateTime),
+		Owner:      o.Owner.toOwner(),
+		CycleID:    o.CycleID,
+		Position:   o.Position,
+		Content:    rawJSONString(o.Content),
+		Notes:      rawJSONString(o.Notes),
+		Score:      o.Score,
+		Weight:     o.Weight,
+	}
+	if o.Deadline != nil {
+		out.Deadline = formatOKRTimestamp(*o.Deadline)
+	}
+	if o.CategoryID != nil {
+		out.CategoryID = *o.CategoryID
+	}
+	return out
+}
+
+type okrRawKeyResult struct {
+	ID          string          `json:"id"`
+	CreateTime  string          `json:"create_time,omitempty"`
+	UpdateTime  string          `json:"update_time,omitempty"`
+	Owner       okrRawOwner     `json:"owner"`
+	ObjectiveID string          `json:"objective_id"`
+	Position    *int32          `json:"position,omitempty"`
+	Content     json.RawMessage `json:"content,omitempty"`
+	Score       *float64        `json:"score,omitempty"`
+	Weight      *float64        `json:"weight,omitempty"`
+	Deadline    *string         `json:"deadline,omitempty"`
+}
+
+func (k *okrRawKeyResult) toKeyResult() *OKRKeyResult {
+	if k == nil {
+		return nil
+	}
+	out := &OKRKeyResult{
+		ID:          k.ID,
+		CreateTime:  formatOKRTimestamp(k.CreateTime),
+		UpdateTime:  formatOKRTimestamp(k.UpdateTime),
+		Owner:       k.Owner.toOwner(),
+		ObjectiveID: k.ObjectiveID,
+		Position:    k.Position,
+		Content:     rawJSONString(k.Content),
+		Score:       k.Score,
+		Weight:      k.Weight,
+	}
+	if k.Deadline != nil {
+		out.Deadline = formatOKRTimestamp(*k.Deadline)
+	}
+	return out
+}
+
+// rawJSONString 将 json.RawMessage 转为字符串（保留 JSON 形态）；空值或 null 返回空字符串。
+func rawJSONString(raw json.RawMessage) string {
+	trimmed := strings.TrimSpace(string(raw))
+	if trimmed == "" || trimmed == "null" {
+		return ""
+	}
+	return trimmed
+}
+
+// formatOKRTimestamp 把毫秒字符串格式化为 YYYY-MM-DD HH:MM:SS（UTC+8 当地时间）；解析失败返回原值。
+func formatOKRTimestamp(ts string) string {
+	if ts == "" {
+		return ""
+	}
+	ms, err := strconv.ParseInt(ts, 10, 64)
+	if err != nil {
+		return ts
+	}
+	// 用 time.UnixMilli + Local 时区，本地展示更直观
+	return timeUnixMilliLocalString(ms)
+}
+
+// --------- OKR 周期列表（v2，分页拉取）---------
+
+// ListOKRCyclesOptions 列出周期的选项
+type ListOKRCyclesOptions struct {
+	UserID     string
+	UserIDType string // open_id / union_id / user_id
+}
+
+// ListOKRCycles 拉取指定用户的所有周期，自动分页（page_size=100）。
+// userAccessToken 必填（OKR 接口默认要求 User Token）。
+func ListOKRCycles(opts ListOKRCyclesOptions, userAccessToken string) ([]*OKRCycle, error) {
+	client, err := GetClient()
+	if err != nil {
+		return nil, err
+	}
+
+	if opts.UserIDType == "" {
+		opts.UserIDType = "open_id"
+	}
+
+	tokenType, reqOpts := resolveTokenOpts(userAccessToken)
+
+	all := make([]*OKRCycle, 0)
+	pageToken := ""
+	for page := 0; ; page++ {
+		query := larkcore.QueryParams{}
+		query.Set("user_id", opts.UserID)
+		query.Set("user_id_type", opts.UserIDType)
+		query.Set("page_size", "100")
+		if pageToken != "" {
+			query.Set("page_token", pageToken)
+		}
+
+		req := &larkcore.ApiReq{
+			HttpMethod:                http.MethodGet,
+			ApiPath:                   "/open-apis/okr/v2/cycles",
+			QueryParams:               query,
+			SupportedAccessTokenTypes: []larkcore.AccessTokenType{tokenType},
+		}
+
+		resp, err := client.Do(Context(), req, reqOpts...)
+		if err != nil {
+			return nil, fmt.Errorf("查询 OKR 周期失败: %w", err)
+		}
+		if resp.StatusCode != http.StatusOK {
+			return nil, fmt.Errorf("查询 OKR 周期失败: HTTP %d, body: %s", resp.StatusCode, string(resp.RawBody))
+		}
+
+		var apiResp struct {
+			Code int    `json:"code"`
+			Msg  string `json:"msg"`
+			Data struct {
+				Items     []*okrRawCycle `json:"items"`
+				HasMore   bool           `json:"has_more"`
+				PageToken string         `json:"page_token"`
+			} `json:"data"`
+		}
+		if err := json.Unmarshal(resp.RawBody, &apiResp); err != nil {
+			return nil, fmt.Errorf("解析 OKR 周期响应失败: %w", err)
+		}
+		if apiResp.Code != 0 {
+			return nil, fmt.Errorf("查询 OKR 周期失败: code=%d, msg=%s", apiResp.Code, apiResp.Msg)
+		}
+
+		for _, item := range apiResp.Data.Items {
+			if c := item.toCycle(); c != nil {
+				all = append(all, c)
+			}
+		}
+
+		if !apiResp.Data.HasMore || apiResp.Data.PageToken == "" {
+			break
+		}
+		pageToken = apiResp.Data.PageToken
+
+		// 防御性：上限 200 页（2 万条），避免异常响应造成死循环
+		if page >= 200 {
+			break
+		}
+	}
+
+	return all, nil
+}
+
+// --------- 周期详情：拉目标 + 每个目标的关键结果 ---------
+
+// GetOKRCycleDetail 拉取一个周期下所有目标及其关键结果，自动分页。
+func GetOKRCycleDetail(cycleID string, userAccessToken string) ([]*OKRObjective, error) {
+	client, err := GetClient()
+	if err != nil {
+		return nil, err
+	}
+
+	tokenType, reqOpts := resolveTokenOpts(userAccessToken)
+
+	rawObjectives, err := listOKRCycleObjectives(client, tokenType, reqOpts, cycleID)
+	if err != nil {
+		return nil, err
+	}
+
+	out := make([]*OKRObjective, 0, len(rawObjectives))
+	for _, ro := range rawObjectives {
+		obj := ro.toObjective()
+		if obj == nil {
+			continue
+		}
+		krs, err := listOKRObjectiveKeyResults(client, tokenType, reqOpts, obj.ID)
+		if err != nil {
+			return nil, fmt.Errorf("查询目标 %s 的关键结果失败: %w", obj.ID, err)
+		}
+		obj.KeyResults = krs
+		out = append(out, obj)
+	}
+	return out, nil
+}
+
+func listOKRCycleObjectives(client okrHTTPDoer, tokenType larkcore.AccessTokenType, reqOpts []larkcore.RequestOptionFunc, cycleID string) ([]*okrRawObjective, error) {
+	all := make([]*okrRawObjective, 0)
+	pageToken := ""
+	for page := 0; ; page++ {
+		query := larkcore.QueryParams{}
+		query.Set("page_size", "100")
+		if pageToken != "" {
+			query.Set("page_token", pageToken)
+		}
+
+		req := &larkcore.ApiReq{
+			HttpMethod:                http.MethodGet,
+			ApiPath:                   fmt.Sprintf("/open-apis/okr/v2/cycles/%s/objectives", cycleID),
+			QueryParams:               query,
+			SupportedAccessTokenTypes: []larkcore.AccessTokenType{tokenType},
+		}
+
+		resp, err := client.Do(Context(), req, reqOpts...)
+		if err != nil {
+			return nil, fmt.Errorf("查询周期目标失败: %w", err)
+		}
+		if resp.StatusCode != http.StatusOK {
+			return nil, fmt.Errorf("查询周期目标失败: HTTP %d, body: %s", resp.StatusCode, string(resp.RawBody))
+		}
+
+		var apiResp struct {
+			Code int    `json:"code"`
+			Msg  string `json:"msg"`
+			Data struct {
+				Items     []*okrRawObjective `json:"items"`
+				HasMore   bool               `json:"has_more"`
+				PageToken string             `json:"page_token"`
+			} `json:"data"`
+		}
+		if err := json.Unmarshal(resp.RawBody, &apiResp); err != nil {
+			return nil, fmt.Errorf("解析周期目标响应失败: %w", err)
+		}
+		if apiResp.Code != 0 {
+			return nil, fmt.Errorf("查询周期目标失败: code=%d, msg=%s", apiResp.Code, apiResp.Msg)
+		}
+
+		all = append(all, apiResp.Data.Items...)
+		if !apiResp.Data.HasMore || apiResp.Data.PageToken == "" {
+			break
+		}
+		pageToken = apiResp.Data.PageToken
+		if page >= 200 {
+			break
+		}
+	}
+	return all, nil
+}
+
+func listOKRObjectiveKeyResults(client okrHTTPDoer, tokenType larkcore.AccessTokenType, reqOpts []larkcore.RequestOptionFunc, objectiveID string) ([]OKRKeyResult, error) {
+	all := make([]OKRKeyResult, 0)
+	pageToken := ""
+	for page := 0; ; page++ {
+		query := larkcore.QueryParams{}
+		query.Set("page_size", "100")
+		if pageToken != "" {
+			query.Set("page_token", pageToken)
+		}
+
+		req := &larkcore.ApiReq{
+			HttpMethod:                http.MethodGet,
+			ApiPath:                   fmt.Sprintf("/open-apis/okr/v2/objectives/%s/key_results", objectiveID),
+			QueryParams:               query,
+			SupportedAccessTokenTypes: []larkcore.AccessTokenType{tokenType},
+		}
+
+		resp, err := client.Do(Context(), req, reqOpts...)
+		if err != nil {
+			return nil, fmt.Errorf("查询目标关键结果失败: %w", err)
+		}
+		if resp.StatusCode != http.StatusOK {
+			return nil, fmt.Errorf("查询目标关键结果失败: HTTP %d, body: %s", resp.StatusCode, string(resp.RawBody))
+		}
+
+		var apiResp struct {
+			Code int    `json:"code"`
+			Msg  string `json:"msg"`
+			Data struct {
+				Items     []*okrRawKeyResult `json:"items"`
+				HasMore   bool               `json:"has_more"`
+				PageToken string             `json:"page_token"`
+			} `json:"data"`
+		}
+		if err := json.Unmarshal(resp.RawBody, &apiResp); err != nil {
+			return nil, fmt.Errorf("解析目标关键结果响应失败: %w", err)
+		}
+		if apiResp.Code != 0 {
+			return nil, fmt.Errorf("查询目标关键结果失败: code=%d, msg=%s", apiResp.Code, apiResp.Msg)
+		}
+
+		for _, item := range apiResp.Data.Items {
+			if kr := item.toKeyResult(); kr != nil {
+				all = append(all, *kr)
+			}
+		}
+
+		if !apiResp.Data.HasMore || apiResp.Data.PageToken == "" {
+			break
+		}
+		pageToken = apiResp.Data.PageToken
+		if page >= 200 {
+			break
+		}
+	}
+	return all, nil
+}
+
+// --------- OKR 进展（v1，走 SDK；List 走 v2 HTTP）---------
+
+// OKRProgressTargetType OKR 进展挂载的实体类型
+type OKRProgressTargetType int
+
+const (
+	// OKRTargetObjective 目标 Objective
+	OKRTargetObjective OKRProgressTargetType = 2
+	// OKRTargetKeyResult 关键结果 Key Result
+	OKRTargetKeyResult OKRProgressTargetType = 3
+)
+
+// ParseOKRTargetType 把 objective / key_result 文本转为枚举
+func ParseOKRTargetType(s string) (OKRProgressTargetType, bool) {
+	switch s {
+	case "objective":
+		return OKRTargetObjective, true
+	case "key_result":
+		return OKRTargetKeyResult, true
+	}
+	return 0, false
+}
+
+// OKRProgressStatus 进展状态
+type OKRProgressStatus int
+
+const (
+	OKRProgressStatusNormal  OKRProgressStatus = 0
+	OKRProgressStatusOverdue OKRProgressStatus = 1
+	OKRProgressStatusDone    OKRProgressStatus = 2
+)
+
+// ParseOKRProgressStatus 把 normal / overdue / done 转为枚举
+func ParseOKRProgressStatus(s string) (OKRProgressStatus, bool) {
+	switch s {
+	case "normal", "0":
+		return OKRProgressStatusNormal, true
+	case "overdue", "1":
+		return OKRProgressStatusOverdue, true
+	case "done", "2":
+		return OKRProgressStatusDone, true
+	}
+	return 0, false
+}
+
+func (s OKRProgressStatus) String() string {
+	switch s {
+	case OKRProgressStatusNormal:
+		return "normal"
+	case OKRProgressStatusOverdue:
+		return "overdue"
+	case OKRProgressStatusDone:
+		return "done"
+	}
+	return ""
+}
+
+// CreateOKRProgressOptions 创建进展记录的选项
+type CreateOKRProgressOptions struct {
+	// ContentJSON 是 ContentBlock 富文本 JSON 字符串（v1 OKR 接口格式）。
+	// 可以传 v1 形态（type/textRun/...）也可以传 v2 形态（block_element_type/...），
+	// 内部会原样下发；推荐外部直接构造 v1 形态以避免歧义。
+	ContentJSON  string
+	TargetID     string
+	TargetType   OKRProgressTargetType
+	SourceTitle  string
+	SourceURL    string
+	UserIDType   string
+	ProgressRate *OKRProgressRateInput
+}
+
+// OKRProgressRateInput 进度率输入；Percent 必填，Status 可空
+type OKRProgressRateInput struct {
+	Percent float64
+	Status  *OKRProgressStatus
+}
+
+// CreateOKRProgress 创建一条 OKR 进展记录。
+// 走 v3 SDK 的 ProgressRecord.Create，内容字段使用 SDK 的 ContentBlock 结构；
+// 但 SDK 的 ContentBlock JSON tag 用的是 v1 字段名（type/textRun/elements/...），
+// 与 lark-cli 的 v1 形态一致，因此外部传入的 JSON 串以 v1 格式为准。
+func CreateOKRProgress(opts CreateOKRProgressOptions, userAccessToken string) (*OKRProgress, error) {
+	client, err := GetClient()
+	if err != nil {
+		return nil, err
+	}
+
+	var contentBlock *larkokr.ContentBlock
+	if strings.TrimSpace(opts.ContentJSON) != "" {
+		contentBlock = &larkokr.ContentBlock{}
+		if err := json.Unmarshal([]byte(opts.ContentJSON), contentBlock); err != nil {
+			return nil, fmt.Errorf("解析 ContentBlock JSON 失败: %w", err)
+		}
+	}
+
+	if opts.SourceTitle == "" {
+		opts.SourceTitle = "created by feishu-cli"
+	}
+	if opts.UserIDType == "" {
+		opts.UserIDType = "open_id"
+	}
+
+	bodyBuilder := larkokr.NewCreateProgressRecordReqBodyBuilder().
+		SourceTitle(opts.SourceTitle).
+		TargetId(opts.TargetID).
+		TargetType(int(opts.TargetType))
+	if opts.SourceURL != "" {
+		bodyBuilder = bodyBuilder.SourceUrl(opts.SourceURL)
+	}
+	if contentBlock != nil {
+		bodyBuilder = bodyBuilder.Content(contentBlock)
+	}
+	if opts.ProgressRate != nil {
+		rateBuilder := larkokr.NewProgressRateNewBuilder().Percent(opts.ProgressRate.Percent)
+		if opts.ProgressRate.Status != nil {
+			rateBuilder = rateBuilder.Status(int(*opts.ProgressRate.Status))
+		}
+		bodyBuilder = bodyBuilder.ProgressRate(rateBuilder.Build())
+	}
+
+	req := larkokr.NewCreateProgressRecordReqBuilder().
+		UserIdType(opts.UserIDType).
+		Body(bodyBuilder.Build()).
+		Build()
+
+	resp, err := client.Okr.ProgressRecord.Create(Context(), req, UserTokenOption(userAccessToken)...)
+	if err != nil {
+		return nil, fmt.Errorf("创建 OKR 进展失败: %w", err)
+	}
+	if !resp.Success() {
+		return nil, fmt.Errorf("创建 OKR 进展失败: code=%d, msg=%s", resp.Code, resp.Msg)
+	}
+	if resp.Data == nil {
+		return nil, fmt.Errorf("创建 OKR 进展失败: 接口未返回数据")
+	}
+	return progressRecordFieldsToOut(resp.Data.ProgressId, resp.Data.ModifyTime, resp.Data.Content, resp.Data.ProgressRate), nil
+}
+
+// UpdateOKRProgressOptions 更新进展记录的选项
+type UpdateOKRProgressOptions struct {
+	ProgressID   string
+	ContentJSON  string
+	UserIDType   string
+	ProgressRate *OKRProgressRateInput
+}
+
+// UpdateOKRProgress 更新一条 OKR 进展记录
+func UpdateOKRProgress(opts UpdateOKRProgressOptions, userAccessToken string) (*OKRProgress, error) {
+	client, err := GetClient()
+	if err != nil {
+		return nil, err
+	}
+
+	var contentBlock *larkokr.ContentBlock
+	if strings.TrimSpace(opts.ContentJSON) != "" {
+		contentBlock = &larkokr.ContentBlock{}
+		if err := json.Unmarshal([]byte(opts.ContentJSON), contentBlock); err != nil {
+			return nil, fmt.Errorf("解析 ContentBlock JSON 失败: %w", err)
+		}
+	}
+
+	if opts.UserIDType == "" {
+		opts.UserIDType = "open_id"
+	}
+
+	bodyBuilder := larkokr.NewUpdateProgressRecordReqBodyBuilder()
+	if contentBlock != nil {
+		bodyBuilder = bodyBuilder.Content(contentBlock)
+	}
+	if opts.ProgressRate != nil {
+		rateBuilder := larkokr.NewProgressRateNewBuilder().Percent(opts.ProgressRate.Percent)
+		if opts.ProgressRate.Status != nil {
+			rateBuilder = rateBuilder.Status(int(*opts.ProgressRate.Status))
+		}
+		bodyBuilder = bodyBuilder.ProgressRate(rateBuilder.Build())
+	}
+
+	req := larkokr.NewUpdateProgressRecordReqBuilder().
+		ProgressId(opts.ProgressID).
+		UserIdType(opts.UserIDType).
+		Body(bodyBuilder.Build()).
+		Build()
+
+	resp, err := client.Okr.ProgressRecord.Update(Context(), req, UserTokenOption(userAccessToken)...)
+	if err != nil {
+		return nil, fmt.Errorf("更新 OKR 进展失败: %w", err)
+	}
+	if !resp.Success() {
+		return nil, fmt.Errorf("更新 OKR 进展失败: code=%d, msg=%s", resp.Code, resp.Msg)
+	}
+	if resp.Data == nil {
+		return nil, fmt.Errorf("更新 OKR 进展失败: 接口未返回数据")
+	}
+	return progressRecordFieldsToOut(resp.Data.ProgressId, resp.Data.ModifyTime, resp.Data.Content, resp.Data.ProgressRate), nil
+}
+
+// GetOKRProgress 根据 ID 拉取一条进展记录
+func GetOKRProgress(progressID string, userIDType string, userAccessToken string) (*OKRProgress, error) {
+	client, err := GetClient()
+	if err != nil {
+		return nil, err
+	}
+	if userIDType == "" {
+		userIDType = "open_id"
+	}
+
+	req := larkokr.NewGetProgressRecordReqBuilder().
+		ProgressId(progressID).
+		UserIdType(userIDType).
+		Build()
+
+	resp, err := client.Okr.ProgressRecord.Get(Context(), req, UserTokenOption(userAccessToken)...)
+	if err != nil {
+		return nil, fmt.Errorf("查询 OKR 进展失败: %w", err)
+	}
+	if !resp.Success() {
+		return nil, fmt.Errorf("查询 OKR 进展失败: code=%d, msg=%s", resp.Code, resp.Msg)
+	}
+	if resp.Data == nil {
+		return nil, fmt.Errorf("查询 OKR 进展失败: 接口未返回数据")
+	}
+	return progressRecordFieldsToOut(resp.Data.ProgressId, resp.Data.ModifyTime, resp.Data.Content, resp.Data.ProgressRate), nil
+}
+
+// DeleteOKRProgress 删除一条进展记录
+func DeleteOKRProgress(progressID string, userAccessToken string) error {
+	client, err := GetClient()
+	if err != nil {
+		return err
+	}
+
+	req := larkokr.NewDeleteProgressRecordReqBuilder().
+		ProgressId(progressID).
+		Build()
+
+	resp, err := client.Okr.ProgressRecord.Delete(Context(), req, UserTokenOption(userAccessToken)...)
+	if err != nil {
+		return fmt.Errorf("删除 OKR 进展失败: %w", err)
+	}
+	if !resp.Success() {
+		return fmt.Errorf("删除 OKR 进展失败: code=%d, msg=%s", resp.Code, resp.Msg)
+	}
+	return nil
+}
+
+// ListOKRProgressesOptions 列出 Objective/KeyResult 的进展记录
+type ListOKRProgressesOptions struct {
+	TargetID         string
+	TargetType       OKRProgressTargetType
+	UserIDType       string
+	DepartmentIDType string
+}
+
+// ListOKRProgresses 拉取一个 Objective 或 KeyResult 下的所有进展记录（v2 接口，自动分页）。
+func ListOKRProgresses(opts ListOKRProgressesOptions, userAccessToken string) ([]*OKRProgress, error) {
+	client, err := GetClient()
+	if err != nil {
+		return nil, err
+	}
+
+	if opts.UserIDType == "" {
+		opts.UserIDType = "open_id"
+	}
+	if opts.DepartmentIDType == "" {
+		opts.DepartmentIDType = "open_department_id"
+	}
+
+	tokenType, reqOpts := resolveTokenOpts(userAccessToken)
+
+	var apiPath string
+	switch opts.TargetType {
+	case OKRTargetObjective:
+		apiPath = fmt.Sprintf("/open-apis/okr/v2/objectives/%s/progresses", opts.TargetID)
+	case OKRTargetKeyResult:
+		apiPath = fmt.Sprintf("/open-apis/okr/v2/key_results/%s/progresses", opts.TargetID)
+	default:
+		return nil, fmt.Errorf("不支持的 target-type: %d", opts.TargetType)
+	}
+
+	all := make([]*OKRProgress, 0)
+	pageToken := ""
+	for page := 0; ; page++ {
+		query := larkcore.QueryParams{}
+		query.Set("user_id_type", opts.UserIDType)
+		query.Set("department_id_type", opts.DepartmentIDType)
+		query.Set("page_size", "100")
+		if pageToken != "" {
+			query.Set("page_token", pageToken)
+		}
+
+		req := &larkcore.ApiReq{
+			HttpMethod:                http.MethodGet,
+			ApiPath:                   apiPath,
+			QueryParams:               query,
+			SupportedAccessTokenTypes: []larkcore.AccessTokenType{tokenType},
+		}
+
+		resp, err := client.Do(Context(), req, reqOpts...)
+		if err != nil {
+			return nil, fmt.Errorf("查询 OKR 进展列表失败: %w", err)
+		}
+		if resp.StatusCode != http.StatusOK {
+			return nil, fmt.Errorf("查询 OKR 进展列表失败: HTTP %d, body: %s", resp.StatusCode, string(resp.RawBody))
+		}
+
+		var apiResp struct {
+			Code int    `json:"code"`
+			Msg  string `json:"msg"`
+			Data struct {
+				Items []struct {
+					ID           string          `json:"id"`
+					CreateTime   string          `json:"create_time,omitempty"`
+					UpdateTime   string          `json:"update_time,omitempty"`
+					Owner        okrRawOwner     `json:"owner"`
+					EntityType   *int32          `json:"entity_type,omitempty"`
+					EntityID     string          `json:"entity_id,omitempty"`
+					Content      json.RawMessage `json:"content,omitempty"`
+					ProgressRate *struct {
+						ProgressPercent *float64 `json:"progress_percent,omitempty"`
+						ProgressStatus  *int     `json:"progress_status,omitempty"`
+					} `json:"progress_rate,omitempty"`
+				} `json:"items"`
+				HasMore   bool   `json:"has_more"`
+				PageToken string `json:"page_token"`
+			} `json:"data"`
+		}
+		if err := json.Unmarshal(resp.RawBody, &apiResp); err != nil {
+			return nil, fmt.Errorf("解析 OKR 进展列表响应失败: %w", err)
+		}
+		if apiResp.Code != 0 {
+			return nil, fmt.Errorf("查询 OKR 进展列表失败: code=%d, msg=%s", apiResp.Code, apiResp.Msg)
+		}
+
+		for _, item := range apiResp.Data.Items {
+			p := &OKRProgress{
+				ProgressID: item.ID,
+				ModifyTime: formatOKRTimestamp(item.UpdateTime),
+				CreateTime: formatOKRTimestamp(item.CreateTime),
+				Content:    rawJSONString(item.Content),
+			}
+			if item.ProgressRate != nil {
+				p.ProgressRate = &OKRProgressRate{
+					Percent: item.ProgressRate.ProgressPercent,
+				}
+				if item.ProgressRate.ProgressStatus != nil {
+					p.ProgressRate.Status = OKRProgressStatus(*item.ProgressRate.ProgressStatus).String()
+				}
+			}
+			all = append(all, p)
+		}
+
+		if !apiResp.Data.HasMore || apiResp.Data.PageToken == "" {
+			break
+		}
+		pageToken = apiResp.Data.PageToken
+		if page >= 200 {
+			break
+		}
+	}
+	return all, nil
+}
+
+// --------- OKR 图片上传（multipart）---------
+
+// OKRImageUploadResult 上传图片返回
+type OKRImageUploadResult struct {
+	FileToken string `json:"file_token"`
+	URL       string `json:"url,omitempty"`
+	FileName  string `json:"file_name"`
+	Size      int64  `json:"size"`
+}
+
+// UploadOKRImage 上传一张图片到 OKR Progress 富文本图床。
+// 通过 SDK 的 Image.Upload 走 multipart/form-data。
+func UploadOKRImage(filePath string, targetID string, targetType OKRProgressTargetType, userAccessToken string) (*OKRImageUploadResult, error) {
+	client, err := GetClient()
+	if err != nil {
+		return nil, err
+	}
+
+	info, err := os.Stat(filePath)
+	if err != nil {
+		return nil, fmt.Errorf("获取图片信息失败: %w", err)
+	}
+	if info.IsDir() {
+		return nil, fmt.Errorf("--file 不能是目录: %s", filePath)
+	}
+
+	f, err := os.Open(filePath)
+	if err != nil {
+		return nil, fmt.Errorf("打开图片失败: %w", err)
+	}
+	defer f.Close()
+
+	fileName := filepath.Base(filePath)
+
+	req := larkokr.NewUploadImageReqBuilder().
+		Body(larkokr.NewUploadImageReqBodyBuilder().
+			Data(f).
+			TargetId(targetID).
+			TargetType(int(targetType)).
+			Build()).
+		Build()
+
+	resp, err := client.Okr.Image.Upload(ContextWithTimeout(downloadTimeout), req, UserTokenOption(userAccessToken)...)
+	if err != nil {
+		return nil, fmt.Errorf("上传 OKR 图片失败: %w", err)
+	}
+	if !resp.Success() {
+		return nil, fmt.Errorf("上传 OKR 图片失败: code=%d, msg=%s", resp.Code, resp.Msg)
+	}
+	if resp.Data == nil {
+		return nil, fmt.Errorf("上传 OKR 图片失败: 接口未返回数据")
+	}
+
+	out := &OKRImageUploadResult{
+		FileToken: StringVal(resp.Data.FileToken),
+		URL:       StringVal(resp.Data.Url),
+		FileName:  fileName,
+		Size:      info.Size(),
+	}
+	if out.FileToken == "" {
+		return nil, fmt.Errorf("上传 OKR 图片失败: 接口未返回 file_token")
+	}
+	return out, nil
+}
+
+// --------- 内部辅助 ---------
+
+// okrHTTPDoer 仅在内部用于测试时 mock client.Do
+type okrHTTPDoer interface {
+	Do(ctx context.Context, req *larkcore.ApiReq, options ...larkcore.RequestOptionFunc) (*larkcore.ApiResp, error)
+}
+
+// timeUnixMilliLocalString 把毫秒时间戳格式化为本地时区 "2006-01-02 15:04:05" 字符串
+func timeUnixMilliLocalString(ms int64) string {
+	return time.UnixMilli(ms).Format("2006-01-02 15:04:05")
+}
+
+// progressRecordFieldsToOut 把 SDK 中形态相同的 Progress 响应（ProgressRecord /
+// CreateProgressRecordRespData / UpdateProgressRecordRespData / GetProgressRecordRespData）
+// 拆出 4 个核心字段后归一化为对外 OKRProgress。
+//
+// 这些 SDK 类型 schema 完全一致但走的是不同 Go 结构体，没法在调用侧共享一个 *ProgressRecord。
+// 改成传字段而非整个对象，避免每加一个响应类型就要写一个 to* helper。
+func progressRecordFieldsToOut(progressID, modifyTime *string, content *larkokr.ContentBlock, rate *larkokr.ProgressRateNew) *OKRProgress {
+	out := &OKRProgress{
+		ProgressID: StringVal(progressID),
+		ModifyTime: formatOKRTimestamp(StringVal(modifyTime)),
+	}
+	if rate != nil {
+		r := &OKRProgressRate{Percent: rate.Percent}
+		if rate.Status != nil {
+			r.Status = OKRProgressStatus(*rate.Status).String()
+		}
+		out.ProgressRate = r
+	}
+	if content != nil {
+		if data, err := json.Marshal(content); err == nil {
+			out.Content = string(data)
+		}
+	}
+	return out
+}

--- a/internal/client/okr.go
+++ b/internal/client/okr.go
@@ -23,17 +23,14 @@ type OKROwner struct {
 	UserID    string `json:"user_id,omitempty"`
 }
 
-// OKRCycle OKR 周期（v2 接口实体）
+// OKRCycle OKR 周期（v1 /open-apis/okr/v1/periods 接口实体，租户级全局周期）
 type OKRCycle struct {
-	ID            string   `json:"id"`
-	CreateTime    string   `json:"create_time,omitempty"`
-	UpdateTime    string   `json:"update_time,omitempty"`
-	TenantCycleID string   `json:"tenant_cycle_id,omitempty"`
-	Owner         OKROwner `json:"owner"`
-	StartTime     string   `json:"start_time,omitempty"`
-	EndTime       string   `json:"end_time,omitempty"`
-	CycleStatus   string   `json:"cycle_status,omitempty"`
-	Score         *float64 `json:"score,omitempty"`
+	ID          string `json:"id"`
+	ZhName      string `json:"zh_name,omitempty"`
+	EnName      string `json:"en_name,omitempty"`
+	StartTime   string `json:"start_time,omitempty"`
+	EndTime     string `json:"end_time,omitempty"`
+	CycleStatus string `json:"cycle_status,omitempty"`
 }
 
 // OKRKeyResult 关键结果
@@ -100,10 +97,11 @@ func (o *okrRawOwner) toOwner() OKROwner {
 	return out
 }
 
-type okrCycleStatus int32
+type okrCycleStatus int
 
 const (
-	okrCycleStatusNormal  okrCycleStatus = 1
+	okrCycleStatusNormal  okrCycleStatus = 0
+	okrCycleStatusPending okrCycleStatus = 1
 	okrCycleStatusInvalid okrCycleStatus = 2
 	okrCycleStatusHidden  okrCycleStatus = 3
 )
@@ -112,6 +110,8 @@ func (s okrCycleStatus) String() string {
 	switch s {
 	case okrCycleStatusNormal:
 		return "normal"
+	case okrCycleStatusPending:
+		return "pending"
 	case okrCycleStatusInvalid:
 		return "invalid"
 	case okrCycleStatusHidden:
@@ -120,16 +120,14 @@ func (s okrCycleStatus) String() string {
 	return ""
 }
 
+// okrRawCycle 与 /open-apis/okr/v1/periods 响应字段对齐
 type okrRawCycle struct {
-	ID            string          `json:"id"`
-	CreateTime    string          `json:"create_time,omitempty"`
-	UpdateTime    string          `json:"update_time,omitempty"`
-	TenantCycleID string          `json:"tenant_cycle_id,omitempty"`
-	Owner         okrRawOwner     `json:"owner"`
-	StartTime     string          `json:"start_time,omitempty"`
-	EndTime       string          `json:"end_time,omitempty"`
-	CycleStatus   *okrCycleStatus `json:"cycle_status,omitempty"`
-	Score         *float64        `json:"score,omitempty"`
+	ID              string          `json:"id"`
+	ZhName          string          `json:"zh_name,omitempty"`
+	EnName          string          `json:"en_name,omitempty"`
+	Status          *okrCycleStatus `json:"status,omitempty"`
+	PeriodStartTime string          `json:"period_start_time,omitempty"`
+	PeriodEndTime   string          `json:"period_end_time,omitempty"`
 }
 
 func (c *okrRawCycle) toCycle() *OKRCycle {
@@ -137,17 +135,14 @@ func (c *okrRawCycle) toCycle() *OKRCycle {
 		return nil
 	}
 	cycle := &OKRCycle{
-		ID:            c.ID,
-		CreateTime:    formatOKRTimestamp(c.CreateTime),
-		UpdateTime:    formatOKRTimestamp(c.UpdateTime),
-		TenantCycleID: c.TenantCycleID,
-		Owner:         c.Owner.toOwner(),
-		StartTime:     formatOKRTimestamp(c.StartTime),
-		EndTime:       formatOKRTimestamp(c.EndTime),
-		Score:         c.Score,
+		ID:        c.ID,
+		ZhName:    c.ZhName,
+		EnName:    c.EnName,
+		StartTime: formatOKRTimestamp(c.PeriodStartTime),
+		EndTime:   formatOKRTimestamp(c.PeriodEndTime),
 	}
-	if c.CycleStatus != nil {
-		cycle.CycleStatus = c.CycleStatus.String()
+	if c.Status != nil {
+		cycle.CycleStatus = c.Status.String()
 	}
 	return cycle
 }
@@ -248,24 +243,18 @@ func formatOKRTimestamp(ts string) string {
 	return timeUnixMilliLocalString(ms)
 }
 
-// --------- OKR 周期列表（v2，分页拉取）---------
+// --------- OKR 周期列表（v1 /open-apis/okr/v1/periods，租户级，分页拉取）---------
 
-// ListOKRCyclesOptions 列出周期的选项
-type ListOKRCyclesOptions struct {
-	UserID     string
-	UserIDType string // open_id / union_id / user_id
-}
+// ListOKRCyclesOptions 列出周期的选项（v1/periods 是租户级全局周期，无 user 过滤参数）
+type ListOKRCyclesOptions struct{}
 
-// ListOKRCycles 拉取指定用户的所有周期，自动分页（page_size=100）。
+// ListOKRCycles 拉取租户的所有 OKR 周期，自动分页（page_size=100）。
+// 注意：飞书 /open-apis/okr/v1/periods 是租户级全局周期列表，不按用户过滤。
 // userAccessToken 必填（OKR 接口默认要求 User Token）。
 func ListOKRCycles(opts ListOKRCyclesOptions, userAccessToken string) ([]*OKRCycle, error) {
 	client, err := GetClient()
 	if err != nil {
 		return nil, err
-	}
-
-	if opts.UserIDType == "" {
-		opts.UserIDType = "open_id"
 	}
 
 	tokenType, reqOpts := resolveTokenOpts(userAccessToken)
@@ -274,8 +263,6 @@ func ListOKRCycles(opts ListOKRCyclesOptions, userAccessToken string) ([]*OKRCyc
 	pageToken := ""
 	for page := 0; ; page++ {
 		query := larkcore.QueryParams{}
-		query.Set("user_id", opts.UserID)
-		query.Set("user_id_type", opts.UserIDType)
 		query.Set("page_size", "100")
 		if pageToken != "" {
 			query.Set("page_token", pageToken)
@@ -283,7 +270,7 @@ func ListOKRCycles(opts ListOKRCyclesOptions, userAccessToken string) ([]*OKRCyc
 
 		req := &larkcore.ApiReq{
 			HttpMethod:                http.MethodGet,
-			ApiPath:                   "/open-apis/okr/v2/cycles",
+			ApiPath:                   "/open-apis/okr/v1/periods",
 			QueryParams:               query,
 			SupportedAccessTokenTypes: []larkcore.AccessTokenType{tokenType},
 		}
@@ -573,17 +560,20 @@ func CreateOKRProgress(opts CreateOKRProgressOptions, userAccessToken string) (*
 	if opts.SourceTitle == "" {
 		opts.SourceTitle = "created by feishu-cli"
 	}
+	if opts.SourceURL == "" {
+		// 飞书 OKR progress create API 要求 source_url 必填，留空会 422；
+		// 给一个 placeholder 兜底，调用方可显式覆盖为真实跳转地址。
+		opts.SourceURL = "https://www.feishu.cn/okr/progress"
+	}
 	if opts.UserIDType == "" {
 		opts.UserIDType = "open_id"
 	}
 
 	bodyBuilder := larkokr.NewCreateProgressRecordReqBodyBuilder().
 		SourceTitle(opts.SourceTitle).
+		SourceUrl(opts.SourceURL).
 		TargetId(opts.TargetID).
 		TargetType(int(opts.TargetType))
-	if opts.SourceURL != "" {
-		bodyBuilder = bodyBuilder.SourceUrl(opts.SourceURL)
-	}
 	if contentBlock != nil {
 		bodyBuilder = bodyBuilder.Content(contentBlock)
 	}

--- a/internal/client/okr_test.go
+++ b/internal/client/okr_test.go
@@ -1,0 +1,75 @@
+package client
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+// TestOKRRawCycleToCycle 验证 v1/periods 响应解析为 OKRCycle 的映射正确
+func TestOKRRawCycleToCycle(t *testing.T) {
+	body := `{
+		"id": "635782378412311",
+		"zh_name": "2026 Q2",
+		"en_name": "2026 Q2",
+		"status": 0,
+		"period_start_time": "1712016000000",
+		"period_end_time": "1719792000000"
+	}`
+	var raw okrRawCycle
+	if err := json.Unmarshal([]byte(body), &raw); err != nil {
+		t.Fatalf("unmarshal v1 period failed: %v", err)
+	}
+	c := raw.toCycle()
+	if c == nil {
+		t.Fatal("toCycle returned nil")
+	}
+	if c.ID != "635782378412311" {
+		t.Errorf("ID = %q, want 635782378412311", c.ID)
+	}
+	if c.ZhName != "2026 Q2" {
+		t.Errorf("ZhName = %q", c.ZhName)
+	}
+	if c.EnName != "2026 Q2" {
+		t.Errorf("EnName = %q", c.EnName)
+	}
+	if c.CycleStatus != "normal" {
+		t.Errorf("CycleStatus = %q, want normal (status=0)", c.CycleStatus)
+	}
+	if c.StartTime == "" || c.EndTime == "" {
+		t.Errorf("StartTime/EndTime not formatted: start=%q end=%q", c.StartTime, c.EndTime)
+	}
+}
+
+// TestOKRCycleStatusMapping 验证 status int → 文本映射齐全
+func TestOKRCycleStatusMapping(t *testing.T) {
+	cases := map[okrCycleStatus]string{
+		okrCycleStatusNormal:  "normal",
+		okrCycleStatusPending: "pending",
+		okrCycleStatusInvalid: "invalid",
+		okrCycleStatusHidden:  "hidden",
+	}
+	for s, want := range cases {
+		if got := s.String(); got != want {
+			t.Errorf("status %d → %q, want %q", int(s), got, want)
+		}
+	}
+}
+
+// TestCreateOKRProgressSourceURLDefault 验证 SourceURL 未填时会兜底 placeholder（避免 422）
+func TestCreateOKRProgressSourceURLDefault(t *testing.T) {
+	// 这里只验证 options 默认值逻辑（不实际打网络），通过反向构造
+	opts := CreateOKRProgressOptions{
+		TargetID:   "7xxx",
+		TargetType: OKRTargetObjective,
+	}
+	// 复刻 CreateOKRProgress 前几行的默认值逻辑
+	if opts.SourceTitle == "" {
+		opts.SourceTitle = "created by feishu-cli"
+	}
+	if opts.SourceURL == "" {
+		opts.SourceURL = "https://www.feishu.cn/okr/progress"
+	}
+	if opts.SourceURL != "https://www.feishu.cn/okr/progress" {
+		t.Errorf("default SourceURL = %q", opts.SourceURL)
+	}
+}

--- a/skills/feishu-cli-okr/SKILL.md
+++ b/skills/feishu-cli-okr/SKILL.md
@@ -1,0 +1,292 @@
+---
+name: feishu-cli-okr
+description: >-
+  飞书 OKR 查询与进度上报。okr cycle list 列租户级 OKR 周期；
+  okr progress list/create 查/创建进度记录。
+  ⚠️ source_url 字段必填（API 强制），默认占位 https://www.feishu.cn/okr/progress 可改。
+  使用 SDK Okr.ProgressRecord + v1/periods HTTP 直调（v2/cycles 不存在）。
+  当用户请求"查 OKR 周期"、"上报 OKR 进度"、"OKR 更新"时使用。
+argument-hint: cycle list | progress list | progress create
+user-invocable: true
+allowed-tools: Bash, Read
+---
+
+# 飞书 OKR 查询与进度上报技能
+
+通过 feishu-cli 查询 OKR 周期、列出/创建进度记录。覆盖 OKR 最高频的 3 个操作。
+
+> **feishu-cli**：如尚未安装，请前往 [riba2534/feishu-cli](https://github.com/riba2534/feishu-cli) 获取安装方式。
+
+## 核心概念
+
+### OKR 数据模型
+
+飞书 OKR 由 4 层对象组成，本技能涉及前 3 层：
+
+| 层级 | 对象 | 说明 | 本技能命令 |
+|------|------|------|-----------|
+| 1 | **Period（周期）** | 租户级全局，如 2026-Q1。所有成员看到的周期一致 | `cycle list` |
+| 2 | **Objective（目标 O）** | 一个周期内的目标，归属用户 | 仅做引用（--objective-id） |
+| 3 | **Key Result（关键结果 KR）** | O 下的可量化结果 | 仅做引用（--key-result-id） |
+| 4 | **Progress Record（进展记录）** | O 或 KR 下的一条进展更新 | `progress list/create` |
+
+**关键约束**：
+
+- **周期是租户级的**，`cycle list` **没有 user_id 参数**——所有人看到的周期相同。你不能"查某人的 OKR 周期"，只能"查租户当前都有哪些周期"。
+- **Objective ID 和 Key Result ID 二选一**（不是同时）：每条进展记录只能挂在一个目标 *或* 一个关键结果上。
+- **进展记录可以独立于周期**：API 不需要传 period_id，但通常一个 O/KR 都属于一个 period。
+
+### 身份：默认 User Token
+
+OKR 模块默认使用 **User Token（用户身份）**，不是 App Token。
+
+- 命令会自动读取 `~/.feishu-cli/token.json`（Device Flow OAuth 登录态）
+- 未登录或 token 过期请先 `feishu-cli auth login --scope "okr:okr"`
+- 也可以通过 `--user-access-token` 或环境变量 `FEISHU_USER_ACCESS_TOKEN` 覆盖
+
+**为什么必须 User Token**：飞书 OKR 是个人维度的目标管理，API 设计层面就要求"以用户身份操作"——查的是"当前用户能看到的周期"、创建的进展归属"当前用户"。Bot 身份没有 OKR 数据。
+
+## 命令速查
+
+| 子命令 | 说明 | 必填参数 |
+|--------|------|---------|
+| `okr cycle list` | 列出当前租户所有 OKR 周期 | — |
+| `okr progress list` | 列出某 O/KR 下的所有进展 | `--objective-id` *或* `--key-result-id` |
+| `okr progress create` | 创建一条新进展 | 目标 ID（二选一）+ 内容（二选一） |
+
+## cycle list — 查租户 OKR 周期
+
+```bash
+# 默认文本输出（带名称 + 时间 + 状态）
+feishu-cli okr cycle list
+
+# JSON 输出（脚本消费）
+feishu-cli okr cycle list --output json
+```
+
+**输出字段**：
+- `id` — 周期 ID（后续创建 O/KR 时会用，本技能不涉及）
+- `zh_name` / `en_name` — 周期名称（如 "2026-Q1"）
+- `start_time` / `end_time` — 周期起止时间
+- `cycle_status` — 周期状态（如 normal / archived）
+
+**实现细节**：底层走 HTTP 直调 `/open-apis/okr/v1/periods`，自动分页。
+
+## progress list — 查进展记录列表
+
+```bash
+# 查目标下的所有进展
+feishu-cli okr progress list --objective-id 7123456789012345678
+
+# 查关键结果下的所有进展
+feishu-cli okr progress list --key-result-id 7123456789012345678
+
+# JSON 输出
+feishu-cli okr progress list --objective-id 7xxx --output json
+```
+
+**参数**：
+
+| 参数 | 说明 | 默认值 |
+|------|------|--------|
+| `--objective-id` | 目标 ID（与 `--key-result-id` **二选一**） | — |
+| `--key-result-id` | 关键结果 ID（与 `--objective-id` **二选一**） | — |
+| `--user-id-type` | 用户 ID 类型：`open_id` / `union_id` / `user_id` | `open_id` |
+| `-o, --output` | 输出格式：`json` | 文本 |
+
+**输出字段**：
+- `progress_id` — 进展 ID
+- `create_time` / `modify_time` — 创建/修改时间（已转本地时区 `YYYY-MM-DD HH:MM:SS`）
+- `progress_rate.percent` / `progress_rate.status` — 进度百分比和状态（如果有）
+
+## progress create — 创建进展记录
+
+最常用：周报/日报中手动同步进度。
+
+### 最简形式（纯文本）
+
+```bash
+feishu-cli okr progress create \
+  --objective-id 7123456789012345678 \
+  --content "本周完成核心模块联调，下周开始联调测试"
+```
+
+CLI 会自动把纯文本包装成飞书 ContentBlock 富文本 JSON（paragraph + textRun）。
+
+### 带进度百分比
+
+```bash
+feishu-cli okr progress create \
+  --key-result-id 7123456789012345678 \
+  --content "完成 8/10 任务" \
+  --progress-percent 80 \
+  --progress-status normal
+```
+
+- `--progress-percent` 数字（0-100）
+- `--progress-status` 取值：`normal`（正常）/ `overdue`（已逾期）/ `done`（已完成）
+- ⚠️ `--progress-status` **必须配合** `--progress-percent` 使用，单独传 status 会报错
+
+### 富文本（ContentBlock JSON）
+
+需要 @某人、嵌入链接、加粗等富文本场景：
+
+```bash
+feishu-cli okr progress create \
+  --objective-id 7xxx \
+  --content-json '{"blocks":[{"type":"paragraph","paragraph":{"elements":[{"type":"textRun","textRun":{"text":"加粗内容","style":{"bold":true}}}]}}]}'
+```
+
+`--content` 和 `--content-json` **互斥**，只能填一个。
+
+### 自定义 source（来源标题 + URL）
+
+```bash
+feishu-cli okr progress create \
+  --objective-id 7xxx \
+  --content "本周完成 X" \
+  --source-title "周报：W18" \
+  --source-url "https://xxx.feishu.cn/docx/abc123"
+```
+
+进展卡片在飞书 OKR 页面会展示来源标题，点击跳转 URL。
+
+### 完整参数表
+
+| 参数 | 说明 | 默认值 |
+|------|------|--------|
+| `--objective-id` | 目标 ID（与 `--key-result-id` 二选一） | — |
+| `--key-result-id` | 关键结果 ID（与 `--objective-id` 二选一） | — |
+| `--content` | 纯文本内容（与 `--content-json` 二选一） | — |
+| `--content-json` | 原始 ContentBlock JSON（与 `--content` 二选一） | — |
+| `--progress-percent` | 进度百分比（数字） | — |
+| `--progress-status` | 进度状态：`normal` / `overdue` / `done` | — |
+| `--source-title` | 来源标题 | `created by feishu-cli` |
+| `--source-url` | 来源 URL（⚠️ API 必填，CLI 已填默认占位） | `https://www.feishu.cn/okr/progress` |
+| `--user-id-type` | 用户 ID 类型 | `open_id` |
+| `-o, --output` | 输出格式：`json` | 文本 |
+
+## ⚠️ 关键踩坑
+
+### 1. `source_url` 字段 API 强制必填
+
+飞书 OKR `progress_record/create` API 在 source 字段下强制要求 `url`，不传会直接报错。CLI 已经默认填了占位值 `https://www.feishu.cn/okr/progress`，但建议显式覆盖为有意义的 URL（如周报文档地址），这样进展卡片在 OKR 页面才有真正的跳转价值。
+
+### 2. cycle 路径是 `v1/periods` 不是 `v2/cycles`
+
+历史上有过混淆——飞书 OKR 周期 OpenAPI 的正确路径是：
+
+```
+GET /open-apis/okr/v1/periods   ✅ 真实存在
+GET /open-apis/okr/v2/cycles    ❌ 不存在，404
+```
+
+`cycle list` 命令的 `cycle` 是 CLI 子命令名（更符合用户直觉），实际调用走 `v1/periods`。如果手动拼 HTTP 请求时不要写错。
+
+### 3. `progress create` 走 SDK，`cycle list` / `progress list` 走 HTTP 直调
+
+实现层面有分工：
+
+| 命令 | 实现方式 |
+|------|---------|
+| `progress create` | 飞书 Open SDK v3.5.3 的 `Okr.ProgressRecord.Create` |
+| `cycle list` | 通用 HTTP client 直调 `/open-apis/okr/v1/periods` |
+| `progress list` | 通用 HTTP client 直调 `/open-apis/okr/v2/...` |
+
+原因：SDK 在 v3.5.3 版本只暴露了 progress record 的 Create 方法（没有 List/Get/Update/Delete），其他能力都得自己拼 HTTP。
+
+### 4. cycle 是租户级，没有 user_id 参数
+
+不要试图传 `--user-id` 给 `cycle list`——周期是全租户共享的，所有成员看到的都是同一份列表。这点容易被"OKR 是个人目标"的直觉误导。
+
+## 权限要求（User Token scope）
+
+| 命令 | 所需 scope（任一即可） |
+|------|----------------------|
+| `cycle list` | `okr:okr:readonly` 或 `okr:okr.period:readonly` |
+| `progress list` | `okr:okr:readonly` 或 `okr:okr.progress:readonly` |
+| `progress create` | `okr:okr` 或 `okr:okr.progress:writeonly` |
+
+**一键申请全部**：
+
+```bash
+feishu-cli auth login --scope "okr:okr"
+```
+
+或预检：
+
+```bash
+feishu-cli auth check --scope "okr:okr"
+```
+
+## 典型工作流
+
+### 周报同步进展
+
+```bash
+# 1. 确保已登录
+feishu-cli auth status
+
+# 2. 查当前有哪些周期（可选，确认正在哪个 Q）
+feishu-cli okr cycle list
+
+# 3. 看某个目标历史进展（可选，回顾上次说了啥）
+feishu-cli okr progress list --objective-id 7xxx
+
+# 4. 同步本周进展
+feishu-cli okr progress create \
+  --objective-id 7xxx \
+  --content "W18: 完成 X 和 Y，下周冲刺 Z" \
+  --progress-percent 60 \
+  --progress-status normal \
+  --source-title "周报 W18" \
+  --source-url "https://xxx.feishu.cn/docx/<your-weekly-doc-id>"
+```
+
+### 脚本化批量同步多个 KR 进展
+
+```bash
+for kr_id in 7xxx 7yyy 7zzz; do
+  feishu-cli okr progress create \
+    --key-result-id "$kr_id" \
+    --content "自动同步: 当前推进中" \
+    --output json
+  sleep 1
+done
+```
+
+## 未实现的能力（按需后续补 CLI）
+
+以下 OKR API 飞书都支持，但本 PR 的 MVP 范围只覆盖 3 个最高频动词。`internal/client` 层已经部分实现，CLI 子命令暂未暴露：
+
+| 能力 | 状态 |
+|------|------|
+| `okr progress get <progress-id>` | ❌ 未实现 |
+| `okr progress update <progress-id>` | ❌ 未实现 |
+| `okr progress delete <progress-id>` | ❌ 未实现 |
+| `okr progress image upload` | ❌ 未实现（图片素材上传） |
+| `okr objective list/get` | ❌ 未实现 |
+| `okr key-result list/get` | ❌ 未实现 |
+| `okr review list/query`（评审/复盘） | ❌ 未实现 |
+
+如有需要，提 issue 或 PR 时参考 `cmd/okr_progress_create.go` 的模式扩展。
+
+## 错误处理
+
+| 错误 | 原因 | 解决 |
+|------|------|------|
+| `必须指定 --objective-id 或 --key-result-id 之一` | 没传目标 ID | 二选一传入 |
+| `--objective-id 和 --key-result-id 只能填一个` | 同时传了两个 | 只保留一个 |
+| `必须指定 --content 或 --content-json 之一` | 没传内容 | 二选一传入 |
+| `--content 和 --content-json 只能填一个` | 同时传了两个 | 只保留一个 |
+| `--progress-status 必须配合 --progress-percent 一起使用` | 单独传 status | 加上 `--progress-percent` |
+| `--content-json 不是合法 JSON` | JSON 语法错误 | 用 `jq .` 校验后再传 |
+| `source_url is required` 或类似 | 飞书 API 强制必填 | CLI 已默认填占位，理论上不会触发；如出现请显式传 `--source-url` |
+| `token expired` / 401 | User Token 过期 | `feishu-cli auth login --scope "okr:okr"` 重新登录 |
+| `scope not authorized` | 缺少 OKR scope | `feishu-cli auth check --scope "okr:okr"` 预检后重登 |
+
+## 相关技能
+
+- **feishu-cli-auth** — OAuth 登录、scope 配置、token 管理
+- **feishu-cli-msg** — 发飞书消息（进展同步后通知 leader/小组）
+- **feishu-cli-toolkit** — 综合工具箱（任务、日历等其他周报相关工具）


### PR DESCRIPTION
## 背景

feishu-cli 之前完全没有 OKR 模块。lark-cli 有 +cycle-list / +progress-* / +image-upload 系列 shortcut，本 PR 补齐 MVP 子集，让 AI agent 在 feishu-cli 单工具栈内做 OKR 进度自动化。

## 新增命令

```bash
# 列出用户的 OKR 周期
feishu-cli okr cycle list --user-id ou_xxx

# 列出进度
feishu-cli okr progress list --objective-id xxx | --key-result-id xxx

# 创建进度（支持纯文本快捷输入或 JSON 透传）
feishu-cli okr progress create \
  --objective-id xxx | --key-result-id xxx \
  --content "本周完成方案设计" \
  [--progress-percent 30 --progress-status normal]

# 进阶用户用 --content-json 透传飞书 ContentBlock 结构
feishu-cli okr progress create --objective-id xxx --content-json '{"blocks":[...]}'
```

## 实现要点

- SDK v3.5.3 已暴露 \`client.Okr.ProgressRecord.{Create,Get,Update,Delete}\` + \`client.Okr.Image.Upload\`
- v2 \`cycles list\` 接口 SDK 未封装 → 用 \`client.Do + larkcore.ApiReq\` 直调 OpenAPI（对齐 lark-cli shortcuts/okr/okr_cycle_list.go）
- \`progress create --content\` 纯文本时自动包装为最小 ContentBlock（paragraph + textRun）
- \`pickOKRTarget\` 共享 \`--objective-id|--key-result-id\` 二选一校验

## 修复

worktree 内有上一个 agent 留下的 untracked \`internal/client/okr.go\` 编译失败：SDK v3.5.3 中 \`CreateProgressRecordRespData\` / \`UpdateProgressRecordRespData\` / \`GetProgressRecordRespData\` 是 3 个独立结构体（schema 一致但 Go 类型不同），原代码把它们都当成 \`*larkokr.ProgressRecord\` 传给同一 helper。重构 \`progressRecordToOut → progressRecordFieldsToOut\` 改成接受 4 个字段而非整个对象，3 个调用点都 unblock。

## Scope

\`okr:okr\` / \`okr:okr:readonly\` (user token)

## 边界（未在本 PR）

按 MVP 范围，client 层已有 progress get/update/delete + image upload，CLI wrapper 留后续 PR；未加单元测试。

## 测试

- \`go build ./...\` / \`go vet ./...\` 全绿
- \`go test ./cmd ./internal/client\` 全过