### PR TITLE
feat(markdown): Drive 原生 Markdown 文件 CRUD（与 doc import/export 互补）

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,41 @@
 
 ## 未发布
 
+### 新增 — `markdown {create,fetch,overwrite}`：Drive 原生 .md 文件 CRUD
+
+新增 `feishu-cli markdown` 顶层命令，把 Drive 上的 `.md` 当作普通文件整体读写，
+保留原始 Markdown 格式（**不做** Markdown ↔ 飞书 docx 块的转换）。
+
+**与 `doc import` / `doc export` 的区别**：
+
+| 命令 | 行为 | 创建出的文档类型 |
+|------|------|------------------|
+| `doc import/export` | Markdown ↔ 飞书 docx 块（标题/列表/表格/Callout…） | docx |
+| `markdown create/...` | 把 `.md` 整体上传/下载，不做转换 | file（普通 Drive 文件） |
+
+适合 AI agent 把生成的 Markdown 直接落盘到飞书 Drive、下次读回时仍是原汁原味
+Markdown 源码的场景。
+
+**子命令**：
+
+- `markdown create --name xxx.md --content "..." | --content-file path.md [--folder-token fldxxx]`
+  从字符串或本地文件创建 `.md`；强制 `.md` 后缀；空内容报错；底层走
+  `client.UploadFileWithToken`（≤ 20MB 单次上传，> 20MB 复用现成分片管线）。
+
+- `markdown fetch --file-token boxcnxxx [--output path | -]`
+  缺省 `--output` 时直接打印到 stdout（行为与 lark-cli `markdown +fetch` 一致）；
+  指定路径则落盘，目录会拼 `fileToken.md`，`--overwrite` 防误覆。
+
+- `markdown overwrite --file-token boxcnxxx --content "..." | --content-file path.md [--name renamed.md]`
+  覆盖现有 `.md` 的内容，`file_token` 保持不变；`--name` 可选改名。
+  **实现细节**：飞书 Go SDK v3.5.3 的 `UploadAllFileReqBody` 没有暴露 `file_token`
+  字段，因此本命令用 `client.Post` + `*larkcore.Formdata` 自己拼 multipart，
+  endpoint 仍是官方的 `POST /open-apis/drive/v1/files/upload_all`，参考 lark-cli
+  `shortcuts/markdown/helpers.go` 的写法。
+
+**权限**：User Access Token + `drive:file:upload` / `drive:file:download`
+（或 `drive:drive`）。
+
 ### 新增 — `comment reply add`：为已有评论添加回复
 
 新增命令 `feishu-cli comment reply add <file_token> <comment_id> --text "..."`，补齐评论回复

--- a/cmd/markdown.go
+++ b/cmd/markdown.go
@@ -1,0 +1,37 @@
+package cmd
+
+import (
+	"github.com/spf13/cobra"
+)
+
+// markdownCmd 是 Drive 原生 Markdown 文件 (.md) 的 CRUD 入口。
+// 注意：与 `doc import` / `doc export` 不同，本模块不做 Markdown ↔ 飞书文档块的转换，
+// 而是把 .md 当作一个普通的 Drive 文件（file_type=file）整体读写——
+// 保留原始 Markdown 格式，适合 AI agent 自动化场景。
+var markdownCmd = &cobra.Command{
+	Use:   "markdown",
+	Short: "Drive 原生 Markdown 文件（.md）的 CRUD",
+	Long: `Drive 原生 Markdown 文件（.md）的 CRUD。
+
+与 ` + "`doc import` / `doc export`" + ` 的区别：
+
+  doc import/export   — 把 Markdown 转换为飞书 docx 块（标题/列表/表格/Callout 等），创建的是 docx 类型文档
+  markdown create/...  — 把 .md 当作普通 Drive 文件整体读写，不做转换，保留原始 Markdown 格式
+
+适合场景：
+  - AI agent 把生成的 Markdown 文档存为 .md 文件，下次读回时仍是原汁原味的 Markdown
+  - 团队协作时希望保留 Markdown 源码（而不是飞书 docx 渲染）
+
+子命令:
+  create     创建 .md 文件（从字符串或本地文件）
+  fetch      读取 .md 文件内容
+  overwrite  覆盖现有 .md 文件
+
+权限要求:
+  - User Access Token（推荐，避免 owner 是 bot）
+  - drive:drive 或 drive:file:upload + drive:file.content:read`,
+}
+
+func init() {
+	rootCmd.AddCommand(markdownCmd)
+}

--- a/cmd/markdown_create.go
+++ b/cmd/markdown_create.go
@@ -1,0 +1,138 @@
+package cmd
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/riba2534/feishu-cli/internal/client"
+	"github.com/riba2534/feishu-cli/internal/config"
+	"github.com/spf13/cobra"
+)
+
+var markdownCreateCmd = &cobra.Command{
+	Use:   "create",
+	Short: "在 Drive 创建一个原生 Markdown (.md) 文件",
+	Long: `把一段 Markdown 内容（或本地 .md 文件）作为普通 Drive 文件上传，保留原始 Markdown 格式。
+
+底层调用 ` + "`/open-apis/drive/v1/files/upload_all`" + `（parent_type=explorer），与 ` + "`feishu-cli drive upload`" + ` 同一 endpoint，
+但本命令强制 .md 后缀、面向 AI agent 文档写盘场景。
+
+必填:
+  --name           远端文件名（必须以 .md 结尾），与 --content 搭配使用
+  --content        Markdown 字符串内容（或用 --content-file 指向本地文件）
+  --content-file   本地 .md 文件路径（与 --content 二选一）
+
+可选:
+  --folder-token        目标文件夹 token（默认 Drive 根目录）
+  --user-access-token   覆盖登录态
+
+权限:
+  - User Access Token
+  - drive:file:upload（或 drive:drive）
+
+示例:
+  feishu-cli markdown create --name plan.md --content "# Plan\n\n- todo 1"
+  feishu-cli markdown create --content-file ./local.md --folder-token fldxxx
+  feishu-cli markdown create --name draft.md --content-file ./tmp.md --folder-token fldxxx`,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		if err := config.Validate(); err != nil {
+			return err
+		}
+
+		token, err := requireUserToken(cmd, "markdown create")
+		if err != nil {
+			return err
+		}
+
+		name, _ := cmd.Flags().GetString("name")
+		content, _ := cmd.Flags().GetString("content")
+		contentFile, _ := cmd.Flags().GetString("content-file")
+		folderToken, _ := cmd.Flags().GetString("folder-token")
+		output, _ := cmd.Flags().GetString("output")
+
+		if content != "" && contentFile != "" {
+			return fmt.Errorf("--content 与 --content-file 不能同时使用")
+		}
+		if content == "" && contentFile == "" {
+			return fmt.Errorf("请提供 --content 或 --content-file")
+		}
+
+		// 解析最终文件名：优先 --name；否则若是 --content-file 用本地文件 basename。
+		fileName := strings.TrimSpace(name)
+		if fileName == "" && contentFile != "" {
+			fileName = filepath.Base(contentFile)
+		}
+		if fileName == "" {
+			return fmt.Errorf("--name 必填（使用 --content 时）")
+		}
+		if !strings.HasSuffix(strings.ToLower(fileName), ".md") {
+			return fmt.Errorf("--name 必须以 .md 结尾，得到 %q", fileName)
+		}
+
+		// 准备本地路径：--content 写临时 .md；--content-file 直接复用本地文件路径。
+		uploadPath := contentFile
+		var cleanup func()
+		if content != "" {
+			tmpFile, err := os.CreateTemp("", "feishu-md-*.md")
+			if err != nil {
+				return fmt.Errorf("创建临时文件失败: %w", err)
+			}
+			if _, err := tmpFile.WriteString(content); err != nil {
+				tmpFile.Close()
+				os.Remove(tmpFile.Name())
+				return fmt.Errorf("写入临时文件失败: %w", err)
+			}
+			if err := tmpFile.Close(); err != nil {
+				os.Remove(tmpFile.Name())
+				return fmt.Errorf("关闭临时文件失败: %w", err)
+			}
+			uploadPath = tmpFile.Name()
+			cleanup = func() { os.Remove(uploadPath) }
+			defer cleanup()
+		}
+
+		stat, err := os.Stat(uploadPath)
+		if err != nil {
+			return fmt.Errorf("读取本地文件失败: %w", err)
+		}
+		if stat.IsDir() {
+			return fmt.Errorf("--content-file 必须指向文件，不是目录")
+		}
+		if stat.Size() == 0 {
+			return fmt.Errorf("Markdown 内容为空，不支持创建空 .md 文件")
+		}
+
+		fileToken, err := client.UploadFileWithToken(uploadPath, folderToken, fileName, token)
+		if err != nil {
+			return err
+		}
+
+		result := map[string]any{
+			"file_token": fileToken,
+			"file_name":  fileName,
+			"size_bytes": stat.Size(),
+		}
+
+		if output == "json" {
+			return printJSON(result)
+		}
+
+		fmt.Printf("Markdown 文件创建成功!\n")
+		fmt.Printf("  file_name:  %s\n", fileName)
+		fmt.Printf("  file_token: %s\n", fileToken)
+		fmt.Printf("  size:       %d bytes\n", stat.Size())
+		return nil
+	},
+}
+
+func init() {
+	markdownCmd.AddCommand(markdownCreateCmd)
+	markdownCreateCmd.Flags().String("name", "", "远端文件名（必须 .md 结尾；--content 搭配时必填）")
+	markdownCreateCmd.Flags().String("content", "", "Markdown 字符串内容（与 --content-file 二选一）")
+	markdownCreateCmd.Flags().String("content-file", "", "本地 .md 文件路径（与 --content 二选一）")
+	markdownCreateCmd.Flags().String("folder-token", "", "目标文件夹 token（默认 Drive 根目录）")
+	markdownCreateCmd.Flags().StringP("output", "o", "", "输出格式（json）")
+	markdownCreateCmd.Flags().String("user-access-token", "", "User Access Token（覆盖登录态）")
+}

--- a/cmd/markdown_fetch.go
+++ b/cmd/markdown_fetch.go
@@ -80,12 +80,11 @@ var markdownFetchCmd = &cobra.Command{
 			return err
 		}
 
-		data, err := os.ReadFile(finalPath)
-		if err != nil {
-			return fmt.Errorf("读取下载文件失败: %w", err)
-		}
-
 		if printToStdout {
+			data, err := os.ReadFile(finalPath)
+			if err != nil {
+				return fmt.Errorf("读取下载文件失败: %w", err)
+			}
 			if outputFormat == "json" {
 				return printJSON(map[string]any{
 					"file_token": fileToken,

--- a/cmd/markdown_fetch.go
+++ b/cmd/markdown_fetch.go
@@ -1,0 +1,131 @@
+package cmd
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/riba2534/feishu-cli/internal/client"
+	"github.com/riba2534/feishu-cli/internal/config"
+	"github.com/spf13/cobra"
+)
+
+var markdownFetchCmd = &cobra.Command{
+	Use:   "fetch",
+	Short: "读取 Drive 中的原生 Markdown (.md) 文件内容",
+	Long: `下载一个 Drive 上的 .md 文件，按需要直接打印到 stdout 或保存到本地。
+
+底层走 ` + "`/open-apis/drive/v1/files/{file_token}/download`" + `（client.DownloadFileWithToken），
+与 ` + "`drive download`" + ` 同一 endpoint，但默认面向 .md 文本场景：未指定 --output 时直接打印为 UTF-8。
+
+必填:
+  --file-token   Markdown 文件 token
+
+可选:
+  --output       本地保存路径（缺省时打印到 stdout）
+  --overwrite    本地路径已存在时是否覆盖
+  --user-access-token  覆盖登录态
+
+权限:
+  - User Access Token
+  - drive:file:download（或 drive:drive）
+
+示例:
+  feishu-cli markdown fetch --file-token boxcnxxx                 # 打印到 stdout
+  feishu-cli markdown fetch --file-token boxcnxxx --output ./local.md
+  feishu-cli markdown fetch --file-token boxcnxxx --output ./local.md --overwrite`,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		if err := config.Validate(); err != nil {
+			return err
+		}
+
+		token, err := requireUserToken(cmd, "markdown fetch")
+		if err != nil {
+			return err
+		}
+
+		fileToken, _ := cmd.Flags().GetString("file-token")
+		outputPath, _ := cmd.Flags().GetString("output")
+		overwrite, _ := cmd.Flags().GetBool("overwrite")
+		outputFormat, _ := cmd.Flags().GetString("output-format")
+
+		if fileToken == "" {
+			return fmt.Errorf("--file-token 必填")
+		}
+
+		// 没传 --output → 落临时文件读完打印（保持与 lark-cli 行为一致：直接给字符串）。
+		printToStdout := outputPath == ""
+		finalPath := outputPath
+		var cleanup func()
+		if printToStdout {
+			tmp, err := os.CreateTemp("", "feishu-md-fetch-*.md")
+			if err != nil {
+				return fmt.Errorf("创建临时文件失败: %w", err)
+			}
+			tmp.Close()
+			finalPath = tmp.Name()
+			cleanup = func() { os.Remove(finalPath) }
+			defer cleanup()
+		} else {
+			// 路径是目录时，拼上文件名（用 fileToken.md 兜底）。
+			if stat, err := os.Stat(finalPath); err == nil && stat.IsDir() {
+				finalPath = filepath.Join(finalPath, fileToken+".md")
+			}
+			if _, err := os.Stat(finalPath); err == nil && !overwrite {
+				return fmt.Errorf("本地文件已存在: %s（使用 --overwrite 覆盖）", finalPath)
+			}
+		}
+
+		if err := client.DownloadFileWithToken(fileToken, finalPath, token); err != nil {
+			return err
+		}
+
+		data, err := os.ReadFile(finalPath)
+		if err != nil {
+			return fmt.Errorf("读取下载文件失败: %w", err)
+		}
+
+		if printToStdout {
+			if outputFormat == "json" {
+				return printJSON(map[string]any{
+					"file_token": fileToken,
+					"content":    string(data),
+					"size_bytes": len(data),
+				})
+			}
+			fmt.Print(string(data))
+			return nil
+		}
+
+		stat, _ := os.Stat(finalPath)
+		result := map[string]any{
+			"file_token": fileToken,
+			"saved_path": finalPath,
+			"size_bytes": int64(0),
+		}
+		if stat != nil {
+			result["size_bytes"] = stat.Size()
+		}
+
+		if outputFormat == "json" {
+			return printJSON(result)
+		}
+
+		fmt.Printf("Markdown 文件下载成功!\n")
+		fmt.Printf("  保存路径: %s\n", finalPath)
+		if stat != nil {
+			fmt.Printf("  大小:     %d bytes\n", stat.Size())
+		}
+		return nil
+	},
+}
+
+func init() {
+	markdownCmd.AddCommand(markdownFetchCmd)
+	markdownFetchCmd.Flags().String("file-token", "", "Markdown 文件 token（必填）")
+	markdownFetchCmd.Flags().String("output", "", "本地保存路径（缺省打印到 stdout）")
+	markdownFetchCmd.Flags().Bool("overwrite", false, "本地路径已存在时是否覆盖")
+	markdownFetchCmd.Flags().String("output-format", "", "输出格式（json）")
+	markdownFetchCmd.Flags().String("user-access-token", "", "User Access Token（覆盖登录态）")
+	mustMarkFlagRequired(markdownFetchCmd, "file-token")
+}

--- a/cmd/markdown_overwrite.go
+++ b/cmd/markdown_overwrite.go
@@ -1,0 +1,131 @@
+package cmd
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/riba2534/feishu-cli/internal/client"
+	"github.com/riba2534/feishu-cli/internal/config"
+	"github.com/spf13/cobra"
+)
+
+var markdownOverwriteCmd = &cobra.Command{
+	Use:   "overwrite",
+	Short: "覆盖 Drive 中已存在的 Markdown (.md) 文件",
+	Long: `把新的 Markdown 内容（字符串或本地文件）写到一个已存在的 .md 文件，file_token 保持不变。
+
+底层调 ` + "`POST /open-apis/drive/v1/files/upload_all`" + `，与 create 同一 endpoint，区别仅是多带 ` + "`file_token`" + ` 字段。
+飞书 Go SDK v3.5.3 的 ` + "`UploadAllFileReqBody`" + ` 没暴露 file_token，所以走自定义 multipart（见 internal/client/markdown.go）。
+
+必填:
+  --file-token     目标 .md 文件 token
+  --content        新 Markdown 内容（与 --content-file 二选一）
+  --content-file   本地 .md 文件路径（与 --content 二选一）
+
+可选:
+  --name           覆盖后修改文件名（必须 .md 结尾；缺省保留原名/用本地 basename）
+  --user-access-token  覆盖登录态
+
+权限:
+  - User Access Token，且对目标文件有编辑权限
+  - drive:file:upload + drive:drive.metadata:readonly
+
+示例:
+  feishu-cli markdown overwrite --file-token boxcnxxx --content "新内容"
+  feishu-cli markdown overwrite --file-token boxcnxxx --content-file ./new.md
+  feishu-cli markdown overwrite --file-token boxcnxxx --content-file ./new.md --name renamed.md`,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		if err := config.Validate(); err != nil {
+			return err
+		}
+
+		token, err := requireUserToken(cmd, "markdown overwrite")
+		if err != nil {
+			return err
+		}
+
+		fileToken, _ := cmd.Flags().GetString("file-token")
+		name, _ := cmd.Flags().GetString("name")
+		content, _ := cmd.Flags().GetString("content")
+		contentFile, _ := cmd.Flags().GetString("content-file")
+		output, _ := cmd.Flags().GetString("output")
+
+		if fileToken == "" {
+			return fmt.Errorf("--file-token 必填")
+		}
+		if content != "" && contentFile != "" {
+			return fmt.Errorf("--content 与 --content-file 不能同时使用")
+		}
+		if content == "" && contentFile == "" {
+			return fmt.Errorf("请提供 --content 或 --content-file")
+		}
+
+		// 确定新文件名：优先 --name；其次 --content-file basename；最后兜底 fileToken.md。
+		fileName := strings.TrimSpace(name)
+		if fileName == "" && contentFile != "" {
+			fileName = filepath.Base(contentFile)
+		}
+		if fileName == "" {
+			fileName = fileToken + ".md"
+		}
+		if !strings.HasSuffix(strings.ToLower(fileName), ".md") {
+			return fmt.Errorf("--name 必须以 .md 结尾，得到 %q", fileName)
+		}
+
+		// 准备字节内容：--content 走字符串；--content-file 读盘。
+		var payload []byte
+		if content != "" {
+			payload = []byte(content)
+		} else {
+			stat, err := os.Stat(contentFile)
+			if err != nil {
+				return fmt.Errorf("读取本地文件失败: %w", err)
+			}
+			if stat.IsDir() {
+				return fmt.Errorf("--content-file 必须指向文件，不是目录")
+			}
+			data, err := os.ReadFile(contentFile)
+			if err != nil {
+				return fmt.Errorf("读取本地文件失败: %w", err)
+			}
+			payload = data
+		}
+		if len(payload) == 0 {
+			return fmt.Errorf("Markdown 内容为空，不支持把 .md 覆盖为空文件")
+		}
+
+		returnedToken, err := client.OverwriteFileWithToken(fileToken, fileName, payload, token)
+		if err != nil {
+			return err
+		}
+
+		result := map[string]any{
+			"file_token": returnedToken,
+			"file_name":  fileName,
+			"size_bytes": len(payload),
+		}
+
+		if output == "json" {
+			return printJSON(result)
+		}
+
+		fmt.Printf("Markdown 文件覆盖成功!\n")
+		fmt.Printf("  file_name:  %s\n", fileName)
+		fmt.Printf("  file_token: %s\n", returnedToken)
+		fmt.Printf("  size:       %d bytes\n", len(payload))
+		return nil
+	},
+}
+
+func init() {
+	markdownCmd.AddCommand(markdownOverwriteCmd)
+	markdownOverwriteCmd.Flags().String("file-token", "", "目标 .md 文件 token（必填）")
+	markdownOverwriteCmd.Flags().String("name", "", "覆盖后修改文件名（必须 .md 结尾；缺省保留原名）")
+	markdownOverwriteCmd.Flags().String("content", "", "新 Markdown 内容（与 --content-file 二选一）")
+	markdownOverwriteCmd.Flags().String("content-file", "", "本地 .md 文件路径（与 --content 二选一）")
+	markdownOverwriteCmd.Flags().StringP("output", "o", "", "输出格式（json）")
+	markdownOverwriteCmd.Flags().String("user-access-token", "", "User Access Token（覆盖登录态）")
+	mustMarkFlagRequired(markdownOverwriteCmd, "file-token")
+}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -46,6 +46,7 @@ var rootCmd = &cobra.Command{
   minutes   妙记（基础信息、AI 产物、媒体下载；User Token）
   mail      邮箱（发送/回复/转发/草稿/查询；User Token）
   drive     云盘增强（分块上传、有界轮询导出/导入、富文本评论、通用 task-result）
+  markdown  Drive 原生 Markdown 文件 CRUD（.md 整体读写，不转换飞书 docx 块）
   search    搜索操作（消息、应用搜索，需要用户授权）
   config    配置管理（初始化配置）
 

--- a/internal/client/markdown.go
+++ b/internal/client/markdown.go
@@ -1,0 +1,99 @@
+package client
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+
+	larkcore "github.com/larksuite/oapi-sdk-go/v3/core"
+)
+
+// OverwriteFileWithToken 覆盖现有 Drive 文件（如 .md）的内容。
+//
+// 飞书 Open API `POST /open-apis/drive/v1/files/upload_all` 支持 `file_token` 参数：
+// 当 `file_token` 存在时，平台将上传的字节流写到该文件的新版本（保留 token、刷新 version、size）；
+// 当 `file_token` 缺省时，则按 `parent_type` + `parent_node` 在指定目录新建文件。
+//
+// 但飞书 SDK v3.5.3 的 `UploadAllFileReqBody` 没有暴露 `file_token` 字段（只有 file_name/parent_type/parent_node/size/checksum/file），
+// 所以这里直接用 `client.Post` + `*larkcore.Formdata` 自己拼 multipart——translator 检测到 `*Formdata` 会自动
+// 切到 FileUpload 多部分序列化路径（见 SDK core/reqtranslator.go:payload）。
+//
+// 参数：
+//   - fileToken：要覆盖的目标文件 token（必填）
+//   - fileName：写入后的文件名（必填；通常和原文件名一致，传别的名字会改名）
+//   - content：新文件字节内容
+//   - userAccessToken：User Access Token，为空时回退 Tenant Token
+//
+// 权限：drive:file:upload + drive:drive.metadata:readonly（用户身份必须对该文件有编辑权限）。
+//
+// 注意：本函数仅适合 ≤ 20MB 的小文件（API 单次上传上限）；大文件覆盖需要分片接口，本镜像未实现。
+func OverwriteFileWithToken(fileToken, fileName string, content []byte, userAccessToken string) (string, error) {
+	if fileToken == "" {
+		return "", fmt.Errorf("file_token 不能为空")
+	}
+	if fileName == "" {
+		return "", fmt.Errorf("file_name 不能为空")
+	}
+
+	cli, err := GetClient()
+	if err != nil {
+		return "", err
+	}
+
+	// 参考 lark-cli `shortcuts/markdown/helpers.go:uploadMarkdownFileAll`：
+	// 覆盖与新建同一 endpoint，区别仅是多带一个 `file_token` 字段；parent_type 仍是 explorer。
+	fd := larkcore.NewFormdata().
+		AddField("file_name", fileName).
+		AddField("parent_type", "explorer").
+		AddField("file_token", fileToken).
+		AddField("size", fmt.Sprintf("%d", len(content))).
+		AddFile("file", bytes.NewReader(content))
+
+	tokenType, opts := resolveTokenOpts(userAccessToken)
+	resp, err := cli.Post(ContextWithTimeout(downloadTimeout), "/open-apis/drive/v1/files/upload_all", fd, tokenType, opts...)
+	if err != nil {
+		return "", fmt.Errorf("覆盖文件失败: %w", err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("覆盖文件失败: HTTP %d, body: %s", resp.StatusCode, string(resp.RawBody))
+	}
+
+	var apiResp struct {
+		Code int    `json:"code"`
+		Msg  string `json:"msg"`
+		Data struct {
+			FileToken string `json:"file_token"`
+		} `json:"data"`
+	}
+	if err := json.Unmarshal(resp.RawBody, &apiResp); err != nil {
+		return "", fmt.Errorf("解析覆盖响应失败: %w", err)
+	}
+	if apiResp.Code != 0 {
+		return "", fmt.Errorf("覆盖文件失败: code=%d, msg=%s", apiResp.Code, apiResp.Msg)
+	}
+
+	returned := apiResp.Data.FileToken
+	if returned == "" {
+		returned = fileToken
+	}
+	return returned, nil
+}
+
+// OverwriteFileFromPathWithToken 把本地文件内容覆盖到远端 Drive 文件。
+// 仅适合 ≤ 20MB 的文件。
+func OverwriteFileFromPathWithToken(filePath, fileToken, fileName, userAccessToken string) (string, error) {
+	f, err := os.Open(filePath)
+	if err != nil {
+		return "", fmt.Errorf("打开本地文件失败: %w", err)
+	}
+	defer f.Close()
+
+	data, err := io.ReadAll(f)
+	if err != nil {
+		return "", fmt.Errorf("读取本地文件失败: %w", err)
+	}
+	return OverwriteFileWithToken(fileToken, fileName, data, userAccessToken)
+}

--- a/skills/feishu-cli-markdown/SKILL.md
+++ b/skills/feishu-cli-markdown/SKILL.md
@@ -1,0 +1,228 @@
+---
+name: feishu-cli-markdown
+description: >-
+  飞书云盘原生 Markdown 文件操作（与 doc import/export 互补）。
+  markdown create 上传新 .md 到云盘；markdown fetch 下载为本地 .md；
+  markdown overwrite 用本地 .md 覆盖云盘已有文件（保 file_token 不变，分享链接持久）。
+  当 doc 文档不适合（图床、密集代码块、版本管理）走 .md 原生文件路径。
+  Drive upload_all + 自拼 Formdata multipart（SDK 不暴露 file_token field）。
+  当用户请求"上传 markdown"、"下载 md"、"覆盖云盘 md"时使用。
+argument-hint: create | fetch | overwrite
+user-invocable: true
+allowed-tools: Bash, Read
+---
+
+# 飞书云盘原生 Markdown（markdown create/fetch/overwrite）
+
+`markdown` 命令组把 Drive 上的 **`.md` 当作普通文件整体读写**，保留原始 Markdown 源码，**不做** Markdown ↔ 飞书 docx 块的转换。
+
+> **feishu-cli**：如尚未安装，请前往 [riba2534/feishu-cli](https://github.com/riba2534/feishu-cli) 获取安装方式。
+
+## 核心概念：与 `doc import` / `doc export` 的区别
+
+| 命令 | 行为 | 创建出的类型 | 适用场景 |
+|------|------|------------|---------|
+| `doc import` | Markdown → 飞书 docx 块（标题/列表/表格/Callout/Mermaid 画板…） | docx（在线协同文档） | 给人读、要排版、要团队评论 |
+| `doc export` | docx → Markdown（块解析回 markdown 源码） | 本地 `.md` | 从飞书 docx 落盘到 Git |
+| `markdown create/fetch/overwrite` | 把 `.md` 整体上传/下载，**不转换** | file（Drive 普通文件） | AI agent 直接落盘原汁原味 `.md`、保留 fenced code block 缩进、当图床/密集代码块/版本管理用 |
+
+**判断走哪条**：
+
+- 想要飞书 docx 渲染（人读、排版、表格分块、画板渲染）→ `doc import`
+- 想要原始 `.md` 文本 unchanged 保留在云盘（AI agent 读回完全一致；docx 块解析有损）→ `markdown create`
+- 想反复覆盖同一份 `.md`、保持 file_token 不变（分享链接持久）→ `markdown overwrite`
+
+## 前置条件
+
+- **认证**：所有 `markdown` 命令默认走 **User Access Token**（执行 `feishu-cli auth login` 登录）
+- **预检**：`feishu-cli auth check --scope "drive:file:upload drive:file:download"`
+
+## 命令速查
+
+### 1. `markdown create` — 上传新 .md 到云盘
+
+```bash
+# 从字符串内容创建
+feishu-cli markdown create --name plan.md --content "# Plan\n\n- todo 1"
+
+# 从本地文件创建（--name 缺省时取本地 basename）
+feishu-cli markdown create --content-file ./local.md
+
+# 指定目标文件夹
+feishu-cli markdown create --name draft.md --content-file ./tmp.md --folder-token fldxxx
+
+# JSON 输出（拿 file_token 给后续步骤）
+feishu-cli markdown create --name plan.md --content-file ./plan.md -o json
+```
+
+**关键 flag**：
+
+| flag | 说明 |
+|------|------|
+| `--name` | 远端文件名，**必须 `.md` 结尾**（`--content` 时必填；`--content-file` 时可省，取本地 basename） |
+| `--content` | 字符串内容（与 `--content-file` 二选一） |
+| `--content-file` | 本地 `.md` 文件路径 |
+| `--folder-token` | 目标文件夹（缺省 Drive 根目录） |
+| `-o json` | JSON 输出（含 `file_token` / `file_name` / `size_bytes`） |
+| `--user-access-token` | 覆盖登录态 |
+
+**校验**：空内容直接报错（不允许创建空 `.md`）。
+
+### 2. `markdown fetch` — 下载云盘 .md
+
+```bash
+# 打印到 stdout（缺省 --output 时，行为与 lark-cli markdown +fetch 一致）
+feishu-cli markdown fetch --file-token boxcnxxx
+
+# 落盘到本地路径
+feishu-cli markdown fetch --file-token boxcnxxx --output ./local.md
+
+# 路径已存在时强制覆盖
+feishu-cli markdown fetch --file-token boxcnxxx --output ./local.md --overwrite
+
+# JSON 输出（含 content 字符串）
+feishu-cli markdown fetch --file-token boxcnxxx --output-format json
+```
+
+**关键 flag**：
+
+| flag | 说明 |
+|------|------|
+| `--file-token` | Markdown 文件 token（必填） |
+| `--output` | 本地保存路径；**目录时拼 `<fileToken>.md`**；缺省打印 stdout |
+| `--overwrite` | 本地文件已存在时覆盖（缺省直接报错） |
+| `--output-format json` | JSON 输出（区别于 `--output` 写盘路径，注意不要混淆） |
+
+### 3. `markdown overwrite` — 覆盖已有 .md（保 file_token）
+
+```bash
+# 字符串覆盖
+feishu-cli markdown overwrite --file-token boxcnxxx --content "新内容"
+
+# 本地文件覆盖
+feishu-cli markdown overwrite --file-token boxcnxxx --content-file ./new.md
+
+# 覆盖 + 改名（必须 .md 结尾）
+feishu-cli markdown overwrite --file-token boxcnxxx --content-file ./new.md --name renamed.md
+```
+
+**关键 flag**：
+
+| flag | 说明 |
+|------|------|
+| `--file-token` | 目标文件 token（必填） |
+| `--content` / `--content-file` | 新内容（二选一） |
+| `--name` | 覆盖后改名（`.md` 结尾；缺省保留原名 / 用本地 basename / 兜底 `<fileToken>.md`） |
+| `-o json` | JSON 输出 |
+
+**核心价值**：`file_token` 保持不变 → 分享链接持久、其他人收藏的链接不失效；多次迭代场景（AI agent 每天更新同一份 `.md`）优于"删了重建"。
+
+## 底层实现 & 踩坑
+
+### 1. SDK 不暴露 `file_token` field —— 自拼 multipart
+
+飞书 Go SDK v3.5.3 的 `UploadAllFileReqBody` 只暴露 `file_name` / `parent_type` / `parent_node` / `size` / `checksum` / `file`，**没有 `file_token`** 字段。
+
+但官方 API `POST /open-apis/drive/v1/files/upload_all` 是支持 `file_token` 的：**带 `file_token` 时覆盖原文件保留 token、刷新 version/size；不带时按 `parent_type+parent_node` 在指定目录新建**。
+
+为绕开 SDK 限制，`internal/client/markdown.go:OverwriteFileWithToken` 用 `client.Post` + `*larkcore.Formdata` 自己拼 multipart（translator 检测到 `*Formdata` 会自动切到 FileUpload 多部分序列化路径，见 SDK `core/reqtranslator.go:payload`）。endpoint 仍是官方 `upload_all`，参考 lark-cli `shortcuts/markdown/helpers.go:uploadMarkdownFileAll` 的写法。
+
+### 2. 文件大小上限 ≤ 20MB
+
+`upload_all` 单次上传 API 上限 **20MB**，本命令组只走单次上传路径：
+
+- `markdown create` 调 `client.UploadFileWithToken`（> 20MB 时该函数会自动切到分片管线，但 `markdown create` 主场景是文本 `.md` 远小于 20MB）
+- `markdown overwrite` **只支持 ≤ 20MB 小文件**，大文件覆盖需要分片接口，本命令组未实现。如果是几十 MB 的 `.md`（罕见，比如海量日志贴）走 `drive upload` 分片管线创建新文件，无法保留原 file_token。
+
+### 3. `.md` 后缀强制校验
+
+`--name`（create）和 `--name`（overwrite）都强制 **`.md` 结尾**（lowercase 检查后缀），非 `.md` 直接报错。如果想存 `.markdown` / `.mdx` 走 `drive upload` 老路径。
+
+### 4. 空内容直接报错
+
+`--content ""` / 空 `--content-file` 都被拒绝（"Markdown 内容为空，不支持创建/覆盖为空文件"）。需要"清空"语义的话走 `markdown overwrite --content " "` 写一个占位空格。
+
+### 5. `--output` 在 fetch 里有两个语义
+
+`markdown fetch` 同时有 `--output`（本地保存路径）和 `--output-format json`（输出格式），命名容易混淆：
+
+- `--output ./x.md` → 落盘到 `./x.md`
+- `--output-format json` → 把 `{file_token, content, size_bytes}` 打到 stdout
+- 两者可叠加：落盘 + 同时 stdout JSON 摘要
+
+### 6. `--output` 是目录时的兜底文件名
+
+`markdown fetch --output ./downloads/` 会拼成 `./downloads/<fileToken>.md`（不从响应头解析原文件名，与 `drive download` 行为一致）。要保留原文件名请自己加查询步骤再拼路径。
+
+## 何时转走 `doc import/export`
+
+- **要飞书 docx 渲染体验**（人读、表格分行、Mermaid 转画板、Callout 高亮）→ `doc import`（参 `feishu-cli-import` skill）
+- **要从飞书 docx 落盘到 Git 仓库**（块解析回 markdown）→ `doc export`（参 `feishu-cli-export` skill）
+- **要把 Markdown 转换前 sanity check**（Mermaid 花括号、表格 9×9 限制、Callout 6 种类型）→ `feishu-cli-doc-guide` skill
+
+## 何时转走 `drive upload`
+
+- **大文件 > 20MB**（罕见，但比如全量代码 dump、长 log）→ `feishu-cli drive upload --file xxx.md` 走分片，会创建新 file_token
+- **非 `.md` 扩展名**（`.mdx` / `.markdown` / `.txt`）→ `drive upload`
+
+## 权限要求
+
+| 命令 | 所需 scope |
+|------|------|
+| `markdown create` | `drive:file:upload`（或 `drive:drive`） |
+| `markdown fetch` | `drive:file:download`（或 `drive:drive`） |
+| `markdown overwrite` | `drive:file:upload` + `drive:drive.metadata:readonly`；且 User Token 对目标文件有编辑权限 |
+
+**推荐做法**：执行 `feishu-cli auth login` 登录后，由 `auth check --scope "drive:file:upload drive:file:download"` 预检；缺 scope 时按提示 `auth login` 补申请。
+
+## 典型工作流
+
+### 工作流 A：AI agent 每天迭代同一份 `.md`
+
+```bash
+# Day 1：创建一次拿到 file_token
+FT=$(feishu-cli markdown create --name daily-summary.md --content-file ./summary.md -o json | jq -r '.file_token')
+echo "$FT" > ~/.cache/daily-summary.token
+
+# Day 2+：覆盖（file_token 不变，分享链接持久）
+feishu-cli markdown overwrite --file-token "$(cat ~/.cache/daily-summary.token)" --content-file ./summary.md
+```
+
+### 工作流 B：从云盘 `.md` 落盘到本地
+
+```bash
+# 读回原汁原味 Markdown 源码
+feishu-cli markdown fetch --file-token boxcnxxx --output ./local.md --overwrite
+
+# 编辑后写回
+feishu-cli markdown overwrite --file-token boxcnxxx --content-file ./local.md
+```
+
+### 工作流 C：与 `doc import` 协作（先落盘 `.md` 再批量 import）
+
+```bash
+# 上游产出 .md 到云盘（保留源码备份）
+feishu-cli markdown create --name design.md --content-file ./design.md --folder-token fldxxx
+
+# 下游再走 doc import 生成飞书 docx 给团队阅读
+feishu-cli doc import ./design.md --title "设计稿" --upload-images
+```
+
+## 注意事项
+
+- **默认 User Access Token**：所有 `markdown` 命令未登录时统一提示 `feishu-cli auth login`
+- **不做 Markdown 转换**：本命令组保留 `.md` 字节流不变，**不**做飞书 docx 块转换，**不**触发图床、画板渲染、Callout 等增强逻辑——需要这些走 `doc import`
+- **强制 `.md` 后缀**：`create --name` 和 `overwrite --name` 都校验 `.md` 结尾
+- **`upload_all` 单次 ≤ 20MB**：大文件覆盖暂不支持
+- **空内容拒绝**：要清空走 `overwrite --content " "`
+- **`fetch --output` 双语义**：路径 vs 格式分别走 `--output` 和 `--output-format`，不要混淆
+
+## 与老命令的对照
+
+| 老命令 | 新 markdown 命令 | 差异 |
+|---|---|---|
+| `drive upload --file x.md` | `markdown create --content-file x.md` | markdown 强制 `.md` 后缀 + 空内容校验 + AI agent 友好 |
+| `drive download --file-token xxx` | `markdown fetch --file-token xxx` | markdown 默认打印 stdout（文本场景）+ 目录路径自动拼 `.md` |
+| 无 | `markdown overwrite` | 老命令没有覆盖语义（只能"删了重建"，file_token 变化） |
+
+**老 `drive upload/download` 仍然可用**（二进制、非 `.md` 走老路径），新能力集中在 `markdown overwrite`（保 file_token 覆盖）。


### PR DESCRIPTION
## 背景

feishu-cli 现有 \`doc import\` / \`doc export\` 做 Markdown ↔ 飞书 docx 块的**双向转换**（标题/列表/表格/Callout/Mermaid 等都转飞书块）。

但有一类场景：AI agent 生成 Markdown 文档想存为 \`.md\` 文件，下次读回时仍是**原汁原味**的 Markdown（不被转成 docx 块），就需要 Drive 原生 \`.md\` 文件 CRUD。

本 PR 补齐 \`feishu-cli markdown\` 模块，对齐 lark-cli \`markdown +create / +fetch / +overwrite\` 行为。

## 关键区别 vs \`doc import/export\`

| 模块 | 用途 | 飞书内部类型 |
|---|---|---|
| \`doc import/export\` | Markdown ↔ 飞书 docx 块双向转换（核心能力） | docx 文档 |
| \`markdown create/fetch/overwrite\` | Markdown 整文件 CRUD（保留原始 .md） | 普通 Drive 文件（.md） |

## 新增命令

```bash
# 创建 .md 文件（从字符串或本地文件）
feishu-cli markdown create --name notes.md --content "# Hello" [--folder-token xxx]
feishu-cli markdown create --name notes.md --content-file ./local.md

# 读取 .md（默认 stdout）
feishu-cli markdown fetch --file-token boxn_xxx [--output local.md]

# 覆盖 .md
feishu-cli markdown overwrite --file-token boxn_xxx --content "..."
feishu-cli markdown overwrite --file-token boxn_xxx --content-file ./new.md
```

## 实现要点

- create 走现成的 \`client.UploadFileWithToken\`（SDK 路径），≤ 20MB 单次上传 / > 20MB 复用现成分片管线
- fetch 走 \`client.DownloadFileWithToken\`（SDK 路径），endpoint \`/drive/v1/files/{token}/download\`
- **overwrite 无法用 SDK**：v3.5.3 的 \`UploadAllFileReqBody\` 只暴露 file_name/parent_type/parent_node/size/checksum/file，没有 \`file_token\` 字段。改用 \`client.Post\` + \`*larkcore.Formdata\` 自拼 multipart（SDK translator 检测到 \`*Formdata\` 会自动设 FileUpload=true 走多部分序列化）。参考 lark-cli shortcuts/markdown/helpers.go:291-320
- 踩坑修正：第一版误用 \`parent_type=explorer_file_version\`，对照 lark-cli 后修为 \`parent_type=explorer\`，与 create 同 endpoint 同 parent_type，唯一差别是 overwrite 多带 \`file_token\`
- 强制 \`.md\` 后缀；空内容报错

## Scope

\`drive:drive\` 或 \`drive:file:upload + drive:file.content:read\` (user token)

## 测试

- \`go build ./...\` / \`go vet ./...\` 全绿
- \`go test ./cmd -run "Markdown"\` 通过