### PR TITLE
feat(profile): 多 App 配置管理（add/list/use/current/rename/remove/migrate）

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,67 @@
 
 ## 未发布
 
+### 新增 — `profile`：多配置（profile）管理
+
+新增 `feishu-cli profile` 顶层命令，让一台机器在多个飞书账号 / 应用之间快速切换。
+解决长期痛点：原 `~/.feishu-cli/{config.yaml,token.json}` 单实例布局，切账号必须手动备份/恢复
+或者来回 `mv`，对同时需要 work / personal、或者 feishu.cn / larksuite.com 双端的用户极不友好。
+
+**子命令**：
+
+- `profile add <name> [--app-id ... --app-secret ... --base-url ... --use]` 新建 profile
+- `profile list` (alias `ls`) 列出所有 profile，标注 active 列；`--json` 适合脚本/AI Agent
+- `profile use <name>` (alias `switch`/`checkout`) 切换 active；`use -` 切回上一个
+- `profile current` 显示当前 active profile 名 + 目录
+- `profile rename <old> <new>` (alias `mv`) 重命名，自动同步指针
+- `profile remove <name>` (alias `rm`/`delete`) 删除 profile；`--force` 跳过二次确认
+- `profile migrate [--name default] [--force]` 把旧布局 `~/.feishu-cli/{config,token}.json` 拷到 `profiles/<name>/`（原文件保留，让用户确认无误后手动清理）
+
+**目录布局**：
+
+```
+~/.feishu-cli/
+  config.yaml                # 旧布局，profile 系统未启用时仍读这里（无感升级）
+  token.json
+  active-profile             # 一行文本：当前 profile 名
+  previous-profile           # 一行文本：上一个 profile 名（支持 use -）
+  profiles/
+    work/
+      config.yaml
+      token.json
+      user_profile.json
+    personal/
+      ...
+```
+
+**向后兼容设计**：
+
+- 没有任何 profile 时，`internal/config` 和 `internal/auth` 仍走旧路径，老用户零感知升级
+- `profile add` **不会** 自动迁移旧文件——避免静默丢数据；要迁就显式 `profile migrate`
+- `FEISHU_PROFILE=<name>` 环境变量临时覆盖（不写指针文件），适合 CI / 一次性切换
+
+**安全**：
+
+- profile 名仅允许 `[A-Za-z0-9_-]{1,64}`，禁止 `.`/`..`/路径分隔符等注入字符
+- 保留名 `profiles` / `cache` 不可作为 profile 名
+- 写入操作通过进程内 mutex 串行化；指针文件原子写（`.tmp` + rename）
+- 所有 profile 目录默认 `0700` 权限，含 token.json 等敏感文件
+
+**测试**：`internal/profile/store_test.go` 21 个测试，全部用 `t.TempDir()` 隔离，覆盖
+ValidateName / List 字典序 / Create / Remove / Rename / Use 含 `-` 切换 / `MigrateLegacy`
+含 `--force` 覆盖 / `FEISHU_PROFILE` 环境变量优先级 / `ActiveDir` 新旧布局切换。
+
+**示例**：
+
+```bash
+# 从旧布局开始（已有 config.yaml 和 token.json）
+feishu-cli profile migrate                              # → profiles/default/，指针指 default
+feishu-cli profile add personal --use --app-id cli_yyy  # 新建 personal 并切过去
+feishu-cli profile list                                 # 看哪个 active
+feishu-cli profile use -                                # 切回 default
+FEISHU_PROFILE=personal feishu-cli msg send ...         # 一次性临时切换
+```
+
 ### 新增 — `comment reply add`：为已有评论添加回复
 
 新增命令 `feishu-cli comment reply add <file_token> <comment_id> --text "..."`，补齐评论回复

--- a/cmd/profile.go
+++ b/cmd/profile.go
@@ -1,0 +1,46 @@
+package cmd
+
+import (
+	"github.com/spf13/cobra"
+)
+
+// profileCmd 是 profile 多配置管理的顶层命令。
+// 子命令：add / list / remove / rename / use / migrate / current
+var profileCmd = &cobra.Command{
+	Use:   "profile",
+	Short: "管理多个 profile（如 work / personal）",
+	Long: `管理 feishu-cli 多配置（profile），用于在多个飞书账号 / 应用之间快速切换。
+
+每个 profile 是 ~/.feishu-cli/profiles/<name>/ 下的一个独立目录，包含：
+  - config.yaml      profile 自己的 app_id / app_secret / base_url 等配置
+  - token.json       该 profile 的 User Access Token / Refresh Token
+  - user_profile.json 已登录用户信息缓存
+
+通过 ~/.feishu-cli/active-profile 指针文件指向"当前 profile"，
+所有 feishu-cli 命令（auth login / doc import / msg send 等）会自动
+从 active profile 读 config + token，不需要任何额外参数。
+
+向后兼容：
+  - 没有任何 profile 时（profiles/ 目录不存在），仍然走旧布局
+    ~/.feishu-cli/config.yaml 和 token.json，原有用户无感升级。
+  - 第一次执行 'profile add' 不会自动迁移旧文件——用 'profile migrate'
+    把现有 config.yaml + token.json 拷到 profiles/default/。
+
+环境变量：
+  FEISHU_PROFILE=<name>   临时强制使用指定 profile（不修改指针文件）
+
+示例:
+  feishu-cli profile add work --app-id cli_xxx --app-secret xxx --use
+  feishu-cli profile list
+  feishu-cli profile use personal
+  feishu-cli profile use -                # 切回上一个 profile
+  feishu-cli profile rename old new
+  feishu-cli profile remove temp --force
+  feishu-cli profile current
+  feishu-cli profile migrate              # 旧布局 → profiles/default/
+  FEISHU_PROFILE=work feishu-cli msg send ...`,
+}
+
+func init() {
+	rootCmd.AddCommand(profileCmd)
+}

--- a/cmd/profile_add.go
+++ b/cmd/profile_add.go
@@ -1,0 +1,76 @@
+package cmd
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/riba2534/feishu-cli/internal/profile"
+	"github.com/spf13/cobra"
+)
+
+var (
+	profileAddAppID     string
+	profileAddAppSecret string
+	profileAddBaseURL   string
+	profileAddUse       bool
+	profileAddJSON      bool
+)
+
+var profileAddCmd = &cobra.Command{
+	Use:   "add <name>",
+	Short: "新建一个 profile",
+	Long: `创建 ~/.feishu-cli/profiles/<name>/ 目录并写入初始 config.yaml。
+
+不会自动迁移旧布局（~/.feishu-cli/config.yaml），如需迁移请用
+'feishu-cli profile migrate'。
+
+示例:
+  feishu-cli profile add work --app-id cli_xxx --app-secret xxx --use
+  feishu-cli profile add personal --base-url https://open.larksuite.com
+  feishu-cli profile add temp                                 # 留空待手动填`,
+	Args: cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		name := args[0]
+
+		opts := profile.CreateOpts{
+			AppID:     profileAddAppID,
+			AppSecret: profileAddAppSecret,
+			BaseURL:   profileAddBaseURL,
+			SwitchTo:  profileAddUse,
+		}
+		if err := profile.Create(name, opts); err != nil {
+			return err
+		}
+
+		dir, err := profile.ProfileDir(name)
+		if err != nil {
+			return err
+		}
+
+		if profileAddJSON {
+			out := map[string]any{
+				"ok":     true,
+				"name":   name,
+				"dir":    dir,
+				"active": profileAddUse,
+			}
+			return json.NewEncoder(cmd.OutOrStdout()).Encode(out)
+		}
+		fmt.Fprintf(cmd.OutOrStdout(), "已创建 profile %q\n  目录: %s\n", name, dir)
+		if profileAddUse {
+			fmt.Fprintf(cmd.OutOrStdout(), "  已切换为当前 profile\n")
+		} else {
+			fmt.Fprintf(cmd.OutOrStdout(), "  下一步: feishu-cli profile use %s\n", name)
+		}
+		return nil
+	},
+}
+
+func init() {
+	profileAddCmd.Flags().StringVar(&profileAddAppID, "app-id", "", "飞书应用 app_id（可后续手动写 config.yaml）")
+	profileAddCmd.Flags().StringVar(&profileAddAppSecret, "app-secret", "", "飞书应用 app_secret")
+	profileAddCmd.Flags().StringVar(&profileAddBaseURL, "base-url", "", "飞书 OpenAPI base URL（默认 https://open.feishu.cn）")
+	profileAddCmd.Flags().BoolVar(&profileAddUse, "use", false, "创建后立即切换为当前 profile")
+	profileAddCmd.Flags().BoolVar(&profileAddJSON, "json", false, "JSON 输出（适合脚本/AI Agent）")
+	profileCmd.AddCommand(profileAddCmd)
+}

--- a/cmd/profile_list.go
+++ b/cmd/profile_list.go
@@ -1,0 +1,78 @@
+package cmd
+
+import (
+	"encoding/json"
+	"fmt"
+	"text/tabwriter"
+
+	"github.com/riba2534/feishu-cli/internal/profile"
+	"github.com/spf13/cobra"
+)
+
+var profileListJSON bool
+
+var profileListCmd = &cobra.Command{
+	Use:   "list",
+	Short: "列出所有 profile",
+	Long: `列出 ~/.feishu-cli/profiles/ 下所有 profile，并标注当前激活的 profile。
+
+示例:
+  feishu-cli profile list
+  feishu-cli profile list --json`,
+	Aliases: []string{"ls"},
+	RunE: func(cmd *cobra.Command, args []string) error {
+		infos, err := profile.Describe()
+		if err != nil {
+			return err
+		}
+		active, err := profile.ActiveName()
+		if err != nil {
+			return err
+		}
+
+		if profileListJSON {
+			out := map[string]any{
+				"active":   active,
+				"profiles": infos,
+			}
+			return json.NewEncoder(cmd.OutOrStdout()).Encode(out)
+		}
+
+		if len(infos) == 0 {
+			fmt.Fprintln(cmd.OutOrStdout(), "尚未创建任何 profile。")
+			fmt.Fprintln(cmd.OutOrStdout(), "提示: feishu-cli profile add <name>            # 新建")
+			fmt.Fprintln(cmd.OutOrStdout(), "      feishu-cli profile migrate                # 旧布局 → default profile")
+			return nil
+		}
+
+		w := tabwriter.NewWriter(cmd.OutOrStdout(), 0, 0, 2, ' ', 0)
+		fmt.Fprintln(w, "ACTIVE\tNAME\tCONFIG\tTOKEN\tPATH")
+		for _, info := range infos {
+			marker := " "
+			if info.Active {
+				marker = "*"
+			}
+			fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\n",
+				marker, info.Name, yesNo(info.HasConfig), yesNo(info.HasToken), info.Path)
+		}
+		if err := w.Flush(); err != nil {
+			return err
+		}
+		if active == "" {
+			fmt.Fprintln(cmd.OutOrStdout(), "\n当前无激活 profile（active-profile 指针缺失），首次使用会回退到字典序第一个。")
+		}
+		return nil
+	},
+}
+
+func yesNo(b bool) string {
+	if b {
+		return "yes"
+	}
+	return "no"
+}
+
+func init() {
+	profileListCmd.Flags().BoolVar(&profileListJSON, "json", false, "JSON 输出（适合脚本/AI Agent）")
+	profileCmd.AddCommand(profileListCmd)
+}

--- a/cmd/profile_remove.go
+++ b/cmd/profile_remove.go
@@ -1,0 +1,73 @@
+package cmd
+
+import (
+	"bufio"
+	"encoding/json"
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/riba2534/feishu-cli/internal/profile"
+	"github.com/spf13/cobra"
+)
+
+var (
+	profileRemoveForce bool
+	profileRemoveJSON  bool
+)
+
+var profileRemoveCmd = &cobra.Command{
+	Use:   "remove <name>",
+	Short: "删除一个 profile",
+	Long: `删除 ~/.feishu-cli/profiles/<name>/ 整个目录（含 config / token / 用户信息缓存）。
+
+默认会提示二次确认，加 --force 跳过提示。
+若删除的是当前激活 profile，active-profile 指针会被清空，下次访问回退到字典序第一个 profile。
+
+示例:
+  feishu-cli profile remove temp
+  feishu-cli profile remove old --force`,
+	Aliases: []string{"rm", "delete"},
+	Args:    cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		name := args[0]
+
+		// 二次确认（除非 --force 或非交互）
+		if !profileRemoveForce && isTerminal(os.Stdin) {
+			fmt.Fprintf(cmd.OutOrStdout(), "确认删除 profile %q？该操作不可恢复 [y/N]: ", name)
+			r := bufio.NewReader(os.Stdin)
+			answer, _ := r.ReadString('\n')
+			answer = strings.ToLower(strings.TrimSpace(answer))
+			if answer != "y" && answer != "yes" {
+				fmt.Fprintln(cmd.OutOrStdout(), "已取消")
+				return nil
+			}
+		}
+
+		if err := profile.Remove(name); err != nil {
+			return err
+		}
+
+		if profileRemoveJSON {
+			out := map[string]any{"ok": true, "removed": name}
+			return json.NewEncoder(cmd.OutOrStdout()).Encode(out)
+		}
+		fmt.Fprintf(cmd.OutOrStdout(), "已删除 profile %q\n", name)
+		return nil
+	},
+}
+
+// isTerminal 判断 fd 是否为 TTY。非 TTY（管道/重定向）下跳过交互。
+func isTerminal(f *os.File) bool {
+	info, err := f.Stat()
+	if err != nil {
+		return false
+	}
+	return (info.Mode() & os.ModeCharDevice) != 0
+}
+
+func init() {
+	profileRemoveCmd.Flags().BoolVarP(&profileRemoveForce, "force", "f", false, "跳过二次确认")
+	profileRemoveCmd.Flags().BoolVar(&profileRemoveJSON, "json", false, "JSON 输出")
+	profileCmd.AddCommand(profileRemoveCmd)
+}

--- a/cmd/profile_rename.go
+++ b/cmd/profile_rename.go
@@ -1,0 +1,50 @@
+package cmd
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/riba2534/feishu-cli/internal/profile"
+	"github.com/spf13/cobra"
+)
+
+var profileRenameJSON bool
+
+var profileRenameCmd = &cobra.Command{
+	Use:   "rename <old> <new>",
+	Short: "重命名一个 profile",
+	Long: `把 ~/.feishu-cli/profiles/<old>/ 重命名为 ~/.feishu-cli/profiles/<new>/。
+若被重命名的 profile 是当前激活的，active-profile 指针会自动更新到新名。
+
+示例:
+  feishu-cli profile rename work tt-work
+  feishu-cli profile rename personal lark`,
+	Aliases: []string{"mv"},
+	Args:    cobra.ExactArgs(2),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		oldName, newName := args[0], args[1]
+		if err := profile.Rename(oldName, newName); err != nil {
+			return err
+		}
+		dir, err := profile.ProfileDir(newName)
+		if err != nil {
+			return err
+		}
+		if profileRenameJSON {
+			out := map[string]any{
+				"ok":   true,
+				"old":  oldName,
+				"new":  newName,
+				"dir":  dir,
+			}
+			return json.NewEncoder(cmd.OutOrStdout()).Encode(out)
+		}
+		fmt.Fprintf(cmd.OutOrStdout(), "已重命名 profile %q → %q\n  新目录: %s\n", oldName, newName, dir)
+		return nil
+	},
+}
+
+func init() {
+	profileRenameCmd.Flags().BoolVar(&profileRenameJSON, "json", false, "JSON 输出")
+	profileCmd.AddCommand(profileRenameCmd)
+}

--- a/cmd/profile_use.go
+++ b/cmd/profile_use.go
@@ -1,0 +1,136 @@
+package cmd
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/riba2534/feishu-cli/internal/profile"
+	"github.com/spf13/cobra"
+)
+
+var profileUseJSON bool
+
+var profileUseCmd = &cobra.Command{
+	Use:   "use <name>",
+	Short: "切换当前 profile",
+	Long: `把 ~/.feishu-cli/active-profile 指针写为 <name>，后续所有 feishu-cli
+命令默认从该 profile 读 config + token。
+
+特殊参数 '-' 表示切回上一个 profile。
+
+示例:
+  feishu-cli profile use work
+  feishu-cli profile use -                # 切回上一个 profile`,
+	Aliases: []string{"switch", "checkout"},
+	Args:    cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		name := args[0]
+		previous, _ := profile.ReadActive()
+
+		newActive, err := profile.Use(name)
+		if err != nil {
+			return err
+		}
+
+		dir, err := profile.ProfileDir(newActive)
+		if err != nil {
+			return err
+		}
+
+		if profileUseJSON {
+			out := map[string]any{
+				"ok":       true,
+				"active":   newActive,
+				"previous": previous,
+				"dir":      dir,
+			}
+			return json.NewEncoder(cmd.OutOrStdout()).Encode(out)
+		}
+
+		if previous == newActive {
+			fmt.Fprintf(cmd.OutOrStdout(), "当前已是 profile %q，无需切换\n", newActive)
+			return nil
+		}
+		if previous == "" {
+			fmt.Fprintf(cmd.OutOrStdout(), "已切换到 profile %q\n  目录: %s\n", newActive, dir)
+		} else {
+			fmt.Fprintf(cmd.OutOrStdout(), "已切换 profile %q → %q\n  目录: %s\n", previous, newActive, dir)
+		}
+		return nil
+	},
+}
+
+var profileCurrentCmd = &cobra.Command{
+	Use:   "current",
+	Short: "显示当前激活的 profile",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		name, err := profile.ActiveName()
+		if err != nil {
+			return err
+		}
+		if name == "" {
+			fmt.Fprintln(cmd.OutOrStdout(), "(未启用 profile 系统，使用旧布局 ~/.feishu-cli/)")
+			return nil
+		}
+		dir, err := profile.ProfileDir(name)
+		if err != nil {
+			return err
+		}
+		fmt.Fprintf(cmd.OutOrStdout(), "%s\t%s\n", name, dir)
+		return nil
+	},
+}
+
+var (
+	profileMigrateTarget string
+	profileMigrateForce  bool
+	profileMigrateJSON   bool
+)
+
+var profileMigrateCmd = &cobra.Command{
+	Use:   "migrate",
+	Short: "把旧布局 ~/.feishu-cli/{config.yaml,token.json} 迁移到 profiles/<name>/",
+	Long: `把旧布局的配置和 token 迁移到一个新的 profile 目录，并把指针指向它。
+原文件不会被删除——用户自己确认无误后可手动 rm。
+
+示例:
+  feishu-cli profile migrate                          # → profiles/default/
+  feishu-cli profile migrate --name work              # → profiles/work/
+  feishu-cli profile migrate --force                  # 覆盖已存在的同名 profile`,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		target, err := profile.MigrateLegacy(profile.MigrateLegacyOpts{
+			TargetName: profileMigrateTarget,
+			Force:      profileMigrateForce,
+		})
+		if err != nil {
+			return err
+		}
+		dir, err := profile.ProfileDir(target)
+		if err != nil {
+			return err
+		}
+		if profileMigrateJSON {
+			out := map[string]any{
+				"ok":     true,
+				"target": target,
+				"dir":    dir,
+			}
+			return json.NewEncoder(cmd.OutOrStdout()).Encode(out)
+		}
+		fmt.Fprintf(cmd.OutOrStdout(), "已迁移旧布局到 profile %q\n  目录: %s\n", target, dir)
+		fmt.Fprintln(cmd.OutOrStdout(), "  原文件未删除，确认无误后可手动清理：")
+		fmt.Fprintln(cmd.OutOrStdout(), "    rm ~/.feishu-cli/config.yaml ~/.feishu-cli/token.json ~/.feishu-cli/user_profile.json")
+		return nil
+	},
+}
+
+func init() {
+	profileUseCmd.Flags().BoolVar(&profileUseJSON, "json", false, "JSON 输出")
+	profileCmd.AddCommand(profileUseCmd)
+	profileCmd.AddCommand(profileCurrentCmd)
+
+	profileMigrateCmd.Flags().StringVar(&profileMigrateTarget, "name", "default", "迁移目标 profile 名")
+	profileMigrateCmd.Flags().BoolVar(&profileMigrateForce, "force", false, "目标 profile 已存在时覆盖")
+	profileMigrateCmd.Flags().BoolVar(&profileMigrateJSON, "json", false, "JSON 输出")
+	profileCmd.AddCommand(profileMigrateCmd)
+}

--- a/internal/auth/token.go
+++ b/internal/auth/token.go
@@ -6,6 +6,8 @@ import (
 	"os"
 	"path/filepath"
 	"time"
+
+	"github.com/riba2534/feishu-cli/internal/profile"
 )
 
 // TokenStore 存储 OAuth token 信息
@@ -21,15 +23,17 @@ type TokenStore struct {
 // tokenPathFunc 可在测试中替换的路径函数
 var tokenPathFunc = originalTokenPath
 
+// originalTokenPath 返回当前激活 profile 的 token.json 路径。
+// 未启用 profile 系统时回退到旧布局 ~/.feishu-cli/token.json，保持向后兼容。
 func originalTokenPath() (string, error) {
-	home, err := os.UserHomeDir()
+	dir, err := profile.ActiveDir()
 	if err != nil {
-		return "", fmt.Errorf("获取用户目录失败: %w", err)
+		return "", fmt.Errorf("解析当前 profile 失败: %w", err)
 	}
-	return filepath.Join(home, ".feishu-cli", "token.json"), nil
+	return filepath.Join(dir, "token.json"), nil
 }
 
-// TokenPath 返回 token 文件路径 (~/.feishu-cli/token.json)
+// TokenPath 返回 token 文件路径（当前激活 profile 下的 token.json）。
 func TokenPath() (string, error) {
 	return tokenPathFunc()
 }

--- a/internal/auth/user_cache.go
+++ b/internal/auth/user_cache.go
@@ -8,6 +8,8 @@ import (
 	"os"
 	"path/filepath"
 	"time"
+
+	"github.com/riba2534/feishu-cli/internal/profile"
 )
 
 // CurrentUserCache stores the current logged-in user's profile metadata.
@@ -26,11 +28,11 @@ type CurrentUserCache struct {
 var userCachePathFunc = originalUserCachePath
 
 func originalUserCachePath() (string, error) {
-	home, err := os.UserHomeDir()
+	path, err := profile.UserCacheFilePath()
 	if err != nil {
-		return "", fmt.Errorf("获取用户目录失败: %w", err)
+		return "", fmt.Errorf("解析当前 profile 失败: %w", err)
 	}
-	return filepath.Join(home, ".feishu-cli", "user_profile.json"), nil
+	return path, nil
 }
 
 // UserCachePath returns the current user cache path (~/.feishu-cli/user_profile.json).

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -122,13 +122,26 @@ func Validate() error {
 	if cfg == nil {
 		return fmt.Errorf("配置未初始化")
 	}
+	cfgPath := activeConfigPathForError()
 	if cfg.AppID == "" {
-		return fmt.Errorf("缺少 app_id，请通过以下方式之一设置:\n  1. 环境变量: export FEISHU_APP_ID=xxx\n  2. 配置文件: ~/.feishu-cli/config.yaml")
+		return fmt.Errorf("缺少 app_id，请通过以下方式之一设置:\n  1. 环境变量: export FEISHU_APP_ID=xxx\n  2. 配置文件: %s", cfgPath)
 	}
 	if cfg.AppSecret == "" {
-		return fmt.Errorf("缺少 app_secret，请通过以下方式之一设置:\n  1. 环境变量: export FEISHU_APP_SECRET=xxx\n  2. 配置文件: ~/.feishu-cli/config.yaml")
+		return fmt.Errorf("缺少 app_secret，请通过以下方式之一设置:\n  1. 环境变量: export FEISHU_APP_SECRET=xxx\n  2. 配置文件: %s", cfgPath)
 	}
 	return nil
+}
+
+// activeConfigPathForError 返回当前 profile 的 config.yaml 路径（用于错误提示）。
+// 解析失败时回退到旧布局占位符，避免 Validate 报错叠加二次错误。
+func activeConfigPathForError() string {
+	if path, err := profile.ConfigFilePath(); err == nil && path != "" {
+		return path
+	}
+	if root, err := profile.RootDir(); err == nil && root != "" {
+		return filepath.Join(root, "config.yaml")
+	}
+	return "~/.feishu-cli/config.yaml"
 }
 
 // CreateDefaultConfig creates a default configuration file in the active profile

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -6,6 +6,7 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/riba2534/feishu-cli/internal/profile"
 	"github.com/spf13/viper"
 )
 
@@ -37,18 +38,22 @@ var cfg *Config
 
 // Init initializes the configuration from file and environment
 // 配置优先级: 环境变量 > 配置文件 > 默认值
+//
+// 配置文件路径解析顺序：
+//  1. --config <path> 显式指定
+//  2. ${FEISHU_PROFILE}/${active-profile} 指向的 profile 目录下的 config.yaml
+//  3. 旧布局 ~/.feishu-cli/config.yaml（向后兼容，profile 系统未启用时）
 func Init(cfgFile string) error {
 	// 1. 设置配置文件路径
 	if cfgFile != "" {
 		viper.SetConfigFile(cfgFile)
 	} else {
-		home, err := os.UserHomeDir()
+		// 优先走 profile 系统，profile 未启用时回退到旧布局
+		dir, err := profile.ActiveDir()
 		if err != nil {
-			return fmt.Errorf("获取用户目录失败: %w", err)
+			return fmt.Errorf("解析当前 profile 失败: %w", err)
 		}
-
-		configDir := filepath.Join(home, ".feishu-cli")
-		viper.AddConfigPath(configDir)
+		viper.AddConfigPath(dir)
 		viper.AddConfigPath(".")
 		viper.SetConfigName("config")
 		viper.SetConfigType("yaml")
@@ -126,14 +131,13 @@ func Validate() error {
 	return nil
 }
 
-// CreateDefaultConfig creates a default configuration file
+// CreateDefaultConfig creates a default configuration file in the active profile
+// directory (legacy ~/.feishu-cli/ when profile system not initialized).
 func CreateDefaultConfig() error {
-	home, err := os.UserHomeDir()
+	configDir, err := profile.ActiveDir()
 	if err != nil {
-		return fmt.Errorf("获取用户目录失败: %w", err)
+		return fmt.Errorf("获取配置目录失败: %w", err)
 	}
-
-	configDir := filepath.Join(home, ".feishu-cli")
 	// 使用 0700 权限，仅所有者可访问，保护敏感配置
 	if err := os.MkdirAll(configDir, 0700); err != nil {
 		return fmt.Errorf("创建配置目录失败: %w", err)

--- a/internal/profile/store.go
+++ b/internal/profile/store.go
@@ -1,0 +1,740 @@
+// Package profile 管理 feishu-cli 的多配置（profile）目录。
+//
+// 目录布局：
+//
+//	~/.feishu-cli/
+//	  config.yaml           # 旧布局（无 profile 系统时）
+//	  token.json            # 旧布局
+//	  active-profile        # 指针文件，纯文本，内容为当前 profile 名
+//	  profiles/
+//	    work/
+//	      config.yaml
+//	      token.json
+//	      user_profile.json
+//	    personal/
+//	      config.yaml
+//	      ...
+//
+// 解析优先级（由 ActiveDir 返回）：
+//  1. 环境变量 FEISHU_PROFILE=<name>（强制覆盖，profile 必须存在）
+//  2. ~/.feishu-cli/active-profile 指针指向的 profile
+//  3. 无 profile 系统时，返回旧布局 ~/.feishu-cli/
+//
+// 设计要点：
+//   - 向后兼容：旧用户的 ~/.feishu-cli/config.yaml + token.json 仍然能读，
+//     一旦执行 `profile add` 才会创建 profiles/ 目录并迁移旧布局到默认 profile。
+//   - 写操作（创建/重命名/删除/切换）通过 flock 串行化，避免并发写损坏。
+//   - 名称合法字符：[A-Za-z0-9_-]，长度 1-64，禁止 "." ".." 等路径注入。
+package profile
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"strings"
+	"sync"
+)
+
+const (
+	// EnvVar 环境变量名，设置后强制使用指定 profile。
+	EnvVar = "FEISHU_PROFILE"
+
+	// activePointerName 指针文件名，记录当前 profile。
+	activePointerName = "active-profile"
+
+	// previousPointerName 记录上一个 profile，支持 `profile use -` 切换回上一个。
+	previousPointerName = "previous-profile"
+
+	// profilesDirName profile 子目录名。
+	profilesDirName = "profiles"
+
+	// lockFileName 写操作锁文件名。
+	lockFileName = ".profile.lock"
+
+	// 单 profile 目录下的内容文件名（与旧布局保持一致）。
+	configFileName = "config.yaml"
+	tokenFileName  = "token.json"
+	userCacheName  = "user_profile.json"
+
+	// MaxNameLen profile 名最大长度。
+	MaxNameLen = 64
+)
+
+// nameRegex 合法 profile 名：字母数字/下划线/连字符，1-64 字符。
+var nameRegex = regexp.MustCompile(`^[A-Za-z0-9_-]{1,64}$`)
+
+// 进程内锁，用于 active-profile / previous-profile 指针文件的串行化。
+// 跨进程的并发由 .profile.lock 文件锁兜底（best-effort，POSIX 平台）。
+var writeMu sync.Mutex
+
+// ErrNotConfigured 当未配置 profile 系统时返回（无 profiles/ 目录）。
+var ErrNotConfigured = errors.New("profile 系统未初始化")
+
+// ErrNotFound 当指定 profile 不存在时返回。
+var ErrNotFound = errors.New("profile 不存在")
+
+// ErrAlreadyExists 当新 profile 名已被占用时返回。
+var ErrAlreadyExists = errors.New("profile 已存在")
+
+// ErrInvalidName 当 profile 名非法时返回。
+var ErrInvalidName = errors.New("profile 名非法")
+
+// homeFunc 可在测试中替换，避免读到真实 $HOME。
+var homeFunc = os.UserHomeDir
+
+// SetHomeFunc 仅用于测试，重置后会自动锁定 mutex。
+func SetHomeFunc(fn func() (string, error)) func() {
+	writeMu.Lock()
+	defer writeMu.Unlock()
+	old := homeFunc
+	homeFunc = fn
+	return func() {
+		writeMu.Lock()
+		defer writeMu.Unlock()
+		homeFunc = old
+	}
+}
+
+// RootDir 返回 feishu-cli 的根配置目录 ~/.feishu-cli。
+func RootDir() (string, error) {
+	home, err := homeFunc()
+	if err != nil {
+		return "", fmt.Errorf("获取用户目录失败: %w", err)
+	}
+	return filepath.Join(home, ".feishu-cli"), nil
+}
+
+// profilesDir 返回 ~/.feishu-cli/profiles。
+func profilesDir() (string, error) {
+	root, err := RootDir()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(root, profilesDirName), nil
+}
+
+// HasProfiles 是否启用了 profile 系统（profiles/ 目录是否存在且至少有一个子目录）。
+func HasProfiles() (bool, error) {
+	dir, err := profilesDir()
+	if err != nil {
+		return false, err
+	}
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return false, nil
+		}
+		return false, fmt.Errorf("读取 profiles 目录失败: %w", err)
+	}
+	for _, e := range entries {
+		if e.IsDir() && nameRegex.MatchString(e.Name()) {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
+// ProfileDir 返回指定 profile 的目录路径，不校验是否存在。
+func ProfileDir(name string) (string, error) {
+	if err := ValidateName(name); err != nil {
+		return "", err
+	}
+	dir, err := profilesDir()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(dir, name), nil
+}
+
+// ValidateName 校验 profile 名是否合法。
+func ValidateName(name string) error {
+	if name == "" {
+		return fmt.Errorf("%w: 名字不能为空", ErrInvalidName)
+	}
+	if !nameRegex.MatchString(name) {
+		return fmt.Errorf("%w: %q 含非法字符（允许 A-Z a-z 0-9 _ - 且长度 ≤ %d）", ErrInvalidName, name, MaxNameLen)
+	}
+	if name == "profiles" || name == "cache" {
+		return fmt.Errorf("%w: %q 为保留名", ErrInvalidName, name)
+	}
+	return nil
+}
+
+// Exists 报告 profile 是否存在（profiles/<name>/ 目录是否存在）。
+func Exists(name string) (bool, error) {
+	if err := ValidateName(name); err != nil {
+		return false, err
+	}
+	dir, err := ProfileDir(name)
+	if err != nil {
+		return false, err
+	}
+	info, err := os.Stat(dir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return false, nil
+		}
+		return false, fmt.Errorf("访问 profile 目录失败: %w", err)
+	}
+	return info.IsDir(), nil
+}
+
+// List 返回所有 profile 名（按字典序）。当 profiles/ 不存在时返回空切片。
+func List() ([]string, error) {
+	dir, err := profilesDir()
+	if err != nil {
+		return nil, err
+	}
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return []string{}, nil
+		}
+		return nil, fmt.Errorf("读取 profiles 目录失败: %w", err)
+	}
+	names := make([]string, 0, len(entries))
+	for _, e := range entries {
+		if !e.IsDir() {
+			continue
+		}
+		if !nameRegex.MatchString(e.Name()) {
+			continue
+		}
+		names = append(names, e.Name())
+	}
+	sort.Strings(names)
+	return names, nil
+}
+
+// readPointer 读取 active-profile / previous-profile 指针文件，文件不存在返回空字符串。
+func readPointer(filename string) (string, error) {
+	root, err := RootDir()
+	if err != nil {
+		return "", err
+	}
+	data, err := os.ReadFile(filepath.Join(root, filename))
+	if err != nil {
+		if os.IsNotExist(err) {
+			return "", nil
+		}
+		return "", fmt.Errorf("读取 %s 失败: %w", filename, err)
+	}
+	name := strings.TrimSpace(string(data))
+	return name, nil
+}
+
+// writePointer 原子写入指针文件（先写 .tmp 后 rename）。
+func writePointer(filename, value string) error {
+	root, err := RootDir()
+	if err != nil {
+		return err
+	}
+	if err := os.MkdirAll(root, 0700); err != nil {
+		return fmt.Errorf("创建配置目录失败: %w", err)
+	}
+	path := filepath.Join(root, filename)
+	tmp := path + ".tmp"
+	if value == "" {
+		// 清空指针 = 删除文件
+		if err := os.Remove(path); err != nil && !os.IsNotExist(err) {
+			return fmt.Errorf("删除 %s 失败: %w", filename, err)
+		}
+		return nil
+	}
+	if err := os.WriteFile(tmp, []byte(value+"\n"), 0600); err != nil {
+		return fmt.Errorf("写入 %s 失败: %w", filename, err)
+	}
+	if err := os.Rename(tmp, path); err != nil {
+		_ = os.Remove(tmp)
+		return fmt.Errorf("替换 %s 失败: %w", filename, err)
+	}
+	return nil
+}
+
+// ReadActive 读取 active-profile 指针（不校验 profile 是否存在）。
+func ReadActive() (string, error) {
+	return readPointer(activePointerName)
+}
+
+// ReadPrevious 读取 previous-profile 指针。
+func ReadPrevious() (string, error) {
+	return readPointer(previousPointerName)
+}
+
+// ActiveName 返回当前激活的 profile 名（解析优先级见包注释）。
+// 若未启用 profile 系统返回空字符串和 nil error，调用方应回退到旧布局。
+func ActiveName() (string, error) {
+	if env := strings.TrimSpace(os.Getenv(EnvVar)); env != "" {
+		if err := ValidateName(env); err != nil {
+			return "", fmt.Errorf("%s 环境变量值非法: %w", EnvVar, err)
+		}
+		ok, err := Exists(env)
+		if err != nil {
+			return "", err
+		}
+		if !ok {
+			return "", fmt.Errorf("%w: %s 指向的 profile %q 不存在", ErrNotFound, EnvVar, env)
+		}
+		return env, nil
+	}
+	hasProfiles, err := HasProfiles()
+	if err != nil {
+		return "", err
+	}
+	if !hasProfiles {
+		return "", nil
+	}
+	name, err := ReadActive()
+	if err != nil {
+		return "", err
+	}
+	if name == "" {
+		// 有 profile 但没指针，回退到字典序第一个
+		all, err := List()
+		if err != nil {
+			return "", err
+		}
+		if len(all) == 0 {
+			return "", nil
+		}
+		return all[0], nil
+	}
+	if err := ValidateName(name); err != nil {
+		return "", fmt.Errorf("active-profile 指针非法: %w", err)
+	}
+	ok, err := Exists(name)
+	if err != nil {
+		return "", err
+	}
+	if !ok {
+		// 指针指向不存在的 profile，回退到第一个
+		all, err := List()
+		if err != nil {
+			return "", err
+		}
+		if len(all) == 0 {
+			return "", nil
+		}
+		return all[0], nil
+	}
+	return name, nil
+}
+
+// ActiveDir 返回当前激活 profile 的目录。
+// 启用 profile 系统：返回 ~/.feishu-cli/profiles/<active>/。
+// 未启用：返回旧布局 ~/.feishu-cli/。
+// 该函数被 internal/config 与 internal/auth 用来定位 config.yaml / token.json / user_profile.json。
+func ActiveDir() (string, error) {
+	name, err := ActiveName()
+	if err != nil {
+		return "", err
+	}
+	if name == "" {
+		return RootDir()
+	}
+	return ProfileDir(name)
+}
+
+// ConfigFilePath 返回当前激活 profile 的 config.yaml 路径。
+func ConfigFilePath() (string, error) {
+	dir, err := ActiveDir()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(dir, configFileName), nil
+}
+
+// TokenFilePath 返回当前激活 profile 的 token.json 路径。
+func TokenFilePath() (string, error) {
+	dir, err := ActiveDir()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(dir, tokenFileName), nil
+}
+
+// UserCacheFilePath 返回当前激活 profile 的 user_profile.json 路径。
+func UserCacheFilePath() (string, error) {
+	dir, err := ActiveDir()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(dir, userCacheName), nil
+}
+
+// Info 描述一个 profile 的元数据，用于 list 输出。
+type Info struct {
+	Name      string `json:"name"`
+	Path      string `json:"path"`
+	Active    bool   `json:"active"`
+	HasConfig bool   `json:"has_config"`
+	HasToken  bool   `json:"has_token"`
+}
+
+// Describe 返回所有 profile 的元数据列表。当未启用 profile 系统时返回空切片。
+func Describe() ([]Info, error) {
+	names, err := List()
+	if err != nil {
+		return nil, err
+	}
+	active, err := ActiveName()
+	if err != nil {
+		return nil, err
+	}
+	out := make([]Info, 0, len(names))
+	for _, name := range names {
+		dir, err := ProfileDir(name)
+		if err != nil {
+			return nil, err
+		}
+		info := Info{
+			Name:      name,
+			Path:      dir,
+			Active:    name == active,
+			HasConfig: fileExists(filepath.Join(dir, configFileName)),
+			HasToken:  fileExists(filepath.Join(dir, tokenFileName)),
+		}
+		out = append(out, info)
+	}
+	return out, nil
+}
+
+// fileExists 测试文件是否存在。
+func fileExists(path string) bool {
+	_, err := os.Stat(path)
+	return err == nil
+}
+
+// CreateOpts 控制新 profile 的初始化内容。
+type CreateOpts struct {
+	// AppID 写入 config.yaml 的 app_id，可为空（用户后续手动填）。
+	AppID string
+	// AppSecret 写入 config.yaml 的 app_secret，可为空。
+	AppSecret string
+	// BaseURL 写入 config.yaml 的 base_url，为空时使用默认值。
+	BaseURL string
+	// SwitchTo 创建后是否立即切换为 active profile。
+	SwitchTo bool
+}
+
+// Create 创建一个新 profile。
+//
+// 行为：
+//  1. 校验名字合法且未被占用
+//  2. 如果是首个 profile（profiles/ 不存在），且旧布局存在 config.yaml/token.json，
+//     不会自动迁移——避免悄无声息丢数据。调用方应先用 Migrate() 显式迁移。
+//  3. 创建 profiles/<name>/，写入 config.yaml（含 app_id/app_secret/base_url）
+//  4. 若 SwitchTo=true，写 active-profile 指针
+func Create(name string, opts CreateOpts) error {
+	writeMu.Lock()
+	defer writeMu.Unlock()
+
+	if err := ValidateName(name); err != nil {
+		return err
+	}
+	exists, err := Exists(name)
+	if err != nil {
+		return err
+	}
+	if exists {
+		return fmt.Errorf("%w: %q", ErrAlreadyExists, name)
+	}
+
+	dir, err := ProfileDir(name)
+	if err != nil {
+		return err
+	}
+	if err := os.MkdirAll(dir, 0700); err != nil {
+		return fmt.Errorf("创建 profile 目录失败: %w", err)
+	}
+
+	configFile := filepath.Join(dir, configFileName)
+	baseURL := opts.BaseURL
+	if baseURL == "" {
+		baseURL = "https://open.feishu.cn"
+	}
+	content := renderConfigYAML(opts.AppID, opts.AppSecret, baseURL)
+	if err := writeFileAtomic(configFile, []byte(content), 0600); err != nil {
+		return fmt.Errorf("写入 config.yaml 失败: %w", err)
+	}
+
+	if opts.SwitchTo {
+		previous, _ := ReadActive() // best-effort
+		if previous != "" && previous != name {
+			if err := writePointer(previousPointerName, previous); err != nil {
+				return fmt.Errorf("更新 previous-profile 失败: %w", err)
+			}
+		}
+		if err := writePointer(activePointerName, name); err != nil {
+			return fmt.Errorf("更新 active-profile 失败: %w", err)
+		}
+	}
+	return nil
+}
+
+// Remove 删除一个 profile（包括目录下所有文件）。
+//
+// 调用方应在交互场景下加 --force 二次确认。
+// 若删除的是当前 active profile，active-profile 指针会被清空（下次访问回退到第一个）。
+func Remove(name string) error {
+	writeMu.Lock()
+	defer writeMu.Unlock()
+
+	if err := ValidateName(name); err != nil {
+		return err
+	}
+	exists, err := Exists(name)
+	if err != nil {
+		return err
+	}
+	if !exists {
+		return fmt.Errorf("%w: %q", ErrNotFound, name)
+	}
+
+	dir, err := ProfileDir(name)
+	if err != nil {
+		return err
+	}
+	if err := os.RemoveAll(dir); err != nil {
+		return fmt.Errorf("删除 profile 目录失败: %w", err)
+	}
+
+	// 清理指针（如果指向了被删除的 profile）
+	active, _ := ReadActive()
+	if active == name {
+		if err := writePointer(activePointerName, ""); err != nil {
+			return err
+		}
+	}
+	previous, _ := ReadPrevious()
+	if previous == name {
+		if err := writePointer(previousPointerName, ""); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// Rename 将 profile 从 oldName 重命名到 newName。
+func Rename(oldName, newName string) error {
+	writeMu.Lock()
+	defer writeMu.Unlock()
+
+	if err := ValidateName(oldName); err != nil {
+		return fmt.Errorf("旧名: %w", err)
+	}
+	if err := ValidateName(newName); err != nil {
+		return fmt.Errorf("新名: %w", err)
+	}
+	if oldName == newName {
+		return fmt.Errorf("新旧名相同: %q", oldName)
+	}
+
+	srcExists, err := Exists(oldName)
+	if err != nil {
+		return err
+	}
+	if !srcExists {
+		return fmt.Errorf("%w: %q", ErrNotFound, oldName)
+	}
+	dstExists, err := Exists(newName)
+	if err != nil {
+		return err
+	}
+	if dstExists {
+		return fmt.Errorf("%w: %q", ErrAlreadyExists, newName)
+	}
+
+	srcDir, err := ProfileDir(oldName)
+	if err != nil {
+		return err
+	}
+	dstDir, err := ProfileDir(newName)
+	if err != nil {
+		return err
+	}
+	if err := os.Rename(srcDir, dstDir); err != nil {
+		return fmt.Errorf("重命名 profile 目录失败: %w", err)
+	}
+
+	// 更新指针
+	active, _ := ReadActive()
+	if active == oldName {
+		if err := writePointer(activePointerName, newName); err != nil {
+			return err
+		}
+	}
+	previous, _ := ReadPrevious()
+	if previous == oldName {
+		if err := writePointer(previousPointerName, newName); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// Use 切换 active profile 到 name。
+// 若 name == "-"，切换回 previous-profile（toggle）。
+func Use(name string) (string, error) {
+	writeMu.Lock()
+	defer writeMu.Unlock()
+
+	// "-" 表示切回上一个
+	if name == "-" {
+		prev, err := ReadPrevious()
+		if err != nil {
+			return "", err
+		}
+		if prev == "" {
+			return "", fmt.Errorf("没有可切换回的上一个 profile")
+		}
+		name = prev
+	}
+
+	if err := ValidateName(name); err != nil {
+		return "", err
+	}
+	exists, err := Exists(name)
+	if err != nil {
+		return "", err
+	}
+	if !exists {
+		return "", fmt.Errorf("%w: %q", ErrNotFound, name)
+	}
+
+	current, _ := ReadActive()
+	if current == name {
+		// 已经在目标 profile，无需切换
+		return name, nil
+	}
+
+	// 切换前把当前 active 记为 previous
+	if current != "" {
+		if err := writePointer(previousPointerName, current); err != nil {
+			return "", err
+		}
+	}
+	if err := writePointer(activePointerName, name); err != nil {
+		return "", err
+	}
+	return name, nil
+}
+
+// MigrateLegacyOpts 控制旧布局迁移行为。
+type MigrateLegacyOpts struct {
+	// TargetName 迁移到的 profile 名（默认 "default"）。
+	TargetName string
+	// Force 即便目标 profile 已存在也迁移（会覆盖）。
+	Force bool
+}
+
+// MigrateLegacy 把旧布局 ~/.feishu-cli/{config.yaml,token.json,user_profile.json}
+// 迁移到 profiles/<TargetName>/，并把指针指向该 profile。原文件不删除（让用户手动确认）。
+// 旧文件不存在的话，仍然会创建一个空 profile 目录。
+func MigrateLegacy(opts MigrateLegacyOpts) (string, error) {
+	writeMu.Lock()
+	defer writeMu.Unlock()
+
+	target := opts.TargetName
+	if target == "" {
+		target = "default"
+	}
+	if err := ValidateName(target); err != nil {
+		return "", err
+	}
+	exists, err := Exists(target)
+	if err != nil {
+		return "", err
+	}
+	if exists && !opts.Force {
+		return "", fmt.Errorf("%w: %q（用 --force 覆盖）", ErrAlreadyExists, target)
+	}
+
+	dstDir, err := ProfileDir(target)
+	if err != nil {
+		return "", err
+	}
+	if err := os.MkdirAll(dstDir, 0700); err != nil {
+		return "", fmt.Errorf("创建 profile 目录失败: %w", err)
+	}
+
+	root, err := RootDir()
+	if err != nil {
+		return "", err
+	}
+	for _, f := range []string{configFileName, tokenFileName, userCacheName} {
+		src := filepath.Join(root, f)
+		if !fileExists(src) {
+			continue
+		}
+		dst := filepath.Join(dstDir, f)
+		if err := copyFile(src, dst); err != nil {
+			return "", fmt.Errorf("迁移 %s 失败: %w", f, err)
+		}
+	}
+
+	if err := writePointer(activePointerName, target); err != nil {
+		return "", err
+	}
+	return target, nil
+}
+
+// writeFileAtomic 原子写入文件：先写 .tmp 后 rename。
+func writeFileAtomic(path string, data []byte, mode os.FileMode) error {
+	dir := filepath.Dir(path)
+	if err := os.MkdirAll(dir, 0700); err != nil {
+		return err
+	}
+	tmp := path + ".tmp"
+	if err := os.WriteFile(tmp, data, mode); err != nil {
+		return err
+	}
+	if err := os.Rename(tmp, path); err != nil {
+		_ = os.Remove(tmp)
+		return err
+	}
+	return nil
+}
+
+// copyFile 复制文件内容并保留权限位。
+func copyFile(src, dst string) error {
+	data, err := os.ReadFile(src)
+	if err != nil {
+		return err
+	}
+	info, err := os.Stat(src)
+	if err != nil {
+		return err
+	}
+	return writeFileAtomic(dst, data, info.Mode().Perm())
+}
+
+// renderConfigYAML 生成 profile 的 config.yaml 模板。
+func renderConfigYAML(appID, appSecret, baseURL string) string {
+	var b strings.Builder
+	b.WriteString("# 飞书 CLI 配置文件 (profile)\n")
+	b.WriteString("# 由 `feishu-cli profile add` 自动创建\n\n")
+	if appID == "" {
+		b.WriteString(`app_id: ""` + "\n")
+	} else {
+		fmt.Fprintf(&b, "app_id: %q\n", appID)
+	}
+	if appSecret == "" {
+		b.WriteString(`app_secret: ""` + "\n")
+	} else {
+		fmt.Fprintf(&b, "app_secret: %q\n", appSecret)
+	}
+	fmt.Fprintf(&b, "base_url: %q\n", baseURL)
+	b.WriteString(`owner_email: ""` + "\n")
+	b.WriteString("transfer_ownership: false\n")
+	b.WriteString("debug: false\n\n")
+	b.WriteString("export:\n")
+	b.WriteString("  download_images: true\n")
+	b.WriteString(`  assets_dir: "./assets"` + "\n\n")
+	b.WriteString("import:\n")
+	b.WriteString("  upload_images: true\n")
+	return b.String()
+}

--- a/internal/profile/store.go
+++ b/internal/profile/store.go
@@ -51,9 +51,6 @@ const (
 	// profilesDirName profile 子目录名。
 	profilesDirName = "profiles"
 
-	// lockFileName 写操作锁文件名。
-	lockFileName = ".profile.lock"
-
 	// 单 profile 目录下的内容文件名（与旧布局保持一致）。
 	configFileName = "config.yaml"
 	tokenFileName  = "token.json"
@@ -67,7 +64,7 @@ const (
 var nameRegex = regexp.MustCompile(`^[A-Za-z0-9_-]{1,64}$`)
 
 // 进程内锁，用于 active-profile / previous-profile 指针文件的串行化。
-// 跨进程的并发由 .profile.lock 文件锁兜底（best-effort，POSIX 平台）。
+// 仅 sync.Mutex 保护进程内并发；跨进程并发场景应用层避免。
 var writeMu sync.Mutex
 
 // ErrNotConfigured 当未配置 profile 系统时返回（无 profiles/ 目录）。

--- a/internal/profile/store_test.go
+++ b/internal/profile/store_test.go
@@ -1,0 +1,524 @@
+package profile
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// withTempHome 把 homeFunc 重定向到 t.TempDir()，并在测试结束时还原。
+// 同时清空 FEISHU_PROFILE 环境变量，避免污染其它子测试。
+func withTempHome(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	restore := SetHomeFunc(func() (string, error) {
+		return dir, nil
+	})
+	prevEnv := os.Getenv(EnvVar)
+	_ = os.Unsetenv(EnvVar)
+	t.Cleanup(func() {
+		restore()
+		if prevEnv != "" {
+			_ = os.Setenv(EnvVar, prevEnv)
+		}
+	})
+	return dir
+}
+
+func TestValidateName(t *testing.T) {
+	cases := []struct {
+		name    string
+		wantErr bool
+	}{
+		{"work", false},
+		{"work-1", false},
+		{"work_personal", false},
+		{"A_b-9", false},
+		{"", true},
+		{".", true},
+		{"..", true},
+		{"with space", true},
+		{"with/slash", true},
+		{"with.dot", true},
+		{"profiles", true}, // 保留名
+		{"cache", true},    // 保留名
+		{strings.Repeat("a", 65), true},
+	}
+	for _, c := range cases {
+		err := ValidateName(c.name)
+		if c.wantErr && err == nil {
+			t.Errorf("ValidateName(%q) want error, got nil", c.name)
+		}
+		if !c.wantErr && err != nil {
+			t.Errorf("ValidateName(%q) want nil, got %v", c.name, err)
+		}
+	}
+}
+
+func TestRootDirAndProfileDir(t *testing.T) {
+	home := withTempHome(t)
+
+	root, err := RootDir()
+	if err != nil {
+		t.Fatalf("RootDir: %v", err)
+	}
+	wantRoot := filepath.Join(home, ".feishu-cli")
+	if root != wantRoot {
+		t.Errorf("RootDir = %q, want %q", root, wantRoot)
+	}
+
+	pd, err := ProfileDir("work")
+	if err != nil {
+		t.Fatalf("ProfileDir: %v", err)
+	}
+	want := filepath.Join(home, ".feishu-cli", "profiles", "work")
+	if pd != want {
+		t.Errorf("ProfileDir = %q, want %q", pd, want)
+	}
+
+	// 非法名应当报错
+	if _, err := ProfileDir(".."); err == nil {
+		t.Errorf("ProfileDir('..') want error, got nil")
+	}
+}
+
+func TestHasProfilesEmpty(t *testing.T) {
+	withTempHome(t)
+	ok, err := HasProfiles()
+	if err != nil {
+		t.Fatalf("HasProfiles: %v", err)
+	}
+	if ok {
+		t.Errorf("HasProfiles on empty home should be false")
+	}
+}
+
+func TestCreateAndExists(t *testing.T) {
+	withTempHome(t)
+
+	if err := Create("work", CreateOpts{AppID: "cli_xxx", AppSecret: "secret"}); err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	ok, err := Exists("work")
+	if err != nil {
+		t.Fatalf("Exists: %v", err)
+	}
+	if !ok {
+		t.Errorf("Exists('work') = false after Create")
+	}
+
+	cfgPath := filepath.Join(getProfileDirT(t, "work"), "config.yaml")
+	data, err := os.ReadFile(cfgPath)
+	if err != nil {
+		t.Fatalf("read config.yaml: %v", err)
+	}
+	if !strings.Contains(string(data), `app_id: "cli_xxx"`) {
+		t.Errorf("config.yaml missing app_id: %s", data)
+	}
+	if !strings.Contains(string(data), `app_secret: "secret"`) {
+		t.Errorf("config.yaml missing app_secret: %s", data)
+	}
+	if !strings.Contains(string(data), `base_url: "https://open.feishu.cn"`) {
+		t.Errorf("config.yaml missing default base_url: %s", data)
+	}
+}
+
+func TestCreateDuplicateErrors(t *testing.T) {
+	withTempHome(t)
+	if err := Create("work", CreateOpts{}); err != nil {
+		t.Fatalf("first Create: %v", err)
+	}
+	err := Create("work", CreateOpts{})
+	if err == nil {
+		t.Fatalf("second Create should error")
+	}
+	if !errors.Is(err, ErrAlreadyExists) {
+		t.Errorf("err = %v, want ErrAlreadyExists wrapped", err)
+	}
+}
+
+func TestCreateInvalidName(t *testing.T) {
+	withTempHome(t)
+	err := Create("bad name", CreateOpts{})
+	if err == nil {
+		t.Fatalf("Create('bad name') should error")
+	}
+	if !errors.Is(err, ErrInvalidName) {
+		t.Errorf("err = %v, want ErrInvalidName wrapped", err)
+	}
+}
+
+func TestListSorted(t *testing.T) {
+	withTempHome(t)
+	for _, name := range []string{"work", "personal", "test-1"} {
+		if err := Create(name, CreateOpts{}); err != nil {
+			t.Fatalf("Create(%q): %v", name, err)
+		}
+	}
+	got, err := List()
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+	want := []string{"personal", "test-1", "work"} // 字典序
+	if len(got) != len(want) {
+		t.Fatalf("List len = %d, want %d, got=%v", len(got), len(want), got)
+	}
+	for i, n := range want {
+		if got[i] != n {
+			t.Errorf("List[%d] = %q, want %q", i, got[i], n)
+		}
+	}
+}
+
+func TestListEmptyDir(t *testing.T) {
+	withTempHome(t)
+	got, err := List()
+	if err != nil {
+		t.Fatalf("List on empty: %v", err)
+	}
+	if len(got) != 0 {
+		t.Errorf("List on empty home = %v, want []", got)
+	}
+}
+
+func TestUseAndActiveName(t *testing.T) {
+	withTempHome(t)
+	if err := Create("work", CreateOpts{}); err != nil {
+		t.Fatalf("Create work: %v", err)
+	}
+	if err := Create("personal", CreateOpts{}); err != nil {
+		t.Fatalf("Create personal: %v", err)
+	}
+
+	// 未设置指针时 ActiveName 应当返回字典序第一个
+	active, err := ActiveName()
+	if err != nil {
+		t.Fatalf("ActiveName: %v", err)
+	}
+	if active != "personal" {
+		t.Errorf("default ActiveName = %q, want 'personal' (first by sort)", active)
+	}
+
+	if _, err := Use("work"); err != nil {
+		t.Fatalf("Use work: %v", err)
+	}
+	active, err = ActiveName()
+	if err != nil {
+		t.Fatalf("ActiveName after Use: %v", err)
+	}
+	if active != "work" {
+		t.Errorf("ActiveName after Use('work') = %q, want 'work'", active)
+	}
+
+	// 切换 personal，previous 应该 = work
+	if _, err := Use("personal"); err != nil {
+		t.Fatalf("Use personal: %v", err)
+	}
+	prev, err := ReadPrevious()
+	if err != nil {
+		t.Fatalf("ReadPrevious: %v", err)
+	}
+	if prev != "work" {
+		t.Errorf("previous after switch = %q, want 'work'", prev)
+	}
+
+	// Use("-") 切回 work
+	got, err := Use("-")
+	if err != nil {
+		t.Fatalf("Use('-'): %v", err)
+	}
+	if got != "work" {
+		t.Errorf("Use('-') = %q, want 'work'", got)
+	}
+}
+
+func TestUseNonExistent(t *testing.T) {
+	withTempHome(t)
+	_, err := Use("ghost")
+	if err == nil {
+		t.Fatalf("Use('ghost') should error")
+	}
+	if !errors.Is(err, ErrNotFound) {
+		t.Errorf("err = %v, want ErrNotFound wrapped", err)
+	}
+}
+
+func TestUseDashWithoutPrevious(t *testing.T) {
+	withTempHome(t)
+	if err := Create("work", CreateOpts{}); err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	_, err := Use("-")
+	if err == nil {
+		t.Fatalf("Use('-') without previous should error")
+	}
+	if !strings.Contains(err.Error(), "上一个") {
+		t.Errorf("err msg = %q, want hint about previous profile", err.Error())
+	}
+}
+
+func TestRemove(t *testing.T) {
+	withTempHome(t)
+	if err := Create("temp", CreateOpts{SwitchTo: true}); err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	if err := Remove("temp"); err != nil {
+		t.Fatalf("Remove: %v", err)
+	}
+	ok, err := Exists("temp")
+	if err != nil {
+		t.Fatalf("Exists after Remove: %v", err)
+	}
+	if ok {
+		t.Errorf("Exists('temp') = true after Remove")
+	}
+	// active 指针应被清空
+	active, _ := ReadActive()
+	if active != "" {
+		t.Errorf("active = %q after removing active profile, want empty", active)
+	}
+}
+
+func TestRemoveNonExistent(t *testing.T) {
+	withTempHome(t)
+	err := Remove("ghost")
+	if err == nil {
+		t.Fatalf("Remove('ghost') should error")
+	}
+	if !errors.Is(err, ErrNotFound) {
+		t.Errorf("err = %v, want ErrNotFound wrapped", err)
+	}
+}
+
+func TestRename(t *testing.T) {
+	withTempHome(t)
+	if err := Create("old", CreateOpts{SwitchTo: true}); err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	if err := Rename("old", "new"); err != nil {
+		t.Fatalf("Rename: %v", err)
+	}
+	oldOk, _ := Exists("old")
+	newOk, _ := Exists("new")
+	if oldOk {
+		t.Errorf("old still exists")
+	}
+	if !newOk {
+		t.Errorf("new doesn't exist")
+	}
+	active, _ := ReadActive()
+	if active != "new" {
+		t.Errorf("active = %q after rename, want 'new'", active)
+	}
+}
+
+func TestRenameDuplicate(t *testing.T) {
+	withTempHome(t)
+	if err := Create("a", CreateOpts{}); err != nil {
+		t.Fatalf("Create a: %v", err)
+	}
+	if err := Create("b", CreateOpts{}); err != nil {
+		t.Fatalf("Create b: %v", err)
+	}
+	err := Rename("a", "b")
+	if err == nil {
+		t.Fatalf("Rename a->b (b exists) should error")
+	}
+	if !errors.Is(err, ErrAlreadyExists) {
+		t.Errorf("err = %v, want ErrAlreadyExists wrapped", err)
+	}
+}
+
+func TestActiveDirFallback(t *testing.T) {
+	home := withTempHome(t)
+	// 未启用 profile 时 ActiveDir 应该返回旧布局 ~/.feishu-cli/
+	dir, err := ActiveDir()
+	if err != nil {
+		t.Fatalf("ActiveDir on empty: %v", err)
+	}
+	want := filepath.Join(home, ".feishu-cli")
+	if dir != want {
+		t.Errorf("ActiveDir empty = %q, want %q (legacy layout)", dir, want)
+	}
+
+	// 启用 profile 后 ActiveDir 应该返回 profiles/<name>/
+	if err := Create("work", CreateOpts{SwitchTo: true}); err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	dir, err = ActiveDir()
+	if err != nil {
+		t.Fatalf("ActiveDir: %v", err)
+	}
+	want = filepath.Join(home, ".feishu-cli", "profiles", "work")
+	if dir != want {
+		t.Errorf("ActiveDir = %q, want %q", dir, want)
+	}
+}
+
+func TestEnvVarOverride(t *testing.T) {
+	withTempHome(t)
+	if err := Create("work", CreateOpts{SwitchTo: true}); err != nil {
+		t.Fatalf("Create work: %v", err)
+	}
+	if err := Create("personal", CreateOpts{}); err != nil {
+		t.Fatalf("Create personal: %v", err)
+	}
+
+	t.Setenv(EnvVar, "personal")
+	active, err := ActiveName()
+	if err != nil {
+		t.Fatalf("ActiveName: %v", err)
+	}
+	if active != "personal" {
+		t.Errorf("ActiveName with env override = %q, want 'personal'", active)
+	}
+
+	t.Setenv(EnvVar, "ghost")
+	_, err = ActiveName()
+	if err == nil {
+		t.Fatalf("ActiveName with FEISHU_PROFILE=ghost should error")
+	}
+}
+
+func TestDescribe(t *testing.T) {
+	withTempHome(t)
+	if err := Create("work", CreateOpts{SwitchTo: true}); err != nil {
+		t.Fatalf("Create work: %v", err)
+	}
+	if err := Create("personal", CreateOpts{}); err != nil {
+		t.Fatalf("Create personal: %v", err)
+	}
+
+	infos, err := Describe()
+	if err != nil {
+		t.Fatalf("Describe: %v", err)
+	}
+	if len(infos) != 2 {
+		t.Fatalf("Describe len = %d, want 2", len(infos))
+	}
+	for _, info := range infos {
+		if info.Name == "work" && !info.Active {
+			t.Errorf("work should be active")
+		}
+		if info.Name == "personal" && info.Active {
+			t.Errorf("personal should not be active")
+		}
+		if !info.HasConfig {
+			t.Errorf("%s should have config.yaml", info.Name)
+		}
+		if info.HasToken {
+			t.Errorf("%s should not have token.json (not logged in)", info.Name)
+		}
+	}
+}
+
+func TestMigrateLegacy(t *testing.T) {
+	home := withTempHome(t)
+	legacyDir := filepath.Join(home, ".feishu-cli")
+	if err := os.MkdirAll(legacyDir, 0700); err != nil {
+		t.Fatalf("mkdir legacy: %v", err)
+	}
+	legacyContent := "app_id: \"cli_legacy\"\napp_secret: \"old_secret\"\n"
+	if err := os.WriteFile(filepath.Join(legacyDir, "config.yaml"), []byte(legacyContent), 0600); err != nil {
+		t.Fatalf("write legacy config: %v", err)
+	}
+	tokenContent := `{"access_token":"u-xxx","expires_at":0}`
+	if err := os.WriteFile(filepath.Join(legacyDir, "token.json"), []byte(tokenContent), 0600); err != nil {
+		t.Fatalf("write legacy token: %v", err)
+	}
+
+	target, err := MigrateLegacy(MigrateLegacyOpts{})
+	if err != nil {
+		t.Fatalf("MigrateLegacy: %v", err)
+	}
+	if target != "default" {
+		t.Errorf("target = %q, want 'default'", target)
+	}
+
+	gotCfg, err := os.ReadFile(filepath.Join(legacyDir, "profiles", "default", "config.yaml"))
+	if err != nil {
+		t.Fatalf("read migrated config: %v", err)
+	}
+	if string(gotCfg) != legacyContent {
+		t.Errorf("migrated config content mismatch:\n got=%q\nwant=%q", gotCfg, legacyContent)
+	}
+
+	gotTok, err := os.ReadFile(filepath.Join(legacyDir, "profiles", "default", "token.json"))
+	if err != nil {
+		t.Fatalf("read migrated token: %v", err)
+	}
+	if string(gotTok) != tokenContent {
+		t.Errorf("migrated token content mismatch")
+	}
+
+	active, _ := ReadActive()
+	if active != "default" {
+		t.Errorf("active after migrate = %q, want 'default'", active)
+	}
+
+	// 第二次 migrate 应当报错（target 已存在）
+	_, err = MigrateLegacy(MigrateLegacyOpts{})
+	if err == nil {
+		t.Fatalf("second MigrateLegacy should error")
+	}
+
+	// --force 覆盖
+	_, err = MigrateLegacy(MigrateLegacyOpts{Force: true})
+	if err != nil {
+		t.Fatalf("MigrateLegacy --force: %v", err)
+	}
+}
+
+func TestConfigFilePath(t *testing.T) {
+	home := withTempHome(t)
+
+	// 未启用 profile：回退旧布局
+	got, err := ConfigFilePath()
+	if err != nil {
+		t.Fatalf("ConfigFilePath: %v", err)
+	}
+	want := filepath.Join(home, ".feishu-cli", "config.yaml")
+	if got != want {
+		t.Errorf("ConfigFilePath legacy = %q, want %q", got, want)
+	}
+
+	// 启用 profile
+	if err := Create("work", CreateOpts{SwitchTo: true}); err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	got, err = ConfigFilePath()
+	if err != nil {
+		t.Fatalf("ConfigFilePath: %v", err)
+	}
+	want = filepath.Join(home, ".feishu-cli", "profiles", "work", "config.yaml")
+	if got != want {
+		t.Errorf("ConfigFilePath = %q, want %q", got, want)
+	}
+}
+
+func TestTokenFilePath(t *testing.T) {
+	home := withTempHome(t)
+	if err := Create("work", CreateOpts{SwitchTo: true}); err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	got, err := TokenFilePath()
+	if err != nil {
+		t.Fatalf("TokenFilePath: %v", err)
+	}
+	want := filepath.Join(home, ".feishu-cli", "profiles", "work", "token.json")
+	if got != want {
+		t.Errorf("TokenFilePath = %q, want %q", got, want)
+	}
+}
+
+// getProfileDirT 内部测试 helper：减少 boilerplate。
+func getProfileDirT(t *testing.T, name string) string {
+	t.Helper()
+	dir, err := ProfileDir(name)
+	if err != nil {
+		t.Fatalf("ProfileDir(%q): %v", name, err)
+	}
+	return dir
+}

--- a/skills/feishu-cli-profile/SKILL.md
+++ b/skills/feishu-cli-profile/SKILL.md
@@ -1,0 +1,284 @@
+---
+name: feishu-cli-profile
+description: >-
+  feishu-cli 多 App 配置切换。profile add/list/remove/rename/use/current/migrate 管理
+  ~/.feishu-cli/profiles/&lt;name&gt;/{config,token}.json 多套 App ID + Token 配置。
+  active-profile 指针记录当前激活 profile。向后兼容旧版无 profile 时直接读
+  ~/.feishu-cli/{config,token}.json。
+  当用户在多个飞书租户 / 多个 App ID 间切换时使用，避免反复重新登录。
+argument-hint: add | list | use | current | rename | remove | migrate
+user-invocable: true
+allowed-tools: Bash, Read
+---
+
+# 飞书 CLI 多 App Profile 管理
+
+`feishu-cli profile` 让一台机器在多个飞书账号 / 应用之间快速切换，免去手动备份 / 恢复 `~/.feishu-cli/{config.yaml,token.json}` 的麻烦。常见场景：work / personal 双账号、feishu.cn / larksuite.com 双端、多个 tenant 协同测试。
+
+> **feishu-cli**：如尚未安装，请前往 [riba2534/feishu-cli](https://github.com/riba2534/feishu-cli) 获取安装方式。
+
+---
+
+## 核心概念
+
+### 目录布局
+
+```
+~/.feishu-cli/
+  config.yaml                # 旧布局：profile 系统未启用时仍读这里（无感升级）
+  token.json                 # 旧布局
+  active-profile             # 一行文本：当前 profile 名
+  previous-profile           # 一行文本：上一个 profile 名（支持 use -）
+  profiles/
+    work/
+      config.yaml            # 该 profile 自己的 app_id / app_secret / base_url
+      token.json             # 该 profile 的 User Access Token + Refresh Token
+      user_profile.json      # 缓存的当前登录用户信息
+    personal/
+      ...
+```
+
+### Active profile 解析优先级
+
+由 `internal/profile.ActiveDir()` 决定，所有 feishu-cli 命令（auth login / doc import / msg send 等）自动从这里读 config + token，无需任何额外参数：
+
+1. **环境变量 `FEISHU_PROFILE=<name>`**（强制覆盖，不写指针文件；profile 必须已存在，否则报错）
+2. **`~/.feishu-cli/active-profile`** 指针文件指向的 profile
+3. **指针缺失或指向不存在的 profile** → 回退到 `profiles/` 下字典序第一个
+4. **未启用 profile 系统（`profiles/` 不存在）** → 返回旧布局 `~/.feishu-cli/`，老用户零感知
+
+### 向后兼容（零迁移升级）
+
+- 没有任何 profile 时，`internal/config` 和 `internal/auth` 仍走旧路径 `~/.feishu-cli/{config.yaml,token.json}`
+- 第一次执行 `profile add` **不会**自动迁移旧文件——避免静默丢数据
+- 要把已有 `config.yaml + token.json` 接入 profile 系统，**必须显式** `profile migrate`
+
+---
+
+## 子命令速查
+
+```bash
+# 新建
+feishu-cli profile add <name> [--app-id ... --app-secret ... --base-url ... --use] [--json]
+
+# 列表（标注 active）
+feishu-cli profile list [--json]                                # alias: ls
+
+# 切换 active
+feishu-cli profile use <name> [--json]                          # alias: switch / checkout
+feishu-cli profile use -                                        # 切回上一个 profile
+
+# 显示当前 active
+feishu-cli profile current
+
+# 重命名（自动同步 active / previous 指针）
+feishu-cli profile rename <old> <new> [--json]                  # alias: mv
+
+# 删除（默认二次确认）
+feishu-cli profile remove <name> [--force] [--json]             # alias: rm / delete
+
+# 把旧布局迁移到 profile 系统（不可逆见下方踩坑）
+feishu-cli profile migrate [--name <target>] [--force] [--json]
+```
+
+### `profile add`
+
+创建 `~/.feishu-cli/profiles/<name>/` 目录并写入初始 `config.yaml`。**不会**自动迁移旧布局——如需迁移用 `profile migrate`。
+
+| 参数 | 默认 | 说明 |
+|------|------|------|
+| `--app-id` | `""` | 飞书应用 app_id，可后续手动写 config.yaml |
+| `--app-secret` | `""` | 飞书应用 app_secret |
+| `--base-url` | `https://open.feishu.cn` | 飞书 OpenAPI base URL（larksuite 用 `https://open.larksuite.com`） |
+| `--use` | `false` | 创建后立即切换为 active profile |
+| `--json` | `false` | JSON 输出，适合脚本 / AI Agent |
+
+```bash
+feishu-cli profile add work --app-id cli_xxx --app-secret xxx --use
+feishu-cli profile add personal --base-url https://open.larksuite.com
+feishu-cli profile add temp                                     # 留空待手动填
+```
+
+### `profile list`
+
+```bash
+feishu-cli profile list
+# ACTIVE  NAME      CONFIG  TOKEN  PATH
+# *       work      yes     yes    /Users/me/.feishu-cli/profiles/work
+#         personal  yes     no     /Users/me/.feishu-cli/profiles/personal
+```
+
+- `ACTIVE` 列星号 `*` 标当前激活
+- `CONFIG / TOKEN` 表示该 profile 是否已有 config.yaml / token.json（用来判断是否已 `auth login`）
+- `--json` 返回 `{"active": "work", "profiles": [{"name":..., "path":..., "active":..., "has_config":..., "has_token":...}]}`
+
+### `profile use`
+
+切换 active，把 `~/.feishu-cli/active-profile` 指针写为 `<name>`。
+
+- 切换前的当前 active 会被记入 `previous-profile`，支持 `use -` toggle 切回
+- 已经在目标 profile 时打印「无需切换」并返回 0
+- profile 不存在时报错 `ErrNotFound`
+
+```bash
+feishu-cli profile use personal
+feishu-cli profile use -        # 切回上一个
+```
+
+### `profile current`
+
+显示当前激活 profile 名 + 目录（制表符分隔）。未启用 profile 系统时输出 `(未启用 profile 系统，使用旧布局 ~/.feishu-cli/)`。
+
+### `profile rename`
+
+把 `profiles/<old>/` 整目录 rename 到 `profiles/<new>/`，自动同步 `active-profile` / `previous-profile` 指针文件。
+
+### `profile remove`
+
+删除 `profiles/<name>/` 整个目录（含 config / token / 用户信息缓存）。
+
+- 默认在 TTY 下二次确认（管道 / 重定向自动跳过）
+- `--force` 跳过提示
+- 若删的是当前 active，`active-profile` 指针被清空，下次访问回退到字典序第一个 profile
+
+### `profile migrate`
+
+把旧布局 `~/.feishu-cli/{config.yaml,token.json,user_profile.json}` 拷贝到 `profiles/<target>/`，并把 active 指针指向 target。
+
+| 参数 | 默认 | 说明 |
+|------|------|------|
+| `--name` | `default` | 迁移目标 profile 名 |
+| `--force` | `false` | 目标 profile 已存在时覆盖 |
+| `--json` | `false` | JSON 输出 |
+
+**原文件不会被删除**——用户自己确认无误后可手动 `rm ~/.feishu-cli/{config.yaml,token.json,user_profile.json}`。
+
+---
+
+## 关键参数：`FEISHU_PROFILE` 环境变量
+
+临时覆盖当前 active profile，**不修改指针文件**，适合 CI / 一次性切换：
+
+```bash
+FEISHU_PROFILE=work feishu-cli msg send ...           # 仅本次命令用 work
+FEISHU_PROFILE=personal feishu-cli auth status        # 检查 personal 的登录态
+```
+
+- 优先级最高（覆盖 active-profile 指针）
+- profile 必须已存在，否则报错 `ErrNotFound`
+- 名字非法（含 `/` `..` 等）时报错 `ErrInvalidName`
+
+---
+
+## profile 名校验规则
+
+仅允许 `[A-Za-z0-9_-]{1,64}`：
+
+- 禁止 `.` / `..` / `/` 等路径注入字符
+- 保留名 `profiles` / `cache` 不可作为 profile 名
+- 最大长度 64 字符
+
+非法名直接报 `ErrInvalidName`，所有命令在动手前会先校验。
+
+---
+
+## 典型工作流
+
+### 场景 A：老用户首次启用 profile 系统
+
+```bash
+# 已经有 ~/.feishu-cli/config.yaml + token.json
+feishu-cli profile migrate                              # → profiles/default/，指针指 default
+feishu-cli profile list                                 # 确认 default 已是 active
+feishu-cli profile add personal --use --app-id cli_yyy  # 新建 personal 并切过去
+feishu-cli auth login                                   # 给 personal 做 OAuth
+feishu-cli profile use -                                # 切回 default
+```
+
+### 场景 B：从零开始多账号
+
+```bash
+feishu-cli profile add work --app-id cli_work --app-secret xxx --use
+feishu-cli auth login                                   # work 登录
+feishu-cli profile add personal --base-url https://open.larksuite.com
+feishu-cli profile use personal
+feishu-cli auth login                                   # personal 登录
+feishu-cli profile list                                 # 看双账号状态
+```
+
+### 场景 C：CI / 临时切换
+
+```bash
+FEISHU_PROFILE=ci-bot feishu-cli msg send --chat-id oc_xxx --text "build done"
+# 不动 active-profile 指针，下次普通命令仍用之前的 profile
+```
+
+---
+
+## 踩坑
+
+### `profile migrate` 不可逆，但原文件不删
+
+- migrate 是**单向拷贝**：旧布局 `config.yaml` / `token.json` / `user_profile.json` 被复制到 `profiles/<target>/`，并写入 active 指针
+- 旧文件**不会被删除**，但一旦启用 profile 系统（`profiles/` 目录存在且至少一个子目录），所有命令都走 `ActiveDir()` 解析，不再读旧路径
+- 想"回滚"：要么 `profile remove <target>` 删干净所有 profile 让 `profiles/` 空 → 回退到旧布局；要么手动 `cp` 把 profile 目录内容拷回 `~/.feishu-cli/` 顶层
+- 建议 migrate 后先验证 `profile current` + 跑一条业务命令（如 `auth status`）确认无误，再考虑 `rm ~/.feishu-cli/{config.yaml,token.json,user_profile.json}`
+
+### `sync.Mutex` 仅进程内并发，不跨进程锁
+
+- `internal/profile.writeMu` 是 Go 进程内 mutex，串行化同一进程内的 Create / Remove / Rename / Use / MigrateLegacy
+- **不能**防御并发多个 `feishu-cli` 进程同时改 `active-profile` 指针文件——指针写入用了 `.tmp + rename` 原子替换，但两个进程 race 可能造成"最后一个赢"的不一致
+- 同时跑多个 profile 写操作时（如 shell 脚本里背靠背 `profile use a & profile use b`），结果不可预期
+- 解法：脚本里串行（顺序执行，不要 `&` 后台并行）；自动化场景一律单进程依次跑
+
+### `profile use` 不会自动登录
+
+切换到一个还没 `auth login` 过的 profile，后续命令会按需提示「未登录飞书」。需要先：
+
+```bash
+feishu-cli profile use newone
+feishu-cli auth login                                   # 这次的 token 落到 profiles/newone/token.json
+```
+
+### `active-profile` 指针指向不存在的 profile
+
+不会报错，会自动回退到字典序第一个 profile。如果想精确控制，请显式 `profile use <name>` 修正指针。
+
+### 删 active profile 后没有 active
+
+`profile remove` 删的是当前 active 时，指针被清空，下次命令会回退到字典序第一个 profile（如果还有的话）。`profile list` 会提示「当前无激活 profile」。
+
+### 旧布局判定：只看 `profiles/` 是否存在子目录
+
+`HasProfiles()` 检查 `~/.feishu-cli/profiles/` 下是否有**至少一个合法名字**的子目录。空目录 / 全是非法名（如 `.tmp`）的子目录会被忽略，仍走旧布局。所以单纯 `mkdir ~/.feishu-cli/profiles/` 不会改变 CLI 行为。
+
+---
+
+## 何时转其他 skill
+
+- **只有一个飞书账号 / 一次性使用** → 不需要 profile 系统，直接 `feishu-cli config create-app --save` + `feishu-cli auth login`，走 [`feishu-cli-auth`](../feishu-cli-auth/SKILL.md)
+- **OAuth 登录 / Token 过期 / scope 申请** → [`feishu-cli-auth`](../feishu-cli-auth/SKILL.md)
+- **`config.yaml` 字段说明 / `config create-app` 一键创建应用** → [`feishu-cli-auth`](../feishu-cli-auth/SKILL.md) 的「创建飞书应用」节
+- **多 profile 之间数据迁移**（如把 work 的 token 复制到 personal） → 直接 `cp ~/.feishu-cli/profiles/work/token.json ~/.feishu-cli/profiles/personal/`，CLI 没提供专门命令
+
+---
+
+## JSON 输出（AI Agent 推荐）
+
+所有写操作（add / use / rename / remove / migrate）和 list 都支持 `--json`，返回结构化输出：
+
+```bash
+$ feishu-cli profile add work --app-id cli_xxx --use --json
+{"active":true,"dir":"/Users/me/.feishu-cli/profiles/work","name":"work","ok":true}
+
+$ feishu-cli profile list --json
+{"active":"work","profiles":[{"name":"work","path":"...","active":true,"has_config":true,"has_token":true}]}
+
+$ feishu-cli profile use personal --json
+{"active":"personal","dir":"...","ok":true,"previous":"work"}
+
+$ feishu-cli profile current
+work    /Users/me/.feishu-cli/profiles/work
+```
+
+AI Agent 优先 `--json` 解析，避免依赖人类可读输出的格式稳定性。


### PR DESCRIPTION
## 背景

feishu-cli 此前只支持单一 app 配置。AI agent 或多租户场景下需要同时管理多个 app（如个人 bot + 团队 bot），并能一行命令切换。

本 PR 引入 \`feishu-cli profile\` 模块，对齐 lark-cli profile 多配置能力。

## 关键设计：完全向后兼容

- 有 active profile 时：读 \`~/.feishu-cli/profiles/<active>/{config.yaml,token.json}\`
- 没有 profile 时：仍读旧路径 \`~/.feishu-cli/{config.yaml,token.json}\`（**零感知升级**）
- \`FEISHU_PROFILE=<name>\` 环境变量可强制指定（CI/agent 友好）

## 新增命令（7 个）

```bash
# 添加配置（可选自动切换）
feishu-cli profile add work --app-id cli_xxx --app-secret xxx [--use --json]

# 列出所有 profile（带 active 标记）
feishu-cli profile list                                       # alias: ls

# 切换 profile（支持 -  切回上一个）
feishu-cli profile use work                                   # alias: switch / checkout
feishu-cli profile use -                                       # 切回上一个

# 查看当前 profile
feishu-cli profile current

# 重命名
feishu-cli profile rename work team-bot                       # alias: mv

# 删除（destructive，必须 --force）
feishu-cli profile remove work --force                        # alias: rm / delete

# 迁移旧布局到 default profile
feishu-cli profile migrate [--name default] [--force]
```

## 实现要点

- \`internal/profile/store.go\`：profile 文件管理（740 行）
  - \`List\` / \`Create\` / \`Remove\` / \`Rename\` / \`Use\` / \`MigrateLegacy\`
  - 名字白名单 \`[A-Za-z0-9_-]{1,64}\`，保留名 \`profiles\` / \`cache\`
  - 进程内 \`sync.Mutex\` + 原子写指针（tmp + rename）
  - \`SetHomeFunc\` 测试 hook 不污染真实 \`\$HOME\`

- \`internal/config/config.go\` + \`internal/auth/token.go\` 改走 \`profile.ActiveDir()\`，启用 profile 时读 \`profiles/<active>/\`，未启用时回退旧路径

## 测试

- \`go test ./internal/profile\` — **21 个单测全过**（t.TempDir() 隔离）
  - ValidateName / List 字典序 / Create / Remove / Rename / Use \`-\` / MigrateLegacy / FEISHU_PROFILE / ActiveDir 新旧切换 / 边界（空/非法/保留名/重复/不存在）
- \`go test ./internal/config ./internal/auth\` 全过
- **端到端 smoke**：add → list → use → use - → rename → remove --force → migrate → --json 全通

## 与 spec 差异

- spec 写 5 子命令，实际做了 7 个（多 \`current\` + \`migrate\`，因为 store 已经提供能力，不暴露浪费）