### PR TITLE
feat(approval): 写流程（instance create/cancel/cc + task approve/reject）

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,35 @@
 
 ## 未发布
 
+### 新增 — `approval` 写流程：发起 / 撤回 / 抄送 / 通过 / 拒绝
+
+补齐审批模块的写能力，原本只有 `approval get`（定义查询）和 `approval task query`（任务列表查询）两条只读命令，现在可以完整完成审批生命周期：
+
+- `feishu-cli approval instance create` — 发起一条审批实例，`--form` 或 `--form-file` 传表单 JSON
+- `feishu-cli approval instance cancel` — 撤回（取消）已发起的审批实例
+- `feishu-cli approval instance cc` — 把审批实例抄送给一个或多个用户（`--cc-user-ids ou_a,ou_b`）
+- `feishu-cli approval task approve` — 通过指定审批任务，可附 `--comment`
+- `feishu-cli approval task reject` — 拒绝指定审批任务，建议在 `--comment` 中填写原因
+
+**权限要求**：User Token + `approval:approval` scope（实例侧 `approval:instance:write` / 任务侧 `approval:task:write` 已包含其中）。
+
+**底层 API**：
+
+- `POST /open-apis/approval/v4/instances`
+- `POST /open-apis/approval/v4/instances/cancel`
+- `POST /open-apis/approval/v4/instances/cc`
+- `POST /open-apis/approval/v4/tasks/approve`
+- `POST /open-apis/approval/v4/tasks/reject`
+
+不在本 MVP 范围（后续按需补）：`tasks/transfer`（转交）、`tasks/rollback`（退回）、`tasks/add_sign`（加签）、`tasks/remind`（催办）。
+
+**代码影响范围**：
+
+- `internal/client/approval.go`：新增 5 个 client 函数（`CreateApprovalInstance` / `CancelApprovalInstance` / `CCApprovalInstance` / `ApproveApprovalTask` / `RejectApprovalTask`）+ 4 个对应 Options 结构 + 共享 POST helper `doApprovalPost`
+- `cmd/approval_instance.go`：新增 `approval instance` 父命令
+- `cmd/approval_instance_{create,cancel,cc}.go`：3 条实例侧子命令
+- `cmd/approval_task_{approve,reject}.go`：2 条任务侧子命令，复用 `readApprovalTaskActionFlags` 校验
+
 ### 新增 — `comment reply add`：为已有评论添加回复
 
 新增命令 `feishu-cli comment reply add <file_token> <comment_id> --text "..."`，补齐评论回复

--- a/cmd/approval.go
+++ b/cmd/approval.go
@@ -5,18 +5,29 @@ import "github.com/spf13/cobra"
 var approvalCmd = &cobra.Command{
 	Use:   "approval",
 	Short: "审批相关命令",
-	Long: `审批相关命令，用于查看审批定义、实例和任务。
+	Long: `审批相关命令，用于查看审批定义、实例和任务，并支持发起/撤回/抄送/审批等写操作。
 
 当前已提供：
   - 审批定义查询（approval get）
   - 审批任务查询（approval task query）
+  - 发起审批实例（approval instance create）
+  - 取消审批实例（approval instance cancel）
+  - 抄送审批实例（approval instance cc）
+  - 通过审批任务（approval task approve）
+  - 拒绝审批任务（approval task reject）
 
 示例:
   # 查看审批定义详情
   feishu-cli approval get <approval_code>
 
   # 查看当前登录用户的待我审批任务
-  feishu-cli approval task query --topic todo`,
+  feishu-cli approval task query --topic todo
+
+  # 发起审批实例
+  feishu-cli approval instance create --approval-code <code> --user-id ou_xxx --form-file form.json
+
+  # 通过审批任务
+  feishu-cli approval task approve --approval-code <code> --instance-code <ic> --task-id <task> --user-id ou_xxx`,
 }
 
 func init() {

--- a/cmd/approval_instance.go
+++ b/cmd/approval_instance.go
@@ -1,0 +1,23 @@
+package cmd
+
+import "github.com/spf13/cobra"
+
+var approvalInstanceCmd = &cobra.Command{
+	Use:   "instance",
+	Short: "审批实例相关命令",
+	Long: `审批实例相关命令，用于创建、取消和抄送审批实例。
+
+示例:
+  # 创建审批实例
+  feishu-cli approval instance create --approval-code <code> --user-id ou_xxx --form-file form.json
+
+  # 取消审批实例
+  feishu-cli approval instance cancel --approval-code <code> --instance-code <ic> --user-id ou_xxx
+
+  # 抄送审批实例
+  feishu-cli approval instance cc --approval-code <code> --instance-code <ic> --user-id ou_xxx --cc-user-ids ou_a,ou_b`,
+}
+
+func init() {
+	approvalCmd.AddCommand(approvalInstanceCmd)
+}

--- a/cmd/approval_instance_cancel.go
+++ b/cmd/approval_instance_cancel.go
@@ -44,7 +44,7 @@ var approvalInstanceCancelCmd = &cobra.Command{
 		}
 
 		userIDType, _ := cmd.Flags().GetString("user-id-type")
-		token := resolveFlagUserToken(cmd)
+		token := resolveOptionalUserTokenWithFallback(cmd)
 
 		err := client.CancelApprovalInstance(client.CancelApprovalInstanceOptions{
 			ApprovalCode: approvalCode,

--- a/cmd/approval_instance_cancel.go
+++ b/cmd/approval_instance_cancel.go
@@ -1,0 +1,73 @@
+package cmd
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/riba2534/feishu-cli/internal/client"
+	"github.com/riba2534/feishu-cli/internal/config"
+	"github.com/spf13/cobra"
+)
+
+var approvalInstanceCancelCmd = &cobra.Command{
+	Use:   "cancel",
+	Short: "取消（撤回）审批实例",
+	Long: `撤回一条已发起的审批实例。需要 User Token + scope approval:approval。
+
+参数:
+  --approval-code    审批定义 code（必填）
+  --instance-code    审批实例 code（必填）
+  --user-id          执行撤回的用户 ID（必填，通常为发起人）
+  --user-id-type     open_id（默认）/user_id/union_id
+
+示例:
+  feishu-cli approval instance cancel \
+    --approval-code <code> --instance-code <ic> --user-id ou_xxx`,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		if err := config.Validate(); err != nil {
+			return err
+		}
+
+		approvalCode, _ := cmd.Flags().GetString("approval-code")
+		if err := validateApprovalCode(approvalCode); err != nil {
+			return err
+		}
+
+		instanceCode, _ := cmd.Flags().GetString("instance-code")
+		if strings.TrimSpace(instanceCode) == "" {
+			return fmt.Errorf("--instance-code 不能为空")
+		}
+
+		userID, _ := cmd.Flags().GetString("user-id")
+		if strings.TrimSpace(userID) == "" {
+			return fmt.Errorf("--user-id 不能为空")
+		}
+
+		userIDType, _ := cmd.Flags().GetString("user-id-type")
+		token := resolveFlagUserToken(cmd)
+
+		err := client.CancelApprovalInstance(client.CancelApprovalInstanceOptions{
+			ApprovalCode: approvalCode,
+			InstanceCode: instanceCode,
+			UserID:       userID,
+			UserIDType:   userIDType,
+		}, token)
+		if err != nil {
+			return err
+		}
+
+		fmt.Printf("审批实例已撤回: %s\n", instanceCode)
+		return nil
+	},
+}
+
+func init() {
+	approvalInstanceCmd.AddCommand(approvalInstanceCancelCmd)
+
+	approvalInstanceCancelCmd.Flags().String("approval-code", "", "审批定义 code（必填）")
+	approvalInstanceCancelCmd.Flags().String("instance-code", "", "审批实例 code（必填）")
+	approvalInstanceCancelCmd.Flags().String("user-id", "", "执行撤回的用户 ID（必填）")
+	approvalInstanceCancelCmd.Flags().String("user-id-type", "open_id", "用户 ID 类型：open_id/user_id/union_id")
+	approvalInstanceCancelCmd.Flags().String("user-access-token", "", "User Access Token（覆盖登录态）")
+	mustMarkFlagRequired(approvalInstanceCancelCmd, "approval-code", "instance-code", "user-id")
+}

--- a/cmd/approval_instance_cc.go
+++ b/cmd/approval_instance_cc.go
@@ -54,7 +54,7 @@ var approvalInstanceCcCmd = &cobra.Command{
 
 		comment, _ := cmd.Flags().GetString("comment")
 		userIDType, _ := cmd.Flags().GetString("user-id-type")
-		token := resolveFlagUserToken(cmd)
+		token := resolveOptionalUserTokenWithFallback(cmd)
 
 		err := client.CCApprovalInstance(client.CCApprovalInstanceOptions{
 			ApprovalCode: approvalCode,
@@ -73,18 +73,22 @@ var approvalInstanceCcCmd = &cobra.Command{
 	},
 }
 
-// parseCommaSeparatedIDs 把逗号分隔的字符串切成去空格、去空值的切片。
+// parseCommaSeparatedIDs 把逗号分隔的字符串切成去空格、去空值、去重的切片。
+// 保留首次出现顺序，便于用户传入 ou_a,ou_b,ou_a 时只抄送一次。
 func parseCommaSeparatedIDs(raw string) []string {
 	if strings.TrimSpace(raw) == "" {
 		return nil
 	}
 	parts := strings.Split(raw, ",")
 	out := make([]string, 0, len(parts))
+	seen := make(map[string]bool, len(parts))
 	for _, p := range parts {
 		p = strings.TrimSpace(p)
-		if p != "" {
-			out = append(out, p)
+		if p == "" || seen[p] {
+			continue
 		}
+		seen[p] = true
+		out = append(out, p)
 	}
 	return out
 }

--- a/cmd/approval_instance_cc.go
+++ b/cmd/approval_instance_cc.go
@@ -1,0 +1,103 @@
+package cmd
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/riba2534/feishu-cli/internal/client"
+	"github.com/riba2534/feishu-cli/internal/config"
+	"github.com/spf13/cobra"
+)
+
+var approvalInstanceCcCmd = &cobra.Command{
+	Use:   "cc",
+	Short: "抄送审批实例",
+	Long: `把某条审批实例抄送给一个或多个用户。需要 User Token + scope approval:approval。
+
+参数:
+  --approval-code    审批定义 code（必填）
+  --instance-code    审批实例 code（必填）
+  --user-id          发起抄送的用户 ID（必填）
+  --cc-user-ids      被抄送用户 ID 列表，逗号分隔（必填，至少一个）
+  --comment          抄送备注（可选）
+  --user-id-type     open_id（默认）/user_id/union_id
+
+示例:
+  feishu-cli approval instance cc \
+    --approval-code <code> --instance-code <ic> \
+    --user-id ou_xxx --cc-user-ids ou_a,ou_b --comment "请知悉"`,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		if err := config.Validate(); err != nil {
+			return err
+		}
+
+		approvalCode, _ := cmd.Flags().GetString("approval-code")
+		if err := validateApprovalCode(approvalCode); err != nil {
+			return err
+		}
+
+		instanceCode, _ := cmd.Flags().GetString("instance-code")
+		if strings.TrimSpace(instanceCode) == "" {
+			return fmt.Errorf("--instance-code 不能为空")
+		}
+
+		userID, _ := cmd.Flags().GetString("user-id")
+		if strings.TrimSpace(userID) == "" {
+			return fmt.Errorf("--user-id 不能为空")
+		}
+
+		ccRaw, _ := cmd.Flags().GetString("cc-user-ids")
+		ccUserIDs := parseCommaSeparatedIDs(ccRaw)
+		if len(ccUserIDs) == 0 {
+			return fmt.Errorf("--cc-user-ids 至少需要一个用户 ID")
+		}
+
+		comment, _ := cmd.Flags().GetString("comment")
+		userIDType, _ := cmd.Flags().GetString("user-id-type")
+		token := resolveFlagUserToken(cmd)
+
+		err := client.CCApprovalInstance(client.CCApprovalInstanceOptions{
+			ApprovalCode: approvalCode,
+			InstanceCode: instanceCode,
+			UserID:       userID,
+			CCUserIDs:    ccUserIDs,
+			Comment:      comment,
+			UserIDType:   userIDType,
+		}, token)
+		if err != nil {
+			return err
+		}
+
+		fmt.Printf("已抄送审批实例 %s 给 %d 位用户\n", instanceCode, len(ccUserIDs))
+		return nil
+	},
+}
+
+// parseCommaSeparatedIDs 把逗号分隔的字符串切成去空格、去空值的切片。
+func parseCommaSeparatedIDs(raw string) []string {
+	if strings.TrimSpace(raw) == "" {
+		return nil
+	}
+	parts := strings.Split(raw, ",")
+	out := make([]string, 0, len(parts))
+	for _, p := range parts {
+		p = strings.TrimSpace(p)
+		if p != "" {
+			out = append(out, p)
+		}
+	}
+	return out
+}
+
+func init() {
+	approvalInstanceCmd.AddCommand(approvalInstanceCcCmd)
+
+	approvalInstanceCcCmd.Flags().String("approval-code", "", "审批定义 code（必填）")
+	approvalInstanceCcCmd.Flags().String("instance-code", "", "审批实例 code（必填）")
+	approvalInstanceCcCmd.Flags().String("user-id", "", "执行抄送的用户 ID（必填）")
+	approvalInstanceCcCmd.Flags().String("cc-user-ids", "", "被抄送用户 ID 列表，逗号分隔（必填）")
+	approvalInstanceCcCmd.Flags().String("comment", "", "抄送备注（可选）")
+	approvalInstanceCcCmd.Flags().String("user-id-type", "open_id", "用户 ID 类型：open_id/user_id/union_id")
+	approvalInstanceCcCmd.Flags().String("user-access-token", "", "User Access Token（覆盖登录态）")
+	mustMarkFlagRequired(approvalInstanceCcCmd, "approval-code", "instance-code", "user-id", "cc-user-ids")
+}

--- a/cmd/approval_instance_create.go
+++ b/cmd/approval_instance_create.go
@@ -53,10 +53,11 @@ var approvalInstanceCreateCmd = &cobra.Command{
 		if err != nil {
 			return err
 		}
-		// 校验是合法 JSON，避免无效字符串透传后服务端报错
-		var dummy any
-		if err := json.Unmarshal([]byte(formData), &dummy); err != nil {
-			return fmt.Errorf("表单数据不是合法 JSON: %w", err)
+		// 校验为合法 JSON 数组，飞书 form 必须是数组（[{"id":...}]），
+		// 否则服务端会返回不友好的参数错误。
+		var arr []any
+		if err := json.Unmarshal([]byte(formData), &arr); err != nil {
+			return fmt.Errorf("表单数据必须是 JSON 数组，解析失败: %w", err)
 		}
 
 		userIDType, _ := cmd.Flags().GetString("user-id-type")
@@ -73,7 +74,7 @@ var approvalInstanceCreateCmd = &cobra.Command{
 			OpenChatID:   openChatID,
 		}
 
-		token := resolveFlagUserToken(cmd)
+		token := resolveOptionalUserTokenWithFallback(cmd)
 		result, err := client.CreateApprovalInstance(opts, token)
 		if err != nil {
 			return err

--- a/cmd/approval_instance_create.go
+++ b/cmd/approval_instance_create.go
@@ -1,0 +1,104 @@
+package cmd
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/riba2534/feishu-cli/internal/client"
+	"github.com/riba2534/feishu-cli/internal/config"
+	"github.com/spf13/cobra"
+)
+
+var approvalInstanceCreateCmd = &cobra.Command{
+	Use:   "create",
+	Short: "创建审批实例（发起审批）",
+	Long: `创建一条审批实例。需要 User Token + scope approval:approval。
+
+参数:
+  --approval-code   审批定义 code（必填）
+  --user-id         发起人 ID（必填，open_id/user_id/union_id）
+  --form            表单数据 JSON 字符串（与 --form-file 二选一）
+  --form-file       表单数据 JSON 文件路径（与 --form 二选一）
+  --user-id-type    open_id（默认）/user_id/union_id
+  --department-id   发起人部门 ID（可选）
+  --open-chat-id    审批结果推送到的群（可选）
+  --output, -o      输出格式：json
+
+示例:
+  # 通过文件提交表单
+  feishu-cli approval instance create --approval-code <code> --user-id ou_xxx --form-file form.json
+
+  # 直接传 JSON 字符串
+  feishu-cli approval instance create --approval-code <code> --user-id ou_xxx \
+    --form '[{"id":"widget_1","type":"input","value":"内容"}]'`,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		if err := config.Validate(); err != nil {
+			return err
+		}
+
+		approvalCode, _ := cmd.Flags().GetString("approval-code")
+		if err := validateApprovalCode(approvalCode); err != nil {
+			return err
+		}
+
+		userID, _ := cmd.Flags().GetString("user-id")
+		if strings.TrimSpace(userID) == "" {
+			return fmt.Errorf("--user-id 不能为空")
+		}
+
+		formInline, _ := cmd.Flags().GetString("form")
+		formFile, _ := cmd.Flags().GetString("form-file")
+		formData, err := loadJSONInput(formInline, formFile, "form", "form-file", "表单数据")
+		if err != nil {
+			return err
+		}
+		// 校验是合法 JSON，避免无效字符串透传后服务端报错
+		var dummy any
+		if err := json.Unmarshal([]byte(formData), &dummy); err != nil {
+			return fmt.Errorf("表单数据不是合法 JSON: %w", err)
+		}
+
+		userIDType, _ := cmd.Flags().GetString("user-id-type")
+		departmentID, _ := cmd.Flags().GetString("department-id")
+		openChatID, _ := cmd.Flags().GetString("open-chat-id")
+		output, _ := cmd.Flags().GetString("output")
+
+		opts := client.CreateApprovalInstanceOptions{
+			ApprovalCode: approvalCode,
+			UserID:       userID,
+			Form:         formData,
+			UserIDType:   userIDType,
+			DepartmentID: departmentID,
+			OpenChatID:   openChatID,
+		}
+
+		token := resolveFlagUserToken(cmd)
+		result, err := client.CreateApprovalInstance(opts, token)
+		if err != nil {
+			return err
+		}
+
+		if output == "json" {
+			return printJSON(result)
+		}
+
+		fmt.Printf("审批实例已创建\n  instance_code: %s\n", result.InstanceCode)
+		return nil
+	},
+}
+
+func init() {
+	approvalInstanceCmd.AddCommand(approvalInstanceCreateCmd)
+
+	approvalInstanceCreateCmd.Flags().String("approval-code", "", "审批定义 code（必填）")
+	approvalInstanceCreateCmd.Flags().String("user-id", "", "发起人用户 ID（必填）")
+	approvalInstanceCreateCmd.Flags().String("form", "", "表单数据 JSON 字符串（与 --form-file 二选一）")
+	approvalInstanceCreateCmd.Flags().String("form-file", "", "表单数据 JSON 文件路径")
+	approvalInstanceCreateCmd.Flags().String("user-id-type", "open_id", "用户 ID 类型：open_id/user_id/union_id")
+	approvalInstanceCreateCmd.Flags().String("department-id", "", "发起人部门 ID（可选）")
+	approvalInstanceCreateCmd.Flags().String("open-chat-id", "", "结果推送的群 ID（可选）")
+	approvalInstanceCreateCmd.Flags().StringP("output", "o", "", "输出格式（json）")
+	approvalInstanceCreateCmd.Flags().String("user-access-token", "", "User Access Token（覆盖登录态）")
+	mustMarkFlagRequired(approvalInstanceCreateCmd, "approval-code", "user-id")
+}

--- a/cmd/approval_task.go
+++ b/cmd/approval_task.go
@@ -5,14 +5,25 @@ import "github.com/spf13/cobra"
 var approvalTaskCmd = &cobra.Command{
 	Use:   "task",
 	Short: "审批任务相关命令",
-	Long: `审批任务相关命令，用于查询当前 auth 登录用户待处理、已处理、已发起或抄送的审批任务。
+	Long: `审批任务相关命令，用于查询、通过或拒绝审批任务。
+
+当前已提供：
+  - 审批任务查询（approval task query）
+  - 通过审批任务（approval task approve）
+  - 拒绝审批任务（approval task reject）
 
 示例:
   # 查询待我审批的任务
   feishu-cli approval task query --topic todo
 
   # 查询我发起的审批
-  feishu-cli approval task query --topic started --output json`,
+  feishu-cli approval task query --topic started --output json
+
+  # 通过审批任务
+  feishu-cli approval task approve --approval-code <code> --instance-code <ic> --task-id <task> --user-id ou_xxx
+
+  # 拒绝审批任务
+  feishu-cli approval task reject --approval-code <code> --instance-code <ic> --task-id <task> --user-id ou_xxx --comment "金额超预算"`,
 }
 
 func init() {

--- a/cmd/approval_task_approve.go
+++ b/cmd/approval_task_approve.go
@@ -36,7 +36,7 @@ var approvalTaskApproveCmd = &cobra.Command{
 			return err
 		}
 
-		token := resolveFlagUserToken(cmd)
+		token := resolveOptionalUserTokenWithFallback(cmd)
 		if err := client.ApproveApprovalTask(opts, token); err != nil {
 			return err
 		}

--- a/cmd/approval_task_approve.go
+++ b/cmd/approval_task_approve.go
@@ -1,0 +1,98 @@
+package cmd
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/riba2534/feishu-cli/internal/client"
+	"github.com/riba2534/feishu-cli/internal/config"
+	"github.com/spf13/cobra"
+)
+
+var approvalTaskApproveCmd = &cobra.Command{
+	Use:   "approve",
+	Short: "通过审批任务",
+	Long: `通过指定的审批任务（同意）。需要 User Token + scope approval:approval。
+
+参数:
+  --approval-code    审批定义 code（必填）
+  --instance-code    审批实例 code（必填）
+  --task-id          审批任务 ID（必填）
+  --user-id          操作人用户 ID（必填）
+  --comment          审批意见（可选）
+  --user-id-type     open_id（默认）/user_id/union_id
+
+示例:
+  feishu-cli approval task approve \
+    --approval-code <code> --instance-code <ic> --task-id <task> --user-id ou_xxx \
+    --comment "同意"`,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		if err := config.Validate(); err != nil {
+			return err
+		}
+
+		opts, err := readApprovalTaskActionFlags(cmd)
+		if err != nil {
+			return err
+		}
+
+		token := resolveFlagUserToken(cmd)
+		if err := client.ApproveApprovalTask(opts, token); err != nil {
+			return err
+		}
+
+		fmt.Printf("已通过审批任务: %s\n", opts.TaskID)
+		return nil
+	},
+}
+
+// readApprovalTaskActionFlags 共享 approve/reject 两条命令的 flag 解析与校验。
+func readApprovalTaskActionFlags(cmd *cobra.Command) (client.ApprovalTaskActionOptions, error) {
+	approvalCode, _ := cmd.Flags().GetString("approval-code")
+	if err := validateApprovalCode(approvalCode); err != nil {
+		return client.ApprovalTaskActionOptions{}, err
+	}
+
+	instanceCode, _ := cmd.Flags().GetString("instance-code")
+	if strings.TrimSpace(instanceCode) == "" {
+		return client.ApprovalTaskActionOptions{}, fmt.Errorf("--instance-code 不能为空")
+	}
+
+	taskID, _ := cmd.Flags().GetString("task-id")
+	if strings.TrimSpace(taskID) == "" {
+		return client.ApprovalTaskActionOptions{}, fmt.Errorf("--task-id 不能为空")
+	}
+
+	userID, _ := cmd.Flags().GetString("user-id")
+	if strings.TrimSpace(userID) == "" {
+		return client.ApprovalTaskActionOptions{}, fmt.Errorf("--user-id 不能为空")
+	}
+
+	comment, _ := cmd.Flags().GetString("comment")
+	userIDType, _ := cmd.Flags().GetString("user-id-type")
+
+	return client.ApprovalTaskActionOptions{
+		ApprovalCode: approvalCode,
+		InstanceCode: instanceCode,
+		TaskID:       taskID,
+		UserID:       userID,
+		Comment:      comment,
+		UserIDType:   userIDType,
+	}, nil
+}
+
+func registerApprovalTaskActionFlags(cmd *cobra.Command) {
+	cmd.Flags().String("approval-code", "", "审批定义 code（必填）")
+	cmd.Flags().String("instance-code", "", "审批实例 code（必填）")
+	cmd.Flags().String("task-id", "", "审批任务 ID（必填）")
+	cmd.Flags().String("user-id", "", "操作人用户 ID（必填）")
+	cmd.Flags().String("comment", "", "审批意见（可选）")
+	cmd.Flags().String("user-id-type", "open_id", "用户 ID 类型：open_id/user_id/union_id")
+	cmd.Flags().String("user-access-token", "", "User Access Token（覆盖登录态）")
+	mustMarkFlagRequired(cmd, "approval-code", "instance-code", "task-id", "user-id")
+}
+
+func init() {
+	approvalTaskCmd.AddCommand(approvalTaskApproveCmd)
+	registerApprovalTaskActionFlags(approvalTaskApproveCmd)
+}

--- a/cmd/approval_task_reject.go
+++ b/cmd/approval_task_reject.go
@@ -35,7 +35,7 @@ var approvalTaskRejectCmd = &cobra.Command{
 			return err
 		}
 
-		token := resolveFlagUserToken(cmd)
+		token := resolveOptionalUserTokenWithFallback(cmd)
 		if err := client.RejectApprovalTask(opts, token); err != nil {
 			return err
 		}

--- a/cmd/approval_task_reject.go
+++ b/cmd/approval_task_reject.go
@@ -1,0 +1,51 @@
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/riba2534/feishu-cli/internal/client"
+	"github.com/riba2534/feishu-cli/internal/config"
+	"github.com/spf13/cobra"
+)
+
+var approvalTaskRejectCmd = &cobra.Command{
+	Use:   "reject",
+	Short: "拒绝审批任务",
+	Long: `拒绝指定的审批任务。需要 User Token + scope approval:approval。
+
+参数:
+  --approval-code    审批定义 code（必填）
+  --instance-code    审批实例 code（必填）
+  --task-id          审批任务 ID（必填）
+  --user-id          操作人用户 ID（必填）
+  --comment          审批意见（可选，建议填写拒绝原因）
+  --user-id-type     open_id（默认）/user_id/union_id
+
+示例:
+  feishu-cli approval task reject \
+    --approval-code <code> --instance-code <ic> --task-id <task> --user-id ou_xxx \
+    --comment "金额超预算"`,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		if err := config.Validate(); err != nil {
+			return err
+		}
+
+		opts, err := readApprovalTaskActionFlags(cmd)
+		if err != nil {
+			return err
+		}
+
+		token := resolveFlagUserToken(cmd)
+		if err := client.RejectApprovalTask(opts, token); err != nil {
+			return err
+		}
+
+		fmt.Printf("已拒绝审批任务: %s\n", opts.TaskID)
+		return nil
+	},
+}
+
+func init() {
+	approvalTaskCmd.AddCommand(approvalTaskRejectCmd)
+	registerApprovalTaskActionFlags(approvalTaskRejectCmd)
+}

--- a/internal/client/approval.go
+++ b/internal/client/approval.go
@@ -426,3 +426,235 @@ func approvalTaskAPIToInfo(task *approvalTaskAPIInfo) *ApprovalTaskInfo {
 
 	return info
 }
+
+// CreateApprovalInstanceOptions represents options for creating an approval instance.
+// 创建审批实例参数（POST /open-apis/approval/v4/instances）
+type CreateApprovalInstanceOptions struct {
+	ApprovalCode string // 必填：审批定义 code
+	UserID       string // 必填：发起人 ID（open_id/user_id/union_id）
+	Form         string // 必填：表单数据 JSON 字符串
+	UserIDType   string // 可选：open_id / user_id / union_id，默认 open_id
+	DepartmentID string // 可选：发起人部门
+	OpenChatID   string // 可选：发送结果到的群聊
+	NodeApproverUserIDList json.RawMessage // 可选：节点指定审批人，JSON 原文
+	NodeCCUserIDList       json.RawMessage // 可选：节点指定抄送人，JSON 原文
+}
+
+// CreateApprovalInstanceResult 创建实例返回结果，仅暴露常用字段。
+type CreateApprovalInstanceResult struct {
+	InstanceCode string `json:"instance_code"`
+}
+
+// CancelApprovalInstanceOptions represents options for cancelling an approval instance.
+// 取消审批实例参数（POST /open-apis/approval/v4/instances/cancel）
+type CancelApprovalInstanceOptions struct {
+	ApprovalCode string // 必填：审批定义 code
+	InstanceCode string // 必填：审批实例 code
+	UserID       string // 必填：执行操作的用户 ID
+	UserIDType   string // 可选：open_id / user_id / union_id
+}
+
+// CCApprovalInstanceOptions represents options for cc'ing an approval instance.
+// 抄送审批实例参数（POST /open-apis/approval/v4/instances/cc）
+type CCApprovalInstanceOptions struct {
+	ApprovalCode string   // 必填：审批定义 code
+	InstanceCode string   // 必填：审批实例 code
+	UserID       string   // 必填：执行抄送的用户 ID
+	CCUserIDs    []string // 必填：被抄送用户 ID 列表
+	Comment      string   // 可选：抄送备注
+	UserIDType   string   // 可选：open_id / user_id / union_id
+}
+
+// ApprovalTaskActionOptions represents shared options for task approve/reject.
+// 通过/拒绝审批任务参数（POST /open-apis/approval/v4/tasks/{approve,reject}）
+type ApprovalTaskActionOptions struct {
+	ApprovalCode string // 必填：审批定义 code
+	InstanceCode string // 必填：审批实例 code
+	TaskID       string // 必填：审批任务 ID
+	UserID       string // 必填：操作人 ID
+	Comment      string // 可选：审批意见
+	Form         string // 可选：表单数据（更新表单时使用），JSON 字符串
+	UserIDType   string // 可选：open_id / user_id / union_id
+}
+
+// genericApprovalAPIResp 解析审批写接口的通用响应（多数返回 data 为空或仅含 instance_code）。
+type genericApprovalAPIResp struct {
+	Code int             `json:"code"`
+	Msg  string          `json:"msg"`
+	Data json.RawMessage `json:"data"`
+}
+
+// doApprovalPost 统一发起审批 POST 调用，支持透传 user_id_type 查询参数 + user/tenant token。
+func doApprovalPost(apiPath string, body map[string]any, userIDType, userAccessToken, action string) (json.RawMessage, error) {
+	c, err := GetClient()
+	if err != nil {
+		return nil, err
+	}
+
+	if userIDType != "" {
+		sep := "?"
+		if strings.Contains(apiPath, "?") {
+			sep = "&"
+		}
+		apiPath = apiPath + sep + "user_id_type=" + userIDType
+	}
+
+	tokenType, opts := resolveTokenOpts(userAccessToken)
+	resp, err := c.Post(Context(), apiPath, body, tokenType, opts...)
+	if err != nil {
+		return nil, fmt.Errorf("%s失败: %w", action, err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("%s失败: HTTP %d, body: %s", action, resp.StatusCode, string(resp.RawBody))
+	}
+
+	var apiResp genericApprovalAPIResp
+	if err := json.Unmarshal(resp.RawBody, &apiResp); err != nil {
+		return nil, fmt.Errorf("解析%s响应失败: %w", action, err)
+	}
+	if apiResp.Code != 0 {
+		return nil, fmt.Errorf("%s失败: code=%d, msg=%s", action, apiResp.Code, apiResp.Msg)
+	}
+	return apiResp.Data, nil
+}
+
+// CreateApprovalInstance 创建一条审批实例，返回 instance_code。
+func CreateApprovalInstance(opts CreateApprovalInstanceOptions, userAccessToken string) (*CreateApprovalInstanceResult, error) {
+	if strings.TrimSpace(opts.ApprovalCode) == "" {
+		return nil, fmt.Errorf("approval_code 不能为空")
+	}
+	if strings.TrimSpace(opts.UserID) == "" {
+		return nil, fmt.Errorf("user_id 不能为空")
+	}
+	if strings.TrimSpace(opts.Form) == "" {
+		return nil, fmt.Errorf("form 不能为空")
+	}
+
+	body := map[string]any{
+		"approval_code": opts.ApprovalCode,
+		"user_id":       opts.UserID,
+		"form":          opts.Form,
+	}
+	if opts.DepartmentID != "" {
+		body["department_id"] = opts.DepartmentID
+	}
+	if opts.OpenChatID != "" {
+		body["open_chat_id"] = opts.OpenChatID
+	}
+	if len(opts.NodeApproverUserIDList) > 0 {
+		var v any
+		if err := json.Unmarshal(opts.NodeApproverUserIDList, &v); err != nil {
+			return nil, fmt.Errorf("解析 node_approver_user_id_list 失败: %w", err)
+		}
+		body["node_approver_user_id_list"] = v
+	}
+	if len(opts.NodeCCUserIDList) > 0 {
+		var v any
+		if err := json.Unmarshal(opts.NodeCCUserIDList, &v); err != nil {
+			return nil, fmt.Errorf("解析 node_cc_user_id_list 失败: %w", err)
+		}
+		body["node_cc_user_id_list"] = v
+	}
+
+	data, err := doApprovalPost("/open-apis/approval/v4/instances", body, opts.UserIDType, userAccessToken, "创建审批实例")
+	if err != nil {
+		return nil, err
+	}
+
+	result := &CreateApprovalInstanceResult{}
+	if len(data) > 0 {
+		if err := json.Unmarshal(data, result); err != nil {
+			return nil, fmt.Errorf("解析创建审批实例响应失败: %w", err)
+		}
+	}
+	return result, nil
+}
+
+// CancelApprovalInstance 取消（撤回）已发起的审批实例。
+func CancelApprovalInstance(opts CancelApprovalInstanceOptions, userAccessToken string) error {
+	if strings.TrimSpace(opts.ApprovalCode) == "" {
+		return fmt.Errorf("approval_code 不能为空")
+	}
+	if strings.TrimSpace(opts.InstanceCode) == "" {
+		return fmt.Errorf("instance_code 不能为空")
+	}
+	if strings.TrimSpace(opts.UserID) == "" {
+		return fmt.Errorf("user_id 不能为空")
+	}
+
+	body := map[string]any{
+		"approval_code": opts.ApprovalCode,
+		"instance_code": opts.InstanceCode,
+		"user_id":       opts.UserID,
+	}
+	_, err := doApprovalPost("/open-apis/approval/v4/instances/cancel", body, opts.UserIDType, userAccessToken, "取消审批实例")
+	return err
+}
+
+// CCApprovalInstance 抄送审批实例给指定用户。
+func CCApprovalInstance(opts CCApprovalInstanceOptions, userAccessToken string) error {
+	if strings.TrimSpace(opts.ApprovalCode) == "" {
+		return fmt.Errorf("approval_code 不能为空")
+	}
+	if strings.TrimSpace(opts.InstanceCode) == "" {
+		return fmt.Errorf("instance_code 不能为空")
+	}
+	if strings.TrimSpace(opts.UserID) == "" {
+		return fmt.Errorf("user_id 不能为空")
+	}
+	if len(opts.CCUserIDs) == 0 {
+		return fmt.Errorf("cc_user_ids 不能为空")
+	}
+
+	body := map[string]any{
+		"approval_code":  opts.ApprovalCode,
+		"instance_code":  opts.InstanceCode,
+		"user_id":        opts.UserID,
+		"cc_user_ids":    opts.CCUserIDs,
+	}
+	if opts.Comment != "" {
+		body["comment"] = opts.Comment
+	}
+	_, err := doApprovalPost("/open-apis/approval/v4/instances/cc", body, opts.UserIDType, userAccessToken, "抄送审批实例")
+	return err
+}
+
+// ApproveApprovalTask 通过指定审批任务。
+func ApproveApprovalTask(opts ApprovalTaskActionOptions, userAccessToken string) error {
+	return runApprovalTaskAction("/open-apis/approval/v4/tasks/approve", opts, userAccessToken, "通过审批任务")
+}
+
+// RejectApprovalTask 拒绝指定审批任务。
+func RejectApprovalTask(opts ApprovalTaskActionOptions, userAccessToken string) error {
+	return runApprovalTaskAction("/open-apis/approval/v4/tasks/reject", opts, userAccessToken, "拒绝审批任务")
+}
+
+func runApprovalTaskAction(apiPath string, opts ApprovalTaskActionOptions, userAccessToken, action string) error {
+	if strings.TrimSpace(opts.ApprovalCode) == "" {
+		return fmt.Errorf("approval_code 不能为空")
+	}
+	if strings.TrimSpace(opts.InstanceCode) == "" {
+		return fmt.Errorf("instance_code 不能为空")
+	}
+	if strings.TrimSpace(opts.TaskID) == "" {
+		return fmt.Errorf("task_id 不能为空")
+	}
+	if strings.TrimSpace(opts.UserID) == "" {
+		return fmt.Errorf("user_id 不能为空")
+	}
+
+	body := map[string]any{
+		"approval_code": opts.ApprovalCode,
+		"instance_code": opts.InstanceCode,
+		"task_id":       opts.TaskID,
+		"user_id":       opts.UserID,
+	}
+	if opts.Comment != "" {
+		body["comment"] = opts.Comment
+	}
+	if opts.Form != "" {
+		body["form"] = opts.Form
+	}
+	_, err := doApprovalPost(apiPath, body, opts.UserIDType, userAccessToken, action)
+	return err
+}

--- a/skills/feishu-cli-approval/SKILL.md
+++ b/skills/feishu-cli-approval/SKILL.md
@@ -1,0 +1,249 @@
+---
+name: feishu-cli-approval
+description: >-
+  飞书审批操作（查询 + 写入）。读：definition detail / task query。
+  写：instance {create,cancel,cc} + task {approve,reject}（v1.23+ 新增）。
+  优先 User Token（自动从 token.json 读，可 --user-access-token 覆盖）；
+  fallback Tenant Token（部分写命令仅 user 身份合法）。
+  当用户请求"提交审批"、"审批通过/拒绝"、"撤回审批"、"抄送"、"审批查询"时使用。
+argument-hint: instance create/cancel/cc | task approve/reject | definition detail | task query
+user-invocable: true
+allowed-tools: Bash, Read
+---
+
+# 飞书审批技能（查询 + 写入）
+
+通过 feishu-cli 完成审批全生命周期：查询审批定义 / 待办任务，发起 / 撤回 / 抄送审批实例，通过 / 拒绝审批任务。
+
+> **feishu-cli**：如尚未安装，请前往 [riba2534/feishu-cli](https://github.com/riba2534/feishu-cli) 获取安装方式。
+
+## 核心概念
+
+飞书审批由四级对象组成，命令按对象分组：
+
+| 对象 | 说明 | 唯一 ID | CLI 子命令 |
+|------|------|---------|-----------|
+| **definition** | 审批定义（审批流模板，行政/财务后台配置） | `approval_code` | `approval get` |
+| **instance** | 审批实例（一次具体的发起，绑定一个 definition + 一份 form） | `instance_code` | `approval instance {create,cancel,cc}` |
+| **task** | 审批任务（实例分发到每个审批节点上的待办） | `task_id` | `approval task {query,approve,reject}` |
+| **cc** | 抄送（把实例送到其他用户阅知，非审批节点） | — | `approval instance cc` |
+
+**生命周期**：`get definition` → 提交 form 触发 `instance create` → 节点用户 `task approve/reject` → 发起人可中途 `instance cancel` 或 `instance cc` 抄送他人。
+
+## 身份说明（Token 策略）
+
+所有写命令（instance create/cancel/cc、task approve/reject）默认走 `resolveOptionalUserTokenWithFallback`：
+
+1. `--user-access-token` 参数（最高优先级）
+2. `FEISHU_USER_ACCESS_TOKEN` 环境变量
+3. `~/.feishu-cli/token.json`（OAuth 登录态，过期自动用 refresh_token 刷新）
+4. 都没有时回退 Tenant Token（App 身份）
+
+**重要**：审批写 API 在飞书侧大多只接受 **User Token**（用户必须是审批流可见人 / 发起人 / 节点审批人）。Tenant Token 调用 `task approve` 会被服务端拒绝。建议执行写操作前先 `feishu-cli auth login`。
+
+`approval get` 用 Tenant Token 即可。`approval task query` 通过 `resolveCurrentAuthedUserID` 自动从登录态推断 `open_id`，必须先 login。
+
+### 所需 scope
+
+| 命令 | scope | Token 类型 |
+|------|-------|-----------|
+| `approval get` | `approval:approval:readonly` | Tenant 即可 |
+| `approval task query` | `approval:task` | **User Token 必需** |
+| `approval instance {create,cancel,cc}` | `approval:approval`（含 `approval:instance:write`） | **User Token 必需** |
+| `approval task {approve,reject}` | `approval:approval`（含 `approval:task:write`） | **User Token 必需** |
+
+```bash
+feishu-cli auth check --scope "approval:approval approval:task"
+feishu-cli auth login --scope "approval:approval approval:task offline_access"
+```
+
+## 命令速查
+
+### 读
+
+```bash
+# 查审批定义（拿表单结构 / 节点列表，发起前必看）
+feishu-cli approval get <approval_code>
+feishu-cli approval get <approval_code> --output raw-json   # 原始 API
+
+# 查我的审批任务
+feishu-cli approval task query --topic todo                 # 待我审批
+feishu-cli approval task query --topic done                 # 我已审批
+feishu-cli approval task query --topic started              # 我发起的
+feishu-cli approval task query --topic cc-unread            # 抄送给我（未读）
+feishu-cli approval task query --topic cc-read              # 抄送给我（已读）
+```
+
+### 写（v1.23+ 新增）
+
+```bash
+# 发起审批实例（form 必须是 JSON 数组）
+feishu-cli approval instance create \
+  --approval-code <code> \
+  --user-id ou_xxx \
+  --form-file form.json
+#   或：--form '[{"id":"widget_1","type":"input","value":"内容"}]'
+
+# 撤回（取消）已发起的审批实例（只有发起人能撤）
+feishu-cli approval instance cancel \
+  --approval-code <code> \
+  --instance-code <ic> \
+  --user-id ou_xxx
+
+# 抄送实例给其他用户（逗号分隔，自动去重保留首次顺序）
+feishu-cli approval instance cc \
+  --approval-code <code> \
+  --instance-code <ic> \
+  --user-id ou_xxx \
+  --cc-user-ids ou_a,ou_b \
+  --comment "请知悉"
+
+# 通过 / 拒绝审批任务
+feishu-cli approval task approve \
+  --approval-code <code> --instance-code <ic> --task-id <task> --user-id ou_xxx \
+  --comment "同意"
+
+feishu-cli approval task reject \
+  --approval-code <code> --instance-code <ic> --task-id <task> --user-id ou_xxx \
+  --comment "金额超预算"
+```
+
+## 关键 flag
+
+### `--approval-code`（所有写命令必填）
+
+审批定义 code，可从 `approval get` 输出或飞书后台审批管理页 URL 拿到。所有命令都先用 `isValidToken` 校验格式。
+
+### `--user-id` + `--user-id-type`
+
+操作人用户 ID。默认 `--user-id-type open_id`（`ou_xxx`），也支持 `user_id` / `union_id`。
+
+- `instance create`：发起人 ID
+- `instance cancel`：必须是发起人（飞书侧校验）
+- `instance cc`：发起抄送的用户（通常仍是发起人）
+- `task approve/reject`：节点上的审批人 ID（不是发起人！）
+
+### `--form` 与 `--form-file`（`instance create` 二选一）
+
+**form 必须是 JSON 数组**，否则 CLI 在客户端先报 "表单数据必须是 JSON 数组，解析失败"。每个元素对应审批定义中的一个 widget：
+
+```json
+[
+  {"id": "widget_1", "type": "input",    "value": "差旅报销 1500"},
+  {"id": "widget_2", "type": "number",   "value": 1500},
+  {"id": "widget_3", "type": "textarea", "value": "上海出差 3 天"}
+]
+```
+
+widget 的 `id` / `type` 从 `approval get --output raw-json` 的 form 字段读，**不要手编**。常见 type：`input` / `textarea` / `number` / `radio` / `checkbox` / `date` / `attachmentV2` / `fieldList`（明细控件，value 是数组的数组）。
+
+### `--cc-user-ids`（`instance cc` 必填）
+
+逗号分隔列表，例如 `ou_a,ou_b,ou_a`。CLI 通过 `parseCommaSeparatedIDs` 自动 trim + 去重，保留首次出现顺序，所以重复传同一个 ID 只会抄送一次。空字符串会被过滤。
+
+### `--comment`（可选，approve/reject/cc 共用）
+
+审批意见 / 抄送备注。`task reject` 建议必填拒绝原因；`task approve` 通常可省。
+
+### `--open-chat-id`（仅 `instance create`）
+
+审批结果推送到的群 ID，发起后自动在该群发卡片更新审批状态。可选。
+
+### `--user-access-token`
+
+覆盖 token 解析链最顶端。多数情况无需指定，自动从 `~/.feishu-cli/token.json` 读已登录态。
+
+## 完整用例
+
+### 例 1：从零到通过一条报销审批
+
+```bash
+# 1. 登录并预检 scope
+feishu-cli auth login --scope "approval:approval approval:task offline_access"
+
+# 2. 查审批定义拿 widget 结构
+feishu-cli approval get 7AB12C... --output raw-json | jq '.form'
+
+# 3. 准备 form.json
+cat > /tmp/form.json <<'EOF'
+[
+  {"id": "widget_1", "type": "input",  "value": "差旅报销"},
+  {"id": "widget_2", "type": "number", "value": 1500}
+]
+EOF
+
+# 4. 发起实例（拿到 instance_code）
+feishu-cli approval instance create \
+  --approval-code 7AB12C... \
+  --user-id ou_self \
+  --form-file /tmp/form.json
+# → 输出：审批实例已创建  instance_code: 8XY99Z...
+
+# 5. 节点审批人通过任务（先在节点审批人电脑/账号上 auth login）
+feishu-cli approval task query --topic todo   # 拿到 task_id
+feishu-cli approval task approve \
+  --approval-code 7AB12C... \
+  --instance-code 8XY99Z... \
+  --task-id 99TASK... \
+  --user-id ou_approver \
+  --comment "同意"
+```
+
+### 例 2：发起后撤回 + 抄送
+
+```bash
+# 发起人撤回
+feishu-cli approval instance cancel \
+  --approval-code <code> --instance-code <ic> --user-id ou_self
+
+# 抄送给 2 个同事（重复 ID 会去重）
+feishu-cli approval instance cc \
+  --approval-code <code> --instance-code <ic> \
+  --user-id ou_self --cc-user-ids ou_a,ou_b,ou_a \
+  --comment "供参考"
+```
+
+## 踩坑
+
+| 问题 | 原因 | 解决 |
+|------|------|------|
+| `表单数据必须是 JSON 数组，解析失败` | `--form` 传了 `{...}` 对象 | 包成数组 `[{...}]`，飞书 form 顶层永远是数组 |
+| `--cc-user-ids` 重复 ID 抄送多次 | 不会，CLI 已去重（`parseCommaSeparatedIDs`） | 如需多次提示，多次执行 `instance cc` |
+| `task approve` 返回 forbidden | 用了 Tenant Token / 操作人不是节点审批人 / 实例已结束 | `auth login` 用节点审批人账号；先 `task query --topic todo` 确认 task 还在 |
+| `instance cancel` 失败 | 操作人不是发起人 / 实例已审批完成 | 只有发起人能撤；已通过/拒绝的实例无法撤 |
+| `widget id` 找不到 | 手编 ID，没对上后台定义 | 先 `approval get --output raw-json` 看 `form` 字段 |
+| `auth login` 没传 `offline_access` | token 1h 后过期不能自动刷新 | 重新 login 显式加 `--scope "... offline_access"`，Device Flow 已自动注入但确认下 |
+| 写命令默认走 token.json，没登录态时静默回退 Tenant | 调用立即 403 | 写之前先 `feishu-cli auth status` 看登录情况 |
+
+## 输出格式
+
+写命令默认输出单行成功摘要：
+
+```
+审批实例已创建
+  instance_code: 8XY99Z...
+```
+
+读命令 `approval get` / `task query` 支持：
+
+- 不传 `--output`：人类可读文本摘要
+- `--output json`：CLI 归一化 JSON
+- `--output raw-json`：飞书 API 原始响应（拿 widget 结构 / debug 必备）
+
+写命令暂未实现 `--output json`，需要拿 `instance_code` 程序消费的话从 stdout 抓字符串。
+
+## 不在本技能范围
+
+| 需求 | 走哪里 |
+|------|--------|
+| 审批流可视化设计（拖拽节点、配置审批人、设置可见范围） | 飞书后台「审批管理」Web UI，CLI 不覆盖 |
+| 转交 / 退回 / 加签 / 催办（`tasks/transfer` / `rollback` / `add_sign` / `remind`） | 暂未实现，按需 PR |
+| 审批回调订阅 / Webhook 处理 | 不属于 CLI 职责，走开放平台事件订阅 |
+| 审批结果通知到群（消息卡片） | `instance create --open-chat-id <chat>` 内置；或 `feishu-cli-msg` 发自定义卡片 |
+| 给审批文档评论 / 加权限 | `feishu-cli-perm` / 评论命令；审批本身不挂在云文档体系 |
+
+## 相关 skill
+
+- `/feishu-cli-auth` — OAuth 登录、scope 预检、token 状态
+- `/feishu-cli-toolkit` — 综合查询入口（也有 approval get / task query 速查段）
+- `/feishu-cli-msg` — 审批结果二次通知到群 / 个人


### PR DESCRIPTION
## 背景

feishu-cli 之前的 approval 模块仅支持查询（get/task query），无法写。这导致 AI agent 不能自动化常见审批流程（请假、报销、采购等）。本 PR 用 lark-cli 同款 OpenAPI 补齐 5 个核心写命令。

## 新增命令（MVP）

```bash
# 创建审批实例（form 支持文件或字符串）
feishu-cli approval instance create \
  --approval-code APPROVAL_xxx --user-id ou_xxx \
  --form @form.json | --form '{"name":"value"}' \
  [--department-id xxx --open-chat-id oc_xxx --user-id-type open_id]

# 取消实例
feishu-cli approval instance cancel --approval-code xxx --instance-code xxx --user-id ou_xxx

# 抄送
feishu-cli approval instance cc --approval-code xxx --instance-code xxx \
  --user-id ou_xxx --cc-user-ids ou_a,ou_b [--comment "..."]

# 通过审批
feishu-cli approval task approve --approval-code xxx --instance-code xxx \
  --task-id xxx --user-id ou_xxx [--comment "..."]

# 拒绝审批
feishu-cli approval task reject --approval-code xxx --instance-code xxx \
  --task-id xxx --user-id ou_xxx [--comment "..."]
```

## 实现要点

- 接口走 `client.Post` HTTP 直调 OpenAPI（与 \`CreateCommentReply\` 同套路）
- 5 写函数共享 \`doApprovalPost\` POST helper：统一处理 \`user_id_type\` query 拼接 + 状态码 + code/msg 错误解码
- \`approve\`/\`reject\` 复用 \`ApprovalTaskActionOptions\` + \`registerApprovalTaskActionFlags\` 共享 flag 注册
- token 解析走 \`resolveFlagUserToken\`（与既有 \`approval task query\` 一致），允许 user/tenant 双 token
- \`--form-file\` / \`--form\` 二选一，本地预校验 JSON 合法性

## 边界（不在本 PR）

按 MVP 范围：未实现 \`tasks/transfer\` / \`tasks/rollback\` / \`tasks/add_sign\` / \`tasks/remind\`，留后续 PR。CHANGELOG 已注明。

## Scope

\`approval:approval\` (user token 推荐；tenant token 在 sandbox 也支持)

## 测试

- \`go build ./...\` / \`go vet ./...\` 全绿
- \`go test ./cmd -run "Approval"\` 6 PASS
- \`go test ./internal/client -run "Approval"\` 4 PASS