### PR TITLE
feat(sheet): filter-view CRUD + dropdown set（lark-cli 对齐）

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,27 @@
 
 ## 未发布
 
+### 新增 — `sheet filter-view` + `sheet dropdown`：筛选视图与下拉菜单
+
+补齐 lark-cli 独占的两块电子表格高级能力：
+
+- **筛选视图 CRUD（V3 API）**：用 SDK `SpreadsheetSheetFilterView` 实现
+  - `feishu-cli sheet filter-view create --token <t> --sheet-id <s> --range "<sheetId>!A1:H14" [--name 视图名 --filter-view-id 自定义ID]`
+  - `feishu-cli sheet filter-view list --token <t> --sheet-id <s>`
+  - `feishu-cli sheet filter-view delete --token <t> --sheet-id <s> --filter-view-id <fv>`
+  - `--range` 不带 sheetId 前缀时自动补全为 `<sheet-id>!<range>`
+- **下拉菜单（V2 dataValidation API）**：list 类型数据验证
+  - `feishu-cli sheet dropdown set --token <t> --range "<sheetId>!A1:A100" --options "待办,处理中,已完成" [--multiple --colors "#FF4D4F,#FAAD14,#52C41A"]`
+  - `--options-json '["a, b","c"]'`：选项内含逗号时绕过 CSV 解析
+  - 传 `--colors` 自动开启 `highlightValidData`，颜色数量需与选项一致
+
+**权限**：`sheets:spreadsheet`（User Token 或 App Token 均可），命令默认 `resolveOptionalUserTokenWithFallback` 自动读取登录态。
+
+**代码影响范围**：
+
+- `internal/client/sheets.go`：新增 `CreateFilterView` / `ListFilterViews` / `DeleteFilterView` / `SetDropdown`
+- `cmd/sheet_filter_view.go`、`cmd/sheet_dropdown.go`：CLI 入口
+
 ### 新增 — `comment reply add`：为已有评论添加回复
 
 新增命令 `feishu-cli comment reply add <file_token> <comment_id> --text "..."`，补齐评论回复

--- a/cmd/sheet.go
+++ b/cmd/sheet.go
@@ -8,7 +8,7 @@ import (
 var sheetCmd = &cobra.Command{
 	Use:   "sheet",
 	Short: "电子表格操作",
-	Long:  "电子表格操作命令组，包括创建、读写、工作表管理等功能",
+	Long:  "电子表格操作命令组，包括创建、读写、工作表管理、筛选视图管理（filter-view）和下拉菜单设置（dropdown）等功能",
 }
 
 func init() {

--- a/cmd/sheet_dropdown.go
+++ b/cmd/sheet_dropdown.go
@@ -47,6 +47,10 @@ options 用逗号分隔多个选项，每项 ≤ 100 字符；如需选项内出
 			return fmt.Errorf("--token、--range 均为必填项")
 		}
 
+		if strings.TrimSpace(optionsJSON) != "" && strings.TrimSpace(optionsCSV) != "" {
+			return fmt.Errorf("--options 和 --options-json 不能同时使用，请选其一")
+		}
+
 		rangeStr = unescapeSheetRange(rangeStr)
 
 		options, err := parseDropdownOptions(optionsCSV, optionsJSON)

--- a/cmd/sheet_dropdown.go
+++ b/cmd/sheet_dropdown.go
@@ -1,0 +1,111 @@
+package cmd
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/riba2534/feishu-cli/internal/client"
+	"github.com/spf13/cobra"
+)
+
+// 下拉菜单命令组
+var sheetDropdownCmd = &cobra.Command{
+	Use:   "dropdown",
+	Short: "下拉菜单操作",
+	Long:  "工作表下拉菜单（数据验证）相关操作",
+}
+
+var sheetDropdownSetCmd = &cobra.Command{
+	Use:   "set",
+	Short: "设置下拉菜单",
+	Long: `在指定区域设置下拉菜单（list 类型数据验证）。
+
+range 必须带 sheetId 前缀，例如 "0b1212!A1:A100"。
+options 用逗号分隔多个选项，每项 ≤ 100 字符；如需选项内出现逗号请改用 --options-json '["a","b,c"]'。
+
+示例:
+  # 简单选项
+  feishu-cli sheet dropdown set --token shtcnxxxxxx --range "0b1212!A1:A100" --options "待办,处理中,已完成"
+
+  # 多选 + 高亮
+  feishu-cli sheet dropdown set --token shtcnxxxxxx --range "0b1212!B1:B100" \
+      --options "P0,P1,P2" --multiple --colors "#FF4D4F,#FAAD14,#52C41A"
+
+  # 选项含逗号
+  feishu-cli sheet dropdown set --token shtcnxxxxxx --range "0b1212!C1:C100" \
+      --options-json '["a, b","c"]'`,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		spreadsheetToken, _ := cmd.Flags().GetString("token")
+		rangeStr, _ := cmd.Flags().GetString("range")
+		optionsCSV, _ := cmd.Flags().GetString("options")
+		optionsJSON, _ := cmd.Flags().GetString("options-json")
+		colorsCSV, _ := cmd.Flags().GetString("colors")
+		multiple, _ := cmd.Flags().GetBool("multiple")
+
+		if spreadsheetToken == "" || rangeStr == "" {
+			return fmt.Errorf("--token、--range 均为必填项")
+		}
+
+		rangeStr = unescapeSheetRange(rangeStr)
+
+		options, err := parseDropdownOptions(optionsCSV, optionsJSON)
+		if err != nil {
+			return err
+		}
+		if len(options) == 0 {
+			return fmt.Errorf("--options 或 --options-json 至少需要一个非空选项")
+		}
+
+		var colors []string
+		if strings.TrimSpace(colorsCSV) != "" {
+			for _, c := range strings.Split(colorsCSV, ",") {
+				c = strings.TrimSpace(c)
+				if c != "" {
+					colors = append(colors, c)
+				}
+			}
+		}
+
+		userAccessToken := resolveOptionalUserTokenWithFallback(cmd)
+
+		if err := client.SetDropdown(client.Context(), spreadsheetToken, rangeStr, options, multiple, colors, userAccessToken); err != nil {
+			return err
+		}
+		fmt.Printf("下拉菜单设置成功！范围: %s，选项数: %d\n", rangeStr, len(options))
+		return nil
+	},
+}
+
+// parseDropdownOptions 解析下拉选项：optionsJSON 优先，否则用 CSV 拆分。
+func parseDropdownOptions(csv, jsonStr string) ([]string, error) {
+	if strings.TrimSpace(jsonStr) != "" {
+		var arr []string
+		if err := json.Unmarshal([]byte(jsonStr), &arr); err != nil {
+			return nil, fmt.Errorf("--options-json 必须是字符串数组（如 '[\"a\",\"b\"]'）: %w", err)
+		}
+		return arr, nil
+	}
+	var out []string
+	for _, s := range strings.Split(csv, ",") {
+		s = strings.TrimSpace(s)
+		if s != "" {
+			out = append(out, s)
+		}
+	}
+	return out, nil
+}
+
+func init() {
+	sheetCmd.AddCommand(sheetDropdownCmd)
+
+	sheetDropdownCmd.AddCommand(sheetDropdownSetCmd)
+
+	sheetDropdownSetCmd.Flags().String("token", "", "电子表格 token（必填）")
+	sheetDropdownSetCmd.Flags().String("range", "", "单元格范围，必须带 sheetId 前缀（如 0b1212!A1:A100）（必填）")
+	sheetDropdownSetCmd.Flags().String("options", "", "下拉选项，逗号分隔（与 --options-json 二选一）")
+	sheetDropdownSetCmd.Flags().String("options-json", "", `下拉选项 JSON 数组，如 '["a","b,c"]'（选项含逗号时使用）`)
+	sheetDropdownSetCmd.Flags().Bool("multiple", false, "启用多选（默认 false）")
+	sheetDropdownSetCmd.Flags().String("colors", "", "选项颜色（RGB hex，逗号分隔；数量需与选项一致，传值时自动开启高亮）")
+	sheetDropdownSetCmd.Flags().String("user-access-token", "", "User Access Token（可选，用于访问无 App 权限的表格）")
+}

--- a/cmd/sheet_filter_view.go
+++ b/cmd/sheet_filter_view.go
@@ -1,0 +1,145 @@
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/riba2534/feishu-cli/internal/client"
+	"github.com/spf13/cobra"
+)
+
+// 筛选视图命令组
+var sheetFilterViewCmd = &cobra.Command{
+	Use:   "filter-view",
+	Short: "筛选视图操作",
+	Long:  "工作表筛选视图相关操作（创建、列出、删除）",
+}
+
+var sheetFilterViewCreateCmd = &cobra.Command{
+	Use:   "create",
+	Short: "创建筛选视图",
+	Long: `在工作表中创建筛选视图。
+
+示例:
+  feishu-cli sheet filter-view create --token shtcnxxxxxx --sheet-id 0b1212 --range "0b1212!A1:H14" --name "我的视图"
+  feishu-cli sheet filter-view create --token shtcnxxxxxx --sheet-id 0b1212 --range "A1:H14"   # range 不带 sheetId 前缀时自动补全`,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		spreadsheetToken, _ := cmd.Flags().GetString("token")
+		sheetID, _ := cmd.Flags().GetString("sheet-id")
+		rangeStr, _ := cmd.Flags().GetString("range")
+		name, _ := cmd.Flags().GetString("name")
+		filterViewID, _ := cmd.Flags().GetString("filter-view-id")
+		output, _ := cmd.Flags().GetString("output")
+
+		if spreadsheetToken == "" || sheetID == "" || rangeStr == "" {
+			return fmt.Errorf("--token、--sheet-id、--range 均为必填项")
+		}
+
+		rangeStr = unescapeSheetRange(rangeStr)
+
+		userAccessToken := resolveOptionalUserTokenWithFallback(cmd)
+
+		fv, err := client.CreateFilterView(client.Context(), spreadsheetToken, sheetID, rangeStr, name, filterViewID, userAccessToken)
+		if err != nil {
+			return err
+		}
+
+		if output == "json" {
+			return printJSON(fv)
+		}
+		fmt.Printf("筛选视图创建成功！\n")
+		fmt.Printf("  ID:    %s\n", fv.FilterViewID)
+		fmt.Printf("  名称:  %s\n", fv.FilterViewName)
+		fmt.Printf("  范围:  %s\n", fv.Range)
+		return nil
+	},
+}
+
+var sheetFilterViewListCmd = &cobra.Command{
+	Use:   "list",
+	Short: "列出筛选视图",
+	Long:  "列出指定工作表的所有筛选视图",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		spreadsheetToken, _ := cmd.Flags().GetString("token")
+		sheetID, _ := cmd.Flags().GetString("sheet-id")
+		output, _ := cmd.Flags().GetString("output")
+
+		if spreadsheetToken == "" || sheetID == "" {
+			return fmt.Errorf("--token、--sheet-id 均为必填项")
+		}
+
+		userAccessToken := resolveOptionalUserTokenWithFallback(cmd)
+
+		items, err := client.ListFilterViews(client.Context(), spreadsheetToken, sheetID, userAccessToken)
+		if err != nil {
+			return err
+		}
+
+		if output == "json" {
+			return printJSON(items)
+		}
+		if len(items) == 0 {
+			fmt.Println("当前工作表没有筛选视图")
+			return nil
+		}
+		fmt.Printf("共 %d 个筛选视图:\n", len(items))
+		for i, fv := range items {
+			fmt.Printf("%d. ID=%s  名称=%s  范围=%s\n", i+1, fv.FilterViewID, fv.FilterViewName, fv.Range)
+		}
+		return nil
+	},
+}
+
+var sheetFilterViewDeleteCmd = &cobra.Command{
+	Use:   "delete",
+	Short: "删除筛选视图",
+	Long: `删除指定的筛选视图。
+
+示例:
+  feishu-cli sheet filter-view delete --token shtcnxxxxxx --sheet-id 0b1212 --filter-view-id pH9hbVcCXA`,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		spreadsheetToken, _ := cmd.Flags().GetString("token")
+		sheetID, _ := cmd.Flags().GetString("sheet-id")
+		filterViewID, _ := cmd.Flags().GetString("filter-view-id")
+
+		if spreadsheetToken == "" || sheetID == "" || filterViewID == "" {
+			return fmt.Errorf("--token、--sheet-id、--filter-view-id 均为必填项")
+		}
+
+		userAccessToken := resolveOptionalUserTokenWithFallback(cmd)
+
+		if err := client.DeleteFilterView(client.Context(), spreadsheetToken, sheetID, filterViewID, userAccessToken); err != nil {
+			return err
+		}
+		fmt.Printf("筛选视图删除成功（ID=%s）\n", filterViewID)
+		return nil
+	},
+}
+
+func init() {
+	sheetCmd.AddCommand(sheetFilterViewCmd)
+
+	sheetFilterViewCmd.AddCommand(sheetFilterViewCreateCmd)
+	sheetFilterViewCmd.AddCommand(sheetFilterViewListCmd)
+	sheetFilterViewCmd.AddCommand(sheetFilterViewDeleteCmd)
+
+	// create
+	sheetFilterViewCreateCmd.Flags().String("token", "", "电子表格 token（必填）")
+	sheetFilterViewCreateCmd.Flags().String("sheet-id", "", "工作表 ID（必填）")
+	sheetFilterViewCreateCmd.Flags().String("range", "", "筛选范围，例如 \"<sheetId>!A1:H14\"（必填）")
+	sheetFilterViewCreateCmd.Flags().String("name", "", "筛选视图名称（≤100 字符，可选）")
+	sheetFilterViewCreateCmd.Flags().String("filter-view-id", "", "自定义视图 ID（10 位字母数字，可选）")
+	sheetFilterViewCreateCmd.Flags().StringP("output", "o", "text", "输出格式: text, json")
+	sheetFilterViewCreateCmd.Flags().String("user-access-token", "", "User Access Token（可选，用于访问无 App 权限的表格）")
+
+	// list
+	sheetFilterViewListCmd.Flags().String("token", "", "电子表格 token（必填）")
+	sheetFilterViewListCmd.Flags().String("sheet-id", "", "工作表 ID（必填）")
+	sheetFilterViewListCmd.Flags().StringP("output", "o", "text", "输出格式: text, json")
+	sheetFilterViewListCmd.Flags().String("user-access-token", "", "User Access Token（可选，用于访问无 App 权限的表格）")
+
+	// delete
+	sheetFilterViewDeleteCmd.Flags().String("token", "", "电子表格 token（必填）")
+	sheetFilterViewDeleteCmd.Flags().String("sheet-id", "", "工作表 ID（必填）")
+	sheetFilterViewDeleteCmd.Flags().String("filter-view-id", "", "筛选视图 ID（必填）")
+	sheetFilterViewDeleteCmd.Flags().String("user-access-token", "", "User Access Token（可选，用于访问无 App 权限的表格）")
+}

--- a/internal/client/sheets.go
+++ b/internal/client/sheets.go
@@ -2328,7 +2328,7 @@ func DeleteFilterView(ctx context.Context, spreadsheetToken, sheetID, filterView
 
 // SetDropdown 在指定区域设置下拉菜单（list 类型数据验证）。
 // rangeStr 必须是带 sheetId 前缀的全范围格式 "<sheetId>!A1:A100"。
-// options 是下拉选项（≤ 500 项，每项 ≤ 100 字符，不含逗号）。
+// options 是下拉选项（≤ 500 项，每项 ≤ 100 字符；通过 CSV 传入时不含逗号，含逗号请用 --options-json）。
 // multiple 为 true 时启用多选；colors 长度需与 options 一致（为 nil 时不上色）。
 func SetDropdown(ctx context.Context, spreadsheetToken, rangeStr string, options []string, multiple bool, colors []string, userAccessToken ...string) error {
 	client, err := GetClient()
@@ -2337,7 +2337,7 @@ func SetDropdown(ctx context.Context, spreadsheetToken, rangeStr string, options
 	}
 
 	if !strings.Contains(rangeStr, "!") {
-		return fmt.Errorf("--range 必须包含 sheetId 前缀（例如 0b**12!A1:A100）")
+		return fmt.Errorf("--range 必须包含 sheetId 前缀（例如 <sheetId>!A1:A100）")
 	}
 	if len(options) == 0 {
 		return fmt.Errorf("下拉选项不能为空")

--- a/internal/client/sheets.go
+++ b/internal/client/sheets.go
@@ -2194,3 +2194,201 @@ func IndexToColumn(index int) string {
 	}
 	return result
 }
+
+// ==================== 筛选视图相关 (V3 API) ====================
+
+// FilterViewSummary 筛选视图摘要
+type FilterViewSummary struct {
+	FilterViewID   string `json:"filter_view_id"`
+	FilterViewName string `json:"filter_view_name"`
+	Range          string `json:"range"`
+}
+
+// CreateFilterView 创建筛选视图 (V3 API)。
+// name / filterViewID 可选；若不传，飞书侧自动生成。
+func CreateFilterView(ctx context.Context, spreadsheetToken, sheetID, rangeStr, name, filterViewID string, userAccessToken ...string) (*FilterViewSummary, error) {
+	client, err := GetClient()
+	if err != nil {
+		return nil, err
+	}
+
+	uat := firstString(userAccessToken)
+
+	// 范围需要包含 sheetId 前缀
+	fullRange := rangeStr
+	if !strings.Contains(rangeStr, "!") {
+		fullRange = sheetID + "!" + rangeStr
+	}
+
+	builder := larksheets.NewFilterViewBuilder().Range(fullRange)
+	if name != "" {
+		builder.FilterViewName(name)
+	}
+	if filterViewID != "" {
+		builder.FilterViewId(filterViewID)
+	}
+
+	req := larksheets.NewCreateSpreadsheetSheetFilterViewReqBuilder().
+		SpreadsheetToken(spreadsheetToken).
+		SheetId(sheetID).
+		FilterView(builder.Build()).
+		Build()
+
+	resp, err := client.Sheets.SpreadsheetSheetFilterView.Create(ctx, req, UserTokenOption(uat)...)
+	if err != nil {
+		return nil, fmt.Errorf("创建筛选视图失败: %w", err)
+	}
+	if !resp.Success() {
+		return nil, fmt.Errorf("创建筛选视图失败: code=%d, msg=%s", resp.Code, resp.Msg)
+	}
+
+	out := &FilterViewSummary{}
+	if resp.Data != nil && resp.Data.FilterView != nil {
+		fv := resp.Data.FilterView
+		if fv.FilterViewId != nil {
+			out.FilterViewID = *fv.FilterViewId
+		}
+		if fv.FilterViewName != nil {
+			out.FilterViewName = *fv.FilterViewName
+		}
+		if fv.Range != nil {
+			out.Range = *fv.Range
+		}
+	}
+	return out, nil
+}
+
+// ListFilterViews 列出工作表的所有筛选视图 (V3 API)
+func ListFilterViews(ctx context.Context, spreadsheetToken, sheetID string, userAccessToken ...string) ([]*FilterViewSummary, error) {
+	client, err := GetClient()
+	if err != nil {
+		return nil, err
+	}
+
+	uat := firstString(userAccessToken)
+
+	req := larksheets.NewQuerySpreadsheetSheetFilterViewReqBuilder().
+		SpreadsheetToken(spreadsheetToken).
+		SheetId(sheetID).
+		Build()
+
+	resp, err := client.Sheets.SpreadsheetSheetFilterView.Query(ctx, req, UserTokenOption(uat)...)
+	if err != nil {
+		return nil, fmt.Errorf("查询筛选视图失败: %w", err)
+	}
+	if !resp.Success() {
+		return nil, fmt.Errorf("查询筛选视图失败: code=%d, msg=%s", resp.Code, resp.Msg)
+	}
+
+	result := make([]*FilterViewSummary, 0)
+	if resp.Data != nil {
+		for _, fv := range resp.Data.Items {
+			item := &FilterViewSummary{}
+			if fv.FilterViewId != nil {
+				item.FilterViewID = *fv.FilterViewId
+			}
+			if fv.FilterViewName != nil {
+				item.FilterViewName = *fv.FilterViewName
+			}
+			if fv.Range != nil {
+				item.Range = *fv.Range
+			}
+			result = append(result, item)
+		}
+	}
+	return result, nil
+}
+
+// DeleteFilterView 删除筛选视图 (V3 API)
+func DeleteFilterView(ctx context.Context, spreadsheetToken, sheetID, filterViewID string, userAccessToken ...string) error {
+	client, err := GetClient()
+	if err != nil {
+		return err
+	}
+
+	uat := firstString(userAccessToken)
+
+	req := larksheets.NewDeleteSpreadsheetSheetFilterViewReqBuilder().
+		SpreadsheetToken(spreadsheetToken).
+		SheetId(sheetID).
+		FilterViewId(filterViewID).
+		Build()
+
+	resp, err := client.Sheets.SpreadsheetSheetFilterView.Delete(ctx, req, UserTokenOption(uat)...)
+	if err != nil {
+		return fmt.Errorf("删除筛选视图失败: %w", err)
+	}
+	if !resp.Success() {
+		return fmt.Errorf("删除筛选视图失败: code=%d, msg=%s", resp.Code, resp.Msg)
+	}
+	return nil
+}
+
+// ==================== 下拉菜单（数据验证）相关 (V2 API) ====================
+
+// SetDropdown 在指定区域设置下拉菜单（list 类型数据验证）。
+// rangeStr 必须是带 sheetId 前缀的全范围格式 "<sheetId>!A1:A100"。
+// options 是下拉选项（≤ 500 项，每项 ≤ 100 字符，不含逗号）。
+// multiple 为 true 时启用多选；colors 长度需与 options 一致（为 nil 时不上色）。
+func SetDropdown(ctx context.Context, spreadsheetToken, rangeStr string, options []string, multiple bool, colors []string, userAccessToken ...string) error {
+	client, err := GetClient()
+	if err != nil {
+		return err
+	}
+
+	if !strings.Contains(rangeStr, "!") {
+		return fmt.Errorf("--range 必须包含 sheetId 前缀（例如 0b**12!A1:A100）")
+	}
+	if len(options) == 0 {
+		return fmt.Errorf("下拉选项不能为空")
+	}
+	if colors != nil && len(colors) != len(options) {
+		return fmt.Errorf("--colors 长度(%d)必须与选项数(%d)一致", len(colors), len(options))
+	}
+
+	condValues := make([]any, len(options))
+	for i, s := range options {
+		condValues[i] = s
+	}
+
+	dv := map[string]any{
+		"conditionValues": condValues,
+	}
+	opts := map[string]any{
+		"multipleValues": multiple,
+	}
+	if colors != nil {
+		colorVals := make([]any, len(colors))
+		for i, c := range colors {
+			colorVals[i] = c
+		}
+		opts["colors"] = colorVals
+		opts["highlightValidData"] = true
+	}
+	dv["options"] = opts
+
+	path := fmt.Sprintf("/open-apis/sheets/v2/spreadsheets/%s/dataValidation", spreadsheetToken)
+	reqBody := map[string]any{
+		"range":              rangeStr,
+		"dataValidationType": "list",
+		"dataValidation":     dv,
+	}
+
+	uat := firstString(userAccessToken)
+	respBody, err := v2APICallWithToken(client, ctx, "POST", path, reqBody, uat)
+	if err != nil {
+		return fmt.Errorf("设置下拉菜单失败: %w", err)
+	}
+
+	var apiResp struct {
+		Code int    `json:"code"`
+		Msg  string `json:"msg"`
+	}
+	if err := json.Unmarshal(respBody, &apiResp); err != nil {
+		return fmt.Errorf("解析响应失败: %w", err)
+	}
+	if apiResp.Code != 0 {
+		return fmt.Errorf("设置下拉菜单失败: code=%d, msg=%s", apiResp.Code, apiResp.Msg)
+	}
+	return nil
+}

--- a/skills/feishu-cli-sheet/SKILL.md
+++ b/skills/feishu-cli-sheet/SKILL.md
@@ -1,0 +1,155 @@
+---
+name: feishu-cli-sheet
+description: >-
+  飞书电子表格高级能力（v1.23+ 新增筛选视图 + 下拉单元格）。
+  filter-view create/list/delete 管理筛选视图（V3 SpreadsheetSheetFilterView）；
+  dropdown set 给单元格设下拉框（V2 dataValidation HTTP 直调）。
+  基础读写（read/write/style/add-rows/add-sheet）仍在 feishu-cli 主命令 sheet/bitable，
+  本 skill 专注 v1.23 新增高级能力。
+  当用户请求"筛选视图"、"加下拉框"、"数据验证"、"列下拉"时使用。
+argument-hint: filter-view create/list/delete | dropdown set
+user-invocable: true
+allowed-tools: Bash, Read
+---
+
+# 飞书电子表格高级能力（v1.23+）
+
+`feishu-cli sheet` 子命令组的 v1.23 新增高级能力——**筛选视图 CRUD** + **单元格下拉菜单**。两块此前是 `lark-cli` 独占的能力，现已补齐到 `feishu-cli`。
+
+> **范围划分**：基础读写（`sheet read` / `write` / `style` / `add-rows` / `add-sheet` 等）和 V3 富文本走主命令 `feishu-cli sheet` / `feishu-cli bitable`，本 skill **只覆盖 v1.23 新增的 filter-view + dropdown**。其他子命令查询 `feishu-cli sheet --help`。
+
+## 前置条件
+
+- **认证**：`sheets:spreadsheet` scope，User Token 或 App Token 均可。命令默认走 `resolveOptionalUserTokenWithFallback`：
+  - 已 `feishu-cli auth login` → 自动用 User Token
+  - 未登录或显式 `--user-access-token` 留空 → 落回 App Token（Bot 身份）
+- **token / sheet-id 来源**：电子表格 URL `https://xxx.feishu.cn/sheets/<token>?sheet=<sheet-id>` 中分别取。
+
+## 命令速查
+
+### 筛选视图 filter-view（V3 API，3 命令）
+
+```bash
+# create —— --name / --filter-view-id 可选，飞书侧自动生成
+feishu-cli sheet filter-view create \
+  --token shtcnxxxxxx --sheet-id 0b1212 \
+  --range "0b1212!A1:H14" --name "我的视图"
+
+# range 不带 sheetId 前缀时自动补全为 <sheet-id>!<range>
+feishu-cli sheet filter-view create --token shtcnxxxxxx --sheet-id 0b1212 --range "A1:H14"
+
+# list
+feishu-cli sheet filter-view list --token shtcnxxxxxx --sheet-id 0b1212
+feishu-cli sheet filter-view list --token shtcnxxxxxx --sheet-id 0b1212 -o json
+
+# delete
+feishu-cli sheet filter-view delete --token shtcnxxxxxx --sheet-id 0b1212 --filter-view-id pH9hbVcCXA
+```
+
+**关键参数**：
+
+| flag | 必填 | 说明 |
+|---|---|---|
+| `--token` | 是 | 电子表格 token（URL `/sheets/<token>`） |
+| `--sheet-id` | 是 | 工作表 ID（URL `?sheet=<sheet-id>`） |
+| `--range` | create 必填 | `"<sheetId>!A1:H14"`，不带 `!` 前缀自动补 |
+| `--name` | 否 | 视图名称 ≤ 100 字符 |
+| `--filter-view-id` | create/delete | create 时自定义 ID（10 位字母数字）；delete 时定位视图 |
+| `-o json` | 否 | 输出原始 JSON |
+| `--user-access-token` | 否 | 显式覆盖登录态 |
+
+底层调用：SDK `client.Sheets.SpreadsheetSheetFilterView.{Create, Query, Delete}`。
+
+### 下拉菜单 dropdown（V2 dataValidation API，1 命令）
+
+```bash
+# 简单选项（CSV 逗号分隔）
+feishu-cli sheet dropdown set --token shtcnxxxxxx --range "0b1212!A1:A100" \
+  --options "待办,处理中,已完成"
+
+# 多选 + 高亮（colors 数量需与 options 一致，自动开启 highlightValidData）
+feishu-cli sheet dropdown set --token shtcnxxxxxx --range "0b1212!B1:B100" \
+  --options "P0,P1,P2" --multiple --colors "#FF4D4F,#FAAD14,#52C41A"
+
+# 选项内含逗号 → 必须改用 --options-json（JSON 数组，绕过 CSV 解析）
+feishu-cli sheet dropdown set --token shtcnxxxxxx --range "0b1212!C1:C100" \
+  --options-json '["a, b","c"]'
+```
+
+**关键参数**：
+
+| flag | 必填 | 说明 |
+|---|---|---|
+| `--token` | 是 | 电子表格 token |
+| `--range` | 是 | **必须带 sheetId 前缀**，例如 `"0b1212!A1:A100"`（不带 `!` 直接报错） |
+| `--options` | 二选一 | CSV 逗号分隔，每项 ≤ 100 字符 |
+| `--options-json` | 二选一 | JSON 数组字符串，选项内含逗号时用 |
+| `--multiple` | 否 | 启用多选（默认单选） |
+| `--colors` | 否 | RGB hex CSV，长度与 options 一致；传值自动开启高亮 |
+
+底层调用：`POST /open-apis/sheets/v2/spreadsheets/{token}/dataValidation`，`dataValidationType: list`。
+
+## 典型工作流
+
+### 1. 任务表加状态下拉 + 优先级筛选视图
+
+```bash
+TOKEN=shtcnxxxxxx
+SHEET=0b1212
+
+# 状态列下拉（A 列）：待办 / 处理中 / 已完成
+feishu-cli sheet dropdown set --token $TOKEN --range "$SHEET!A2:A1000" \
+  --options "待办,处理中,已完成"
+
+# 优先级列下拉（B 列）+ 颜色高亮
+feishu-cli sheet dropdown set --token $TOKEN --range "$SHEET!B2:B1000" \
+  --options "P0,P1,P2" --colors "#FF4D4F,#FAAD14,#52C41A"
+
+# 创建"P0 高优"筛选视图
+feishu-cli sheet filter-view create --token $TOKEN --sheet-id $SHEET \
+  --range "$SHEET!A1:H1000" --name "P0 高优"
+# 在飞书 UI 里给该视图配置筛选条件（CLI 暂不支持写条件，只能创建空视图后 UI 配）
+```
+
+### 2. 清理工作表筛选视图
+
+```bash
+# list → 拿到 ID → 批量 delete
+feishu-cli sheet filter-view list --token $TOKEN --sheet-id $SHEET -o json | \
+  jq -r '.[].filter_view_id' | \
+  xargs -I{} feishu-cli sheet filter-view delete --token $TOKEN --sheet-id $SHEET --filter-view-id {}
+```
+
+## 踩坑
+
+- **`--options` / `--options-json` 互斥**：同时传会报错 `--options 和 --options-json 不能同时使用，请选其一`；含逗号的选项必走 `--options-json`，否则会被 CSV 切碎
+- **dropdown `--range` 必须带 `!` 前缀**：不带前缀直接报错（`--range 必须包含 sheetId 前缀`），不像 filter-view 会自动补
+- **`--colors` 长度必须 = options 长度**：例如 3 个选项就要 3 个颜色，少一个报错 `--colors 长度(X) 必须与选项数(Y) 一致`；传 colors 自动开启 `highlightValidData: true`
+- **dropdown 用英文逗号分隔 不是中文「，」**：`--options` CSV 解析器只识别 ASCII `,`，中文逗号会让多选项合并成一个，容易踩
+- **filter-view 只能创建空视图，无法 CLI 配条件**：飞书 V3 SDK 暂未暴露写筛选条件的接口，创建后需到飞书 Web UI 里手动配筛选；想用 CLI 写复杂条件请走 **`feishu-cli bitable view view-filter-set`**（多维表格而非电子表格）
+- **filter-view 范围 v.s. 单元格写入限制**：filter-view `--range` 仅圈定视图作用域，**不写入数据**；写入受 V3 单 cell ≤ 50000 字符 / 单批 ≤ 5000 cells / 10 ranges 限制（详见主 `feishu-cli sheet` 命令）
+- **`-o json` 仅 filter-view 支持**：dropdown set 只回吐成功摘要文本（API 本身只返回 code/msg）
+
+## 何时该转主命令
+
+| 需求 | 走哪 |
+|---|---|
+| 读单元格、整行整列、富文本 | `feishu-cli sheet read` / `read-rich` |
+| 写入数据、追加行 | `feishu-cli sheet write` / `append` / `add-rows` |
+| 单元格样式、合并、保护、查找替换 | `feishu-cli sheet style` / `merge` / `protect` / `find` / `replace` |
+| 工作表增删改、复制、导出 | `feishu-cli sheet add-sheet` / `copy-sheet` / `export` |
+| Markdown 表格批量导入 | `feishu-cli sheet import-md`（参考 `feishu-cli-toolkit`） |
+| 多维表格的视图过滤/排序/分组 | `feishu-cli bitable view view-*-set`（语义更强，能配条件） |
+
+## 权限要求
+
+- `sheets:spreadsheet`（读写均覆盖；User Token / App Token 均可）
+
+## 底层实现位置
+
+| 命令 | 客户端实现 | CLI 入口 |
+|---|---|---|
+| `filter-view create/list/delete` | `internal/client/sheets.go: CreateFilterView/ListFilterViews/DeleteFilterView` | `cmd/sheet_filter_view.go` |
+| `dropdown set` | `internal/client/sheets.go: SetDropdown` | `cmd/sheet_dropdown.go` |
+
+filter-view 走 SDK `larksheets.SpreadsheetSheetFilterView`；dropdown 走通用 HTTP（`v2APICallWithToken`）直调 V2 dataValidation 端点（SDK 未封装）。


### PR DESCRIPTION
## 背景

feishu-cli 现有 sheet read/write/style/filter/protect/merge 等，但缺少 lark-cli 独占的 **筛选视图 CRUD** 和 **下拉菜单**。本 PR 补齐这两类高频能力（MVP），后续 PR 再补 condition CRUD / float-image / batch-style。

## 新增命令

```bash
# 筛选视图 CRUD
feishu-cli sheet filter-view create --token xxx --sheet-id xxx --name "我的视图"
feishu-cli sheet filter-view list --token xxx --sheet-id xxx
feishu-cli sheet filter-view delete --token xxx --sheet-id xxx --filter-view-id fv_xxx

# 下拉菜单（数据验证）
feishu-cli sheet dropdown set --token xxx --range "Sheet1!A1:A100" --options "选项 1,选项 2,选项 3"
# 或用 JSON 兜底逗号选项
feishu-cli sheet dropdown set --token xxx --range xxx --options-json '["选项 A,B", "选项 C"]'
```

## 实现要点

- filter-view 走 SDK 内置 \`NewFilterViewBuilder\` + \`SpreadsheetSheetFilterView.{Create,Query,Delete}\`
- dropdown 走 V2 HTTP（\`v2APICallWithToken\`），因为 V2 \`dataValidation\` 没 SDK 包装
- \`--options\` CSV 与 \`--options-json\` JSON 兜底兼容（处理选项含逗号场景）
- 所有命令 \`resolveOptionalUserTokenWithFallback\`，与 \`sheet_filter\` 既有风格一致

## Scope

\`sheets:spreadsheet\` (user token)

## 边界（不在本 PR）

- filter-view condition CRUD
- dropdown {update, get, delete}
- float-image / batch-style

留作后续 PR。

## 测试

- \`go build ./...\` / \`go vet ./...\` 全绿
- \`go test ./cmd -run Sheet -count=1\` PASS