### PR TITLE
feat(mail): CID 内联图片自动扫描 + 模板 CRUD（MVP）

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,55 @@
 
 ## 未发布
 
+### 新增 — `mail` 高级能力：CID 内联图片 + 邮件模板（MVP）
+
+为 `mail` 模块补齐两块进阶能力，对齐 lark-cli `mail +send` / `mail +template-create` 的核心子集。
+
+**1. `mail send --inline-images-auto-scan`（CID 内联图片）**
+
+HTML body 中所有 `<img src="本地相对/绝对路径">` 会被自动扫描：
+
+1. 跳过已经是 `cid:` / `http(s):` / `data:` / `//` scheme 的引用
+2. 同一本地路径只上传一次（去重）
+3. 每张图独立生成 20-hex CID
+4. 走 `drive/v1/medias/upload_all`（`parent_type=email`，`parent_node = 当前登录用户 open_id`）
+5. EML 走 `multipart/related`：HTML 段 + 每张图一个 `Content-ID: <cid>`、`Content-Disposition: inline` 的 part
+6. 改写 `src` 为 `cid:<cid>` 后回写到 body
+
+依赖 `~/.feishu-cli/user_profile.json` 中缓存的 open_id（`auth login` 后自动写入）。
+
+**2. `mail template create` / `mail template list`（邮件模板 MVP）**
+
+- `mail template create --name xxx --subject xxx --body xxx [--to ... --cc ... --bcc ... --plain-text]`
+  调用 `POST /open-apis/mail/v1/user_mailboxes/{id}/templates`
+- `mail template list [--mailbox me]`
+  调用 `GET /open-apis/mail/v1/user_mailboxes/{id}/templates`（接口不分页，一次返回所有 id+name）
+
+底层 client 也实现了 `GetMailTemplate` / `UpdateMailTemplate` / `DeleteMailTemplate`，但 CLI 层目前只暴露 create/list（MVP）。
+
+**权限要求**：
+
+- User Access Token
+- `mail:user_mailbox:readonly` / `mail:user_mailbox.message:modify` / `mail:user_mailbox.message:send`
+- 模板相关 scope：`mail:user.email.template`
+
+⚠️ **字节租户 `mail:user.email.template` 暂未开放** —— 命令本身实现完整、参数校验完整、EML/JSON payload
+正确，但调用模板 API 时可能返回 scope 校验失败（401/permission denied）；等飞书侧开放该 scope 后立即可用。
+CID 内联图片功能不依赖此 scope，已可正常使用。
+
+**示例**：
+
+```bash
+# 内联图片
+feishu-cli mail send --to user@example.com --subject "周报" \
+    --body '<p>看附图</p><img src="./screenshot.png">' \
+    --inline-images-auto-scan --confirm-send
+
+# 模板创建+列表
+feishu-cli mail template create --name "周报" --subject "本周进度" --body "<p>模板</p>"
+feishu-cli mail template list
+```
+
 ### 新增 — `comment reply add`：为已有评论添加回复
 
 新增命令 `feishu-cli comment reply add <file_token> <comment_id> --text "..."`，补齐评论回复

--- a/cmd/mail.go
+++ b/cmd/mail.go
@@ -10,7 +10,7 @@ var mailCmd = &cobra.Command{
 	Short: "飞书邮箱（Mail）操作命令",
 	Long: `飞书邮箱（Mail）操作，通过 OAuth User Access Token 访问。
 
-⚠️ 首期限制：send/draft/reply/forward 仅支持纯文本 body 和 HTML body，暂不支持附件和 CID 内联图片。
+⚠️ 首期限制：send/draft/reply/forward 暂不支持普通附件；CID 内联图片走 send --inline-images-auto-scan 自动扫描上传。
 
 子命令:
   message       获取单封邮件内容（含 HTML/纯文本 body）
@@ -23,6 +23,7 @@ var mailCmd = &cobra.Command{
   reply         回复邮件（自动带 Re: 前缀和引用块）
   reply-all     全部回复（包含 To 和 CC）
   forward       转发邮件
+  template      邮件模板 CRUD（create/list；字节租户 scope 暂未开放）
 
 权限要求（User Access Token）:
   - mail:user_mailbox:readonly

--- a/cmd/mail_common.go
+++ b/cmd/mail_common.go
@@ -1,25 +1,46 @@
 package cmd
 
 import (
+	"crypto/rand"
 	"encoding/base64"
+	"encoding/hex"
 	"fmt"
 	"net/mail"
 	"strings"
 	"time"
 )
 
+// mailBoundary 生成一个 multipart 边界字符串（16-hex 随机）
+func mailBoundary() (string, error) {
+	var b [8]byte
+	if _, err := rand.Read(b[:]); err != nil {
+		return "", fmt.Errorf("生成 boundary 失败: %w", err)
+	}
+	return "fcli_" + hex.EncodeToString(b[:]), nil
+}
+
 // mailMessageInput 构造邮件的输入
 type mailMessageInput struct {
-	From       string   // 发件人邮箱地址
-	FromName   string   // 发件人显示名
-	To         []string // 收件人（"Name <email>" 或 "email"）
-	CC         []string
-	BCC        []string
-	Subject    string
-	BodyText   string // 纯文本 body
-	BodyHTML   string // HTML body（与 BodyText 互斥，同时提供时优先 HTML）
-	InReplyTo  string // 回复场景：原邮件的 Message-ID header
-	References string // 回复场景：原邮件的 References header
+	From         string   // 发件人邮箱地址
+	FromName     string   // 发件人显示名
+	To           []string // 收件人（"Name <email>" 或 "email"）
+	CC           []string
+	BCC          []string
+	Subject      string
+	BodyText     string // 纯文本 body
+	BodyHTML     string // HTML body（与 BodyText 互斥，同时提供时优先 HTML）
+	InReplyTo    string // 回复场景：原邮件的 Message-ID header
+	References   string // 回复场景：原邮件的 References header
+	InlineImages []inlineImagePart
+}
+
+// inlineImagePart 内嵌图片 part（用于 multipart/related）
+// CID 不包 "<>"；Filename 为附件展示名；Bytes 是 raw 内容；MIME 是 Content-Type
+type inlineImagePart struct {
+	CID      string
+	Filename string
+	Bytes    []byte
+	MIME     string
 }
 
 // buildEMLBase64URL 构造一个符合 RFC 5322 的 EML，base64 URL-safe 编码
@@ -67,7 +88,40 @@ func buildEMLBase64URL(input mailMessageInput) (string, error) {
 	}
 
 	// Body
-	if strings.TrimSpace(input.BodyHTML) != "" {
+	hasInline := strings.TrimSpace(input.BodyHTML) != "" && len(input.InlineImages) > 0
+	if hasInline {
+		// multipart/related：HTML body + 内嵌图片
+		boundary, berr := mailBoundary()
+		if berr != nil {
+			return "", berr
+		}
+		fmt.Fprintf(&b, "Content-Type: multipart/related; boundary=\"%s\"\r\n\r\n", boundary)
+		// HTML part
+		fmt.Fprintf(&b, "--%s\r\n", boundary)
+		b.WriteString("Content-Type: text/html; charset=\"UTF-8\"\r\n")
+		b.WriteString("Content-Transfer-Encoding: base64\r\n\r\n")
+		b.WriteString(base64Encode([]byte(input.BodyHTML)))
+		b.WriteString("\r\n")
+		// 每张内嵌图片
+		for _, img := range input.InlineImages {
+			fmt.Fprintf(&b, "--%s\r\n", boundary)
+			mime := img.MIME
+			if mime == "" {
+				mime = "application/octet-stream"
+			}
+			fname := img.Filename
+			if fname == "" {
+				fname = img.CID
+			}
+			fmt.Fprintf(&b, "Content-Type: %s; name=\"%s\"\r\n", mime, fname)
+			b.WriteString("Content-Transfer-Encoding: base64\r\n")
+			fmt.Fprintf(&b, "Content-ID: <%s>\r\n", img.CID)
+			fmt.Fprintf(&b, "Content-Disposition: inline; filename=\"%s\"\r\n\r\n", fname)
+			b.WriteString(base64Encode(img.Bytes))
+			b.WriteString("\r\n")
+		}
+		fmt.Fprintf(&b, "--%s--\r\n", boundary)
+	} else if strings.TrimSpace(input.BodyHTML) != "" {
 		b.WriteString("Content-Type: text/html; charset=\"UTF-8\"\r\n")
 		b.WriteString("Content-Transfer-Encoding: base64\r\n\r\n")
 		b.WriteString(base64Encode([]byte(input.BodyHTML)))

--- a/cmd/mail_common.go
+++ b/cmd/mail_common.go
@@ -89,8 +89,15 @@ func buildEMLBase64URL(input mailMessageInput) (string, error) {
 
 	// Body
 	hasInline := strings.TrimSpace(input.BodyHTML) != "" && len(input.InlineImages) > 0
+	// 防御性：有内嵌图片但 HTML body 为空时直接报错，避免静默丢弃 InlineImages
+	if len(input.InlineImages) > 0 && strings.TrimSpace(input.BodyHTML) == "" {
+		return "", fmt.Errorf("内嵌图片需要 HTML body（BodyHTML 为空时 InlineImages 会被静默丢弃）")
+	}
 	if hasInline {
 		// multipart/related：HTML body + 内嵌图片
+		// RFC 2046 §5.1.1: 每个 boundary delimiter line 前面必须有一个 CRLF，
+		// 该 CRLF 在概念上属于 boundary 而非 preceding part body。
+		// 实现上：每个 part body 后写 "\r\n\r\n"（结尾 CRLF + 分隔空行）再跟 boundary 行。
 		boundary, berr := mailBoundary()
 		if berr != nil {
 			return "", berr
@@ -101,7 +108,7 @@ func buildEMLBase64URL(input mailMessageInput) (string, error) {
 		b.WriteString("Content-Type: text/html; charset=\"UTF-8\"\r\n")
 		b.WriteString("Content-Transfer-Encoding: base64\r\n\r\n")
 		b.WriteString(base64Encode([]byte(input.BodyHTML)))
-		b.WriteString("\r\n")
+		b.WriteString("\r\n\r\n")
 		// 每张内嵌图片
 		for _, img := range input.InlineImages {
 			fmt.Fprintf(&b, "--%s\r\n", boundary)
@@ -118,7 +125,7 @@ func buildEMLBase64URL(input mailMessageInput) (string, error) {
 			fmt.Fprintf(&b, "Content-ID: <%s>\r\n", img.CID)
 			fmt.Fprintf(&b, "Content-Disposition: inline; filename=\"%s\"\r\n\r\n", fname)
 			b.WriteString(base64Encode(img.Bytes))
-			b.WriteString("\r\n")
+			b.WriteString("\r\n\r\n")
 		}
 		fmt.Fprintf(&b, "--%s--\r\n", boundary)
 	} else if strings.TrimSpace(input.BodyHTML) != "" {

--- a/cmd/mail_inline.go
+++ b/cmd/mail_inline.go
@@ -1,0 +1,80 @@
+package cmd
+
+import (
+	"fmt"
+	"path/filepath"
+
+	"github.com/riba2534/feishu-cli/internal/auth"
+	"github.com/riba2534/feishu-cli/internal/client"
+)
+
+// scanAndUploadInlineImages 是 --inline-images-auto-scan 的内部实现
+// 步骤:
+//  1. 解析 HTML body 中所有 <img src="local-path">（跳过 cid:/http:/https:/data: 等已有 scheme）
+//  2. 解析当前登录用户的 open_id（drive upload 的 parent_node 要求 user open_id）
+//  3. 每张图生成 CID，读盘 → drive upload (parent_type=email) → 拿 file_token
+//  4. 回填 inlineImagePart 列表，并把 body 中 src 改写为 cid:xxx
+//
+// 失败行为: 任何一步出错都返回 error，调用方应中止（不发送脏 body）
+func scanAndUploadInlineImages(htmlBody, mailboxID, userToken string) (string, []inlineImagePart, error) {
+	rawSrcs := client.ScanInlineImagePaths(htmlBody)
+	if len(rawSrcs) == 0 {
+		return htmlBody, nil, nil
+	}
+
+	// 解析 open_id：drive upload parent_node 必填
+	openID, err := resolveCurrentUserOpenID()
+	if err != nil {
+		return "", nil, fmt.Errorf("--inline-images-auto-scan 需要 open_id：%w", err)
+	}
+
+	refs := make([]client.MailInlineImageRef, 0, len(rawSrcs))
+	parts := make([]inlineImagePart, 0, len(rawSrcs))
+
+	for _, src := range rawSrcs {
+		cid, err := client.GenerateMailCID()
+		if err != nil {
+			return "", nil, err
+		}
+		ref := client.MailInlineImageRef{
+			RawSrc:    src,
+			LocalPath: src,
+			CID:       cid,
+			FileName:  filepath.Base(src),
+		}
+		// 读盘填充 bytes/mime（multipart/related part 必需）
+		if loadErr := client.LoadInlineImageBytes(&ref); loadErr != nil {
+			return "", nil, fmt.Errorf("内嵌图片 %s: %w", src, loadErr)
+		}
+		// 上传到飞书云盘（parent_type=email）
+		fileToken, upErr := client.UploadMailInlineImage(ref.LocalPath, ref.FileName, openID, userToken)
+		if upErr != nil {
+			return "", nil, fmt.Errorf("上传内嵌图片 %s 失败: %w", src, upErr)
+		}
+		ref.FileToken = fileToken
+
+		refs = append(refs, ref)
+		parts = append(parts, inlineImagePart{
+			CID:      ref.CID,
+			Filename: ref.FileName,
+			Bytes:    ref.Bytes,
+			MIME:     ref.MIME,
+		})
+	}
+
+	rewritten := client.ReplaceInlineImageSrc(htmlBody, refs)
+	return rewritten, parts, nil
+}
+
+// resolveCurrentUserOpenID 从 ~/.feishu-cli/user_profile.json 读出当前登录用户 open_id
+// 没有缓存或为空时返回明确错误，提示用户先 auth login
+func resolveCurrentUserOpenID() (string, error) {
+	cache, err := auth.LoadCurrentUserCache()
+	if err != nil {
+		return "", err
+	}
+	if cache == nil || cache.OpenID == "" {
+		return "", fmt.Errorf("未找到当前用户 open_id，请先执行 `feishu-cli auth login` 完成登录")
+	}
+	return cache.OpenID, nil
+}

--- a/cmd/mail_inline_test.go
+++ b/cmd/mail_inline_test.go
@@ -1,0 +1,150 @@
+package cmd
+
+import (
+	"encoding/base64"
+	"strings"
+	"testing"
+
+	"github.com/riba2534/feishu-cli/internal/client"
+)
+
+// TestMailScanInlineImagePaths_BasicAndSchemeSkip 验证扫描器:
+//  1. 抓 <img src="本地路径">
+//  2. 跳过 cid:/http:/data:/// scheme
+//  3. 重复路径只返回一次
+func TestMailScanInlineImagePaths_BasicAndSchemeSkip(t *testing.T) {
+	html := `
+		<p>hi</p>
+		<img src="./a.png">
+		<IMG SRC='b.jpg'>
+		<img src="http://cdn/x.png">
+		<img src="cid:already">
+		<img src="data:image/png;base64,xxxx">
+		<img src="//cdn/y.png">
+		<img src="./a.png">
+	`
+	got := client.ScanInlineImagePaths(html)
+	want := []string{"./a.png", "b.jpg"}
+	if len(got) != len(want) {
+		t.Fatalf("ScanInlineImagePaths: got %d items %v, want %d %v", len(got), got, len(want), want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Errorf("[%d] got %q, want %q", i, got[i], want[i])
+		}
+	}
+}
+
+// TestMailReplaceInlineImageSrc 验证 src 被替换为 cid:xxx 且只替换匹配项
+func TestMailReplaceInlineImageSrc(t *testing.T) {
+	html := `<p>x</p><img src="./a.png"><img src="b.jpg"><img src="http://keep.me/y.png">`
+	refs := []client.MailInlineImageRef{
+		{RawSrc: "./a.png", CID: "cid_a"},
+		{RawSrc: "b.jpg", CID: "cid_b"},
+	}
+	out := client.ReplaceInlineImageSrc(html, refs)
+	if !strings.Contains(out, `src="cid:cid_a"`) {
+		t.Errorf("missing cid:cid_a in output: %s", out)
+	}
+	if !strings.Contains(out, `src="cid:cid_b"`) {
+		t.Errorf("missing cid:cid_b in output: %s", out)
+	}
+	if !strings.Contains(out, `src="http://keep.me/y.png"`) {
+		t.Errorf("外部 http URL 被错误改写: %s", out)
+	}
+}
+
+// TestBuildEMLBase64URL_WithInlineImages 验证 multipart/related 结构生成
+func TestBuildEMLBase64URL_WithInlineImages(t *testing.T) {
+	input := mailMessageInput{
+		From:     "me@example.com",
+		To:       []string{"a@example.com"},
+		Subject:  "test",
+		BodyHTML: `<p>x</p><img src="cid:cid_a">`,
+		InlineImages: []inlineImagePart{
+			{CID: "cid_a", Filename: "a.png", MIME: "image/png", Bytes: []byte{0x89, 0x50, 0x4e, 0x47}},
+		},
+	}
+	rawB64, err := buildEMLBase64URL(input)
+	if err != nil {
+		t.Fatalf("buildEMLBase64URL: %v", err)
+	}
+	decoded, err := base64.RawURLEncoding.DecodeString(rawB64)
+	if err != nil {
+		t.Fatalf("decode rawB64: %v", err)
+	}
+	raw := string(decoded)
+	if !strings.Contains(raw, "Content-Type: multipart/related;") {
+		t.Errorf("missing multipart/related: %s", raw)
+	}
+	if !strings.Contains(raw, "Content-ID: <cid_a>") {
+		t.Errorf("missing Content-ID <cid_a>: %s", raw)
+	}
+	if !strings.Contains(raw, "Content-Disposition: inline") {
+		t.Errorf("missing inline disposition: %s", raw)
+	}
+	if !strings.Contains(raw, "Content-Type: image/png") {
+		t.Errorf("missing image/png part header: %s", raw)
+	}
+	if !strings.Contains(raw, "Content-Type: text/html") {
+		t.Errorf("missing text/html part header: %s", raw)
+	}
+}
+
+// TestBuildEMLBase64URL_WithoutInline 没有内嵌图片时不应该走 multipart/related（保持原路径）
+func TestBuildEMLBase64URL_WithoutInline(t *testing.T) {
+	input := mailMessageInput{
+		From:     "me@example.com",
+		To:       []string{"a@example.com"},
+		Subject:  "test",
+		BodyHTML: "<p>x</p>",
+	}
+	rawB64, err := buildEMLBase64URL(input)
+	if err != nil {
+		t.Fatalf("buildEMLBase64URL: %v", err)
+	}
+	decoded, _ := base64.RawURLEncoding.DecodeString(rawB64)
+	raw := string(decoded)
+	if strings.Contains(raw, "multipart/related") {
+		t.Errorf("纯 HTML body 不应使用 multipart/related: %s", raw)
+	}
+	if !strings.Contains(raw, "Content-Type: text/html") {
+		t.Errorf("missing text/html: %s", raw)
+	}
+}
+
+// TestToMailTemplateAddrs 验证 "Name <email>" 拆分
+func TestToMailTemplateAddrs(t *testing.T) {
+	in := []string{"Alice <a@example.com>", "b@example.com", "  ", "Bob<b2@example.com>"}
+	got := toMailTemplateAddrs(in)
+	if len(got) != 3 {
+		t.Fatalf("len=%d, want 3, got=%+v", len(got), got)
+	}
+	if got[0].Name != "Alice" || got[0].MailAddress != "a@example.com" {
+		t.Errorf("[0] %+v", got[0])
+	}
+	if got[1].Name != "" || got[1].MailAddress != "b@example.com" {
+		t.Errorf("[1] %+v", got[1])
+	}
+	if got[2].Name != "Bob" || got[2].MailAddress != "b2@example.com" {
+		t.Errorf("[2] %+v", got[2])
+	}
+}
+
+// TestGenerateMailCID 验证 CID 长度且唯一
+func TestGenerateMailCID(t *testing.T) {
+	a, err := client.GenerateMailCID()
+	if err != nil {
+		t.Fatalf("GenerateMailCID: %v", err)
+	}
+	b, err := client.GenerateMailCID()
+	if err != nil {
+		t.Fatalf("GenerateMailCID: %v", err)
+	}
+	if a == b {
+		t.Errorf("two CIDs should differ: %s == %s", a, b)
+	}
+	if len(a) != 20 {
+		t.Errorf("CID length should be 20 hex chars, got %d (%q)", len(a), a)
+	}
+}

--- a/cmd/mail_inline_test.go
+++ b/cmd/mail_inline_test.go
@@ -91,6 +91,55 @@ func TestBuildEMLBase64URL_WithInlineImages(t *testing.T) {
 	}
 }
 
+// TestBuildEMLBase64URL_MultipartCRLFSeparator 验证 RFC 2046 §5.1.1 要求：
+// 每个 boundary delimiter line 前必须有一个 CRLF（独立于 part body 内容）
+// 即 body 末尾必须出现 "\r\n\r\n--boundary" 而非紧贴 "<base64>\r\n--boundary"
+func TestBuildEMLBase64URL_MultipartCRLFSeparator(t *testing.T) {
+	input := mailMessageInput{
+		From:     "me@example.com",
+		To:       []string{"a@example.com"},
+		Subject:  "test",
+		BodyHTML: `<p>x</p><img src="cid:cid_a">`,
+		InlineImages: []inlineImagePart{
+			{CID: "cid_a", Filename: "a.png", MIME: "image/png", Bytes: []byte{0x89, 0x50, 0x4e, 0x47}},
+			{CID: "cid_b", Filename: "b.png", MIME: "image/png", Bytes: []byte{0x89, 0x50, 0x4e, 0x48}},
+		},
+	}
+	rawB64, err := buildEMLBase64URL(input)
+	if err != nil {
+		t.Fatalf("buildEMLBase64URL: %v", err)
+	}
+	decoded, _ := base64.RawURLEncoding.DecodeString(rawB64)
+	raw := string(decoded)
+	// boundary delimiter 之前必须是 "\r\n\r\n"（part body 结尾 CRLF + 空行）
+	// 数 "\r\n\r\n--" 的出现次数：应该 ≥ part 数（HTML + 2 inline = 3 个分隔）
+	cnt := strings.Count(raw, "\r\n\r\n--")
+	if cnt < 3 {
+		t.Errorf("RFC 2046 CRLF 分隔不足：got %d 次 `\\r\\n\\r\\n--`，want ≥3\nraw=%q", cnt, raw)
+	}
+}
+
+// TestBuildEMLBase64URL_InlineWithoutHTMLRejected 验证 InlineImages 非空但 HTML body 为空时报错
+// 防御性断言：避免静默丢弃 InlineImages
+func TestBuildEMLBase64URL_InlineWithoutHTMLRejected(t *testing.T) {
+	input := mailMessageInput{
+		From:     "me@example.com",
+		To:       []string{"a@example.com"},
+		Subject:  "test",
+		BodyText: "plain only",
+		InlineImages: []inlineImagePart{
+			{CID: "cid_a", Filename: "a.png", MIME: "image/png", Bytes: []byte{0x89}},
+		},
+	}
+	_, err := buildEMLBase64URL(input)
+	if err == nil {
+		t.Fatal("应当报错：InlineImages 非空但 BodyHTML 为空")
+	}
+	if !strings.Contains(err.Error(), "HTML") {
+		t.Errorf("错误信息未提到 HTML body 要求: %v", err)
+	}
+}
+
 // TestBuildEMLBase64URL_WithoutInline 没有内嵌图片时不应该走 multipart/related（保持原路径）
 func TestBuildEMLBase64URL_WithoutInline(t *testing.T) {
 	input := mailMessageInput{

--- a/cmd/mail_send.go
+++ b/cmd/mail_send.go
@@ -18,7 +18,7 @@ var mailSendCmd = &cobra.Command{
   1. 默认: 构造 EML 并保存为草稿，返回 draft_id
   2. --confirm-send: 保存草稿后立即发送，返回 message_id
 
-⚠️ 首期限制: 仅支持纯文本 body 和 HTML body（body 含 HTML 标签自动检测），不支持附件和 CID 内联图片。
+⚠️ 首期限制: 暂不支持普通附件；CID 内联图片走 --inline-images-auto-scan 自动扫描上传。
 
 必填:
   --to        收件人（逗号分隔多个地址，支持 "Name <email>" 或 "email"）
@@ -26,13 +26,14 @@ var mailSendCmd = &cobra.Command{
   --body      正文（自动检测纯文本/HTML）
 
 可选:
-  --cc / --bcc    抄送/密送
-  --from          发件人地址（默认使用登录账号的 primary_email_address）
-  --from-name     发件人显示名
-  --mailbox       邮箱 ID（默认 me）
-  --confirm-send  保存草稿后立即发送
-  --html          强制视为 HTML（即使不含 HTML 标签）
-  --plain-text    强制视为纯文本
+  --cc / --bcc                   抄送/密送
+  --from                         发件人地址（默认使用登录账号的 primary_email_address）
+  --from-name                    发件人显示名
+  --mailbox                      邮箱 ID（默认 me）
+  --confirm-send                 保存草稿后立即发送
+  --html                         强制视为 HTML（即使不含 HTML 标签）
+  --plain-text                   强制视为纯文本
+  --inline-images-auto-scan      扫描 HTML 中 <img src="本地路径"> → 上传到飞书云盘 → 改写为 cid: 引用
 
 权限:
   - User Access Token
@@ -62,6 +63,7 @@ var mailSendCmd = &cobra.Command{
 		confirmSend, _ := cmd.Flags().GetBool("confirm-send")
 		forceHTML, _ := cmd.Flags().GetBool("html")
 		plainText, _ := cmd.Flags().GetBool("plain-text")
+		autoScanInline, _ := cmd.Flags().GetBool("inline-images-auto-scan")
 		output, _ := cmd.Flags().GetString("output")
 
 		to, err := parseEmailList(toRaw)
@@ -109,6 +111,17 @@ var mailSendCmd = &cobra.Command{
 			input.BodyHTML = body
 		} else {
 			input.BodyText = body
+		}
+
+		// --inline-images-auto-scan: 扫 <img src="local-path"> → drive 上传 → 改写为 cid:xxx
+		// 仅在 HTML body 下生效；纯文本下跳过
+		if autoScanInline && input.BodyHTML != "" {
+			rewritten, parts, scanErr := scanAndUploadInlineImages(input.BodyHTML, mailbox, token)
+			if scanErr != nil {
+				return scanErr
+			}
+			input.BodyHTML = rewritten
+			input.InlineImages = parts
 		}
 
 		rawB64, err := buildEMLBase64URL(input)
@@ -182,6 +195,7 @@ func init() {
 	mailSendCmd.Flags().Bool("confirm-send", false, "保存草稿后立即发送")
 	mailSendCmd.Flags().Bool("html", false, "强制视为 HTML body")
 	mailSendCmd.Flags().Bool("plain-text", false, "强制视为纯文本")
+	mailSendCmd.Flags().Bool("inline-images-auto-scan", false, "扫描 HTML body 中 <img src=\"local-path\"> 自动上传飞书云盘并改写为 cid: 引用")
 	mailSendCmd.Flags().StringP("output", "o", "", "输出格式（json）")
 	mailSendCmd.Flags().String("user-access-token", "", "User Access Token（覆盖登录态）")
 	mustMarkFlagRequired(mailSendCmd, "to", "subject", "body")

--- a/cmd/mail_template.go
+++ b/cmd/mail_template.go
@@ -1,0 +1,32 @@
+package cmd
+
+import (
+	"github.com/spf13/cobra"
+)
+
+// mailTemplateCmd 邮件模板命令组（template create/list 等）
+var mailTemplateCmd = &cobra.Command{
+	Use:   "template",
+	Short: "邮件模板（templates）操作",
+	Long: `飞书邮箱个人邮件模板（template）管理。
+
+子命令:
+  create   创建邮件模板
+  list     列出当前邮箱下的全部模板
+
+权限要求（User Access Token）:
+  - mail:user_mailbox:readonly
+  - mail:user_mailbox.message:modify
+  - mail:user.email.template（部分租户需单独申请；字节租户该 scope 暂未开放）
+
+⚠️ 字节租户该 scope 目前尚未对外开放，命令调用可能返回 401/scope 校验失败；
+   功能已实现完整，等飞书侧开放 scope 后即可使用。
+
+示例:
+  feishu-cli mail template create --name "周报" --subject "本周进度" --body "..."
+  feishu-cli mail template list`,
+}
+
+func init() {
+	mailCmd.AddCommand(mailTemplateCmd)
+}

--- a/cmd/mail_template_create.go
+++ b/cmd/mail_template_create.go
@@ -1,0 +1,147 @@
+package cmd
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/riba2534/feishu-cli/internal/client"
+	"github.com/riba2534/feishu-cli/internal/config"
+	"github.com/spf13/cobra"
+)
+
+var mailTemplateCreateCmd = &cobra.Command{
+	Use:   "create",
+	Short: "创建邮件模板（personal mail template）",
+	Long: `创建一个个人邮件模板，可在 mail send --template-id 引用复用。
+
+必填:
+  --name        模板名（≤ 100 字符）
+
+可选:
+  --subject     默认主题
+  --body        默认正文（含 HTML/纯文本；不会扫内嵌图片 — 模板内嵌图请走专用流程）
+  --plain-text  纯文本模式（is_plain_text_mode=true）
+  --to          默认收件人列表（逗号分隔）
+  --cc          默认抄送
+  --bcc         默认密送
+  --mailbox     邮箱 ID（默认 me）
+
+权限:
+  - User Access Token
+  - mail:user_mailbox.message:modify / mail:user_mailbox:readonly
+  - mail:user.email.template（字节租户暂未开放）
+
+示例:
+  feishu-cli mail template create --name "周报" --subject "本周进度" \
+      --body "<p>这是模板</p>" --to lead@example.com`,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		if err := config.Validate(); err != nil {
+			return err
+		}
+		token, err := requireUserToken(cmd, "mail template create")
+		if err != nil {
+			return err
+		}
+		name, _ := cmd.Flags().GetString("name")
+		if strings.TrimSpace(name) == "" {
+			return fmt.Errorf("--name 必填")
+		}
+		if len([]rune(name)) > 100 {
+			return fmt.Errorf("--name 长度不能超过 100 个字符")
+		}
+		subject, _ := cmd.Flags().GetString("subject")
+		body, _ := cmd.Flags().GetString("body")
+		plainText, _ := cmd.Flags().GetBool("plain-text")
+		mailbox, _ := cmd.Flags().GetString("mailbox")
+		toRaw, _ := cmd.Flags().GetString("to")
+		ccRaw, _ := cmd.Flags().GetString("cc")
+		bccRaw, _ := cmd.Flags().GetString("bcc")
+		output, _ := cmd.Flags().GetString("output")
+
+		toList, err := parseEmailList(toRaw)
+		if err != nil {
+			return err
+		}
+		ccList, err := parseEmailList(ccRaw)
+		if err != nil {
+			return err
+		}
+		bccList, err := parseEmailList(bccRaw)
+		if err != nil {
+			return err
+		}
+
+		tpl := &client.MailTemplate{
+			Name:            name,
+			Subject:         subject,
+			TemplateContent: body,
+			IsPlainTextMode: plainText,
+			Tos:             toMailTemplateAddrs(toList),
+			Ccs:             toMailTemplateAddrs(ccList),
+			Bccs:            toMailTemplateAddrs(bccList),
+		}
+
+		created, err := client.CreateMailTemplate(mailbox, tpl, token)
+		if err != nil {
+			return fmt.Errorf("创建邮件模板失败: %w", err)
+		}
+
+		result := map[string]any{
+			"template_id":        created.TemplateID,
+			"name":               created.Name,
+			"subject":            created.Subject,
+			"is_plain_text_mode": created.IsPlainTextMode,
+		}
+		if output == "json" {
+			return printJSON(result)
+		}
+		fmt.Printf("邮件模板已创建:\n")
+		fmt.Printf("  template_id: %s\n", created.TemplateID)
+		fmt.Printf("  name:        %s\n", created.Name)
+		if created.Subject != "" {
+			fmt.Printf("  subject:     %s\n", created.Subject)
+		}
+		return nil
+	},
+}
+
+// toMailTemplateAddrs 把 "Name <email>" / "email" 列表转为 MailTemplateAddr
+func toMailTemplateAddrs(addrs []string) []client.MailTemplateAddr {
+	if len(addrs) == 0 {
+		return nil
+	}
+	out := make([]client.MailTemplateAddr, 0, len(addrs))
+	for _, raw := range addrs {
+		raw = strings.TrimSpace(raw)
+		if raw == "" {
+			continue
+		}
+		// "Name <email>" 拆 name / address
+		if open := strings.Index(raw, "<"); open >= 0 {
+			close := strings.LastIndex(raw, ">")
+			if close > open {
+				name := strings.TrimSpace(raw[:open])
+				addr := strings.TrimSpace(raw[open+1 : close])
+				out = append(out, client.MailTemplateAddr{MailAddress: addr, Name: name})
+				continue
+			}
+		}
+		out = append(out, client.MailTemplateAddr{MailAddress: raw})
+	}
+	return out
+}
+
+func init() {
+	mailTemplateCmd.AddCommand(mailTemplateCreateCmd)
+	mailTemplateCreateCmd.Flags().String("name", "", "模板名（必填，≤ 100 字符）")
+	mailTemplateCreateCmd.Flags().String("subject", "", "默认主题")
+	mailTemplateCreateCmd.Flags().String("body", "", "默认正文（HTML 或纯文本）")
+	mailTemplateCreateCmd.Flags().Bool("plain-text", false, "纯文本模式")
+	mailTemplateCreateCmd.Flags().String("to", "", "默认收件人，逗号分隔")
+	mailTemplateCreateCmd.Flags().String("cc", "", "默认抄送")
+	mailTemplateCreateCmd.Flags().String("bcc", "", "默认密送")
+	mailTemplateCreateCmd.Flags().String("mailbox", "me", "邮箱 ID（默认 me）")
+	mailTemplateCreateCmd.Flags().StringP("output", "o", "", "输出格式（json）")
+	mailTemplateCreateCmd.Flags().String("user-access-token", "", "User Access Token（覆盖登录态）")
+	mustMarkFlagRequired(mailTemplateCreateCmd, "name")
+}

--- a/cmd/mail_template_list.go
+++ b/cmd/mail_template_list.go
@@ -1,0 +1,69 @@
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/riba2534/feishu-cli/internal/client"
+	"github.com/riba2534/feishu-cli/internal/config"
+	"github.com/spf13/cobra"
+)
+
+var mailTemplateListCmd = &cobra.Command{
+	Use:   "list",
+	Short: "列出当前邮箱下的全部邮件模板",
+	Long: `列出指定邮箱（默认 me）下的全部个人邮件模板。
+
+注意: 该 OpenAPI 不分页，会一次性返回所有模板的 id 与 name。
+
+可选:
+  --mailbox  邮箱 ID（默认 me）
+  -o json    JSON 输出
+
+权限:
+  - User Access Token
+  - mail:user_mailbox:readonly
+  - mail:user.email.template（字节租户暂未开放）
+
+示例:
+  feishu-cli mail template list
+  feishu-cli mail template list -o json`,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		if err := config.Validate(); err != nil {
+			return err
+		}
+		token, err := requireUserToken(cmd, "mail template list")
+		if err != nil {
+			return err
+		}
+		mailbox, _ := cmd.Flags().GetString("mailbox")
+		output, _ := cmd.Flags().GetString("output")
+
+		list, err := client.ListMailTemplates(mailbox, token)
+		if err != nil {
+			return fmt.Errorf("列出邮件模板失败: %w", err)
+		}
+
+		if output == "json" {
+			return printJSON(map[string]any{
+				"templates": list,
+				"total":     len(list),
+			})
+		}
+		if len(list) == 0 {
+			fmt.Println("当前邮箱下没有任何邮件模板。")
+			return nil
+		}
+		fmt.Printf("共 %d 个邮件模板:\n", len(list))
+		for i, t := range list {
+			fmt.Printf("  %d. [%s] %s\n", i+1, t.TemplateID, t.Name)
+		}
+		return nil
+	},
+}
+
+func init() {
+	mailTemplateCmd.AddCommand(mailTemplateListCmd)
+	mailTemplateListCmd.Flags().String("mailbox", "me", "邮箱 ID（默认 me）")
+	mailTemplateListCmd.Flags().StringP("output", "o", "", "输出格式（json）")
+	mailTemplateListCmd.Flags().String("user-access-token", "", "User Access Token（覆盖登录态）")
+}

--- a/internal/client/mail_advanced.go
+++ b/internal/client/mail_advanced.go
@@ -1,0 +1,280 @@
+package client
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/url"
+	"strings"
+)
+
+// ==================== 邮件模板 ====================
+
+// MailTemplateAddr 模板的发件人/收件人地址（snake_case 与 OpenAPI 对齐）
+type MailTemplateAddr struct {
+	MailAddress string `json:"mail_address"`
+	Name        string `json:"name,omitempty"`
+}
+
+// MailTemplateAttachment 模板附件结构
+// body 是后端强制必填字段，否则会返回 99992402；对于已上传到云盘的文件，
+// id 与 body 共用同一份 file_key 即可满足校验
+type MailTemplateAttachment struct {
+	ID             string `json:"id,omitempty"`
+	Filename       string `json:"filename,omitempty"`
+	CID            string `json:"cid,omitempty"`
+	IsInline       bool   `json:"is_inline"`
+	AttachmentType int    `json:"attachment_type,omitempty"` // 1=SMALL, 2=LARGE
+	Body           string `json:"body"`
+}
+
+// MailTemplate 个人邮件模板（用于 templates.create / update / get）
+type MailTemplate struct {
+	TemplateID      string                   `json:"template_id,omitempty"`
+	Name            string                   `json:"name"`
+	Subject         string                   `json:"subject,omitempty"`
+	TemplateContent string                   `json:"template_content,omitempty"`
+	IsPlainTextMode bool                     `json:"is_plain_text_mode"`
+	Tos             []MailTemplateAddr       `json:"tos,omitempty"`
+	Ccs             []MailTemplateAddr       `json:"ccs,omitempty"`
+	Bccs            []MailTemplateAddr       `json:"bccs,omitempty"`
+	Attachments     []MailTemplateAttachment `json:"attachments,omitempty"`
+	CreateTime      string                   `json:"create_time,omitempty"`
+}
+
+// templatePath 构造模板 API 路径
+// /open-apis/mail/v1/user_mailboxes/{mailbox_id}/templates[/{template_id}]
+func templatePath(mailboxID string, segments ...string) string {
+	if mailboxID == "" {
+		mailboxID = "me"
+	}
+	parts := []string{url.PathEscape(mailboxID), "templates"}
+	for _, s := range segments {
+		if s == "" {
+			continue
+		}
+		parts = append(parts, url.PathEscape(s))
+	}
+	return mailBase + "/user_mailboxes/" + strings.Join(parts, "/")
+}
+
+// CreateMailTemplate 创建个人邮件模板
+// API: POST /open-apis/mail/v1/user_mailboxes/{mailbox_id}/templates
+// 请求体形如 {"template": {...}}，响应也包在 "template" 下
+func CreateMailTemplate(mailboxID string, tpl *MailTemplate, userAccessToken string) (*MailTemplate, error) {
+	body := map[string]any{"template": tpl}
+	data, err := callMailAPI(http.MethodPost, templatePath(mailboxID), body, userAccessToken)
+	if err != nil {
+		return nil, err
+	}
+	return extractTemplate(data)
+}
+
+// UpdateMailTemplate 全量替换式更新模板（无乐观锁，last-write-wins）
+// API: PUT /open-apis/mail/v1/user_mailboxes/{mailbox_id}/templates/{template_id}
+func UpdateMailTemplate(mailboxID, templateID string, tpl *MailTemplate, userAccessToken string) (*MailTemplate, error) {
+	body := map[string]any{"template": tpl}
+	data, err := callMailAPI(http.MethodPut, templatePath(mailboxID, templateID), body, userAccessToken)
+	if err != nil {
+		return nil, err
+	}
+	return extractTemplate(data)
+}
+
+// GetMailTemplate 获取模板详情
+// API: GET /open-apis/mail/v1/user_mailboxes/{mailbox_id}/templates/{template_id}
+func GetMailTemplate(mailboxID, templateID, userAccessToken string) (*MailTemplate, error) {
+	data, err := callMailAPI(http.MethodGet, templatePath(mailboxID, templateID), nil, userAccessToken)
+	if err != nil {
+		return nil, err
+	}
+	return extractTemplate(data)
+}
+
+// DeleteMailTemplate 删除模板
+// API: DELETE /open-apis/mail/v1/user_mailboxes/{mailbox_id}/templates/{template_id}
+func DeleteMailTemplate(mailboxID, templateID, userAccessToken string) error {
+	_, err := callMailAPI(http.MethodDelete, templatePath(mailboxID, templateID), nil, userAccessToken)
+	return err
+}
+
+// MailTemplateBrief 列表返回的精简结构（接口本身不分页，只返回 id/name）
+type MailTemplateBrief struct {
+	TemplateID string `json:"template_id"`
+	Name       string `json:"name"`
+}
+
+// ListMailTemplates 列出指定邮箱下的全部个人邮件模板
+// API: GET /open-apis/mail/v1/user_mailboxes/{mailbox_id}/templates
+// 注意：接口不分页，返回所有模板的 id 与 name
+func ListMailTemplates(mailboxID, userAccessToken string) ([]MailTemplateBrief, error) {
+	data, err := callMailAPI(http.MethodGet, templatePath(mailboxID), nil, userAccessToken)
+	if err != nil {
+		return nil, err
+	}
+	var parsed struct {
+		Templates []MailTemplateBrief `json:"templates"`
+		Items     []MailTemplateBrief `json:"items"`
+	}
+	if err := json.Unmarshal(data, &parsed); err != nil {
+		return nil, fmt.Errorf("解析模板列表失败: %w", err)
+	}
+	if len(parsed.Templates) > 0 {
+		return parsed.Templates, nil
+	}
+	return parsed.Items, nil
+}
+
+// extractTemplate 从响应里取出 "template" 包装的对象
+func extractTemplate(data json.RawMessage) (*MailTemplate, error) {
+	var parsed struct {
+		Template *MailTemplate `json:"template"`
+	}
+	if err := json.Unmarshal(data, &parsed); err != nil {
+		return nil, fmt.Errorf("解析模板响应失败: %w", err)
+	}
+	if parsed.Template == nil {
+		// 有些场景直接返回顶层对象（如自定义 mock），兜底解析
+		var direct MailTemplate
+		if err := json.Unmarshal(data, &direct); err == nil && direct.TemplateID != "" {
+			return &direct, nil
+		}
+		return nil, fmt.Errorf("响应中未找到 template 字段")
+	}
+	return parsed.Template, nil
+}
+
+// ==================== 已读回执 ====================
+
+// ModifyMailMessage 修改邮件（添加/移除 label）
+// API: PUT /open-apis/mail/v1/user_mailboxes/{mailbox_id}/messages/{message_id}/modify
+func ModifyMailMessage(mailboxID, messageID string, addLabels, removeLabels []string, userAccessToken string) error {
+	if mailboxID == "" {
+		mailboxID = "me"
+	}
+	body := map[string]any{}
+	if len(addLabels) > 0 {
+		body["add_label_ids"] = addLabels
+	}
+	if len(removeLabels) > 0 {
+		body["remove_label_ids"] = removeLabels
+	}
+	_, err := callMailAPI(http.MethodPut, mailboxPath(mailboxID, "messages", messageID, "modify"), body, userAccessToken)
+	return err
+}
+
+// ==================== 分享到聊天 ====================
+
+// CreateMailShareToken 为邮件或会话生成分享 token
+// API: POST /open-apis/mail/v1/user_mailboxes/{mailbox_id}/messages/share_token
+// body 二选一：{"message_id": "xxx"} 或 {"thread_id": "xxx"}
+// 返回的 card_id 用于 SendMailShareCard
+func CreateMailShareToken(mailboxID, messageID, threadID, userAccessToken string) (string, error) {
+	if mailboxID == "" {
+		mailboxID = "me"
+	}
+	body := map[string]any{}
+	switch {
+	case threadID != "":
+		body["thread_id"] = threadID
+	case messageID != "":
+		body["message_id"] = messageID
+	default:
+		return "", fmt.Errorf("message_id / thread_id 至少一个非空")
+	}
+	data, err := callMailAPI(http.MethodPost, mailboxPath(mailboxID, "messages", "share_token"), body, userAccessToken)
+	if err != nil {
+		return "", err
+	}
+	var parsed struct {
+		CardID string `json:"card_id"`
+	}
+	if err := json.Unmarshal(data, &parsed); err != nil {
+		return "", fmt.Errorf("解析 share_token 响应失败: %w", err)
+	}
+	if parsed.CardID == "" {
+		return "", fmt.Errorf("响应中未返回 card_id")
+	}
+	return parsed.CardID, nil
+}
+
+// SendMailShareCard 把分享 token 投递到指定 IM 会话
+// API: POST /open-apis/mail/v1/user_mailboxes/{mailbox_id}/share_tokens/{card_id}/send?receive_id_type={type}
+// receiveIDType: chat_id | open_id | user_id | union_id | email
+// 返回 IM message_id（投递后的卡片消息 ID）
+func SendMailShareCard(mailboxID, cardID, receiveID, receiveIDType, userAccessToken string) (string, error) {
+	if mailboxID == "" {
+		mailboxID = "me"
+	}
+	if receiveIDType == "" {
+		receiveIDType = "chat_id"
+	}
+	apiPath := mailboxPath(mailboxID, "share_tokens", cardID, "send") + "?receive_id_type=" + url.QueryEscape(receiveIDType)
+	body := map[string]any{"receive_id": receiveID}
+	data, err := callMailAPI(http.MethodPost, apiPath, body, userAccessToken)
+	if err != nil {
+		return "", err
+	}
+	var parsed struct {
+		MessageID string `json:"message_id"`
+	}
+	if err := json.Unmarshal(data, &parsed); err != nil {
+		return "", fmt.Errorf("解析 share send 响应失败: %w", err)
+	}
+	return parsed.MessageID, nil
+}
+
+// ==================== 邮箱事件订阅（watch） ====================
+
+// SubscribeMailEvent 订阅邮箱事件（watch 启动前必须调用一次）
+// API: POST /open-apis/mail/v1/user_mailboxes/{mailbox_id}/event/subscribe
+// event_type: 1 = message_received（推送新邮件事件）
+func SubscribeMailEvent(mailboxID string, eventType int, userAccessToken string) error {
+	if mailboxID == "" {
+		mailboxID = "me"
+	}
+	if eventType == 0 {
+		eventType = 1
+	}
+	_, err := callMailAPI(http.MethodPost, mailboxPath(mailboxID, "event", "subscribe"),
+		map[string]any{"event_type": eventType}, userAccessToken)
+	return err
+}
+
+// UnsubscribeMailEvent 取消订阅邮箱事件（watch 退出时调用）
+// API: POST /open-apis/mail/v1/user_mailboxes/{mailbox_id}/event/unsubscribe
+func UnsubscribeMailEvent(mailboxID string, eventType int, userAccessToken string) error {
+	if mailboxID == "" {
+		mailboxID = "me"
+	}
+	if eventType == 0 {
+		eventType = 1
+	}
+	_, err := callMailAPI(http.MethodPost, mailboxPath(mailboxID, "event", "unsubscribe"),
+		map[string]any{"event_type": eventType}, userAccessToken)
+	return err
+}
+
+// GetMailEventSubscription 查询邮箱事件订阅状态
+// API: GET /open-apis/mail/v1/user_mailboxes/{mailbox_id}/event/subscription
+func GetMailEventSubscription(mailboxID, userAccessToken string) (json.RawMessage, error) {
+	if mailboxID == "" {
+		mailboxID = "me"
+	}
+	return callMailAPI(http.MethodGet, mailboxPath(mailboxID, "event", "subscription"), nil, userAccessToken)
+}
+
+// ==================== CID 上传辅助（内嵌图片） ====================
+
+// UploadMailInlineImage 上传一张内嵌图片到云盘并返回 file_token
+// parent_type 固定 "email"，与模板/大附件链路对齐
+// userOpenID 必填：飞书要求 email 上下文的 ParentNode 是 user open_id
+//
+// 复用 drive.UploadMedia（SDK v3 的 UploadAll），parent_type=email 走内嵌图片场景
+func UploadMailInlineImage(filePath, fileName, userOpenID, userAccessToken string) (string, error) {
+	fileToken, _, err := UploadMedia(filePath, "email", userOpenID, fileName, userAccessToken)
+	if err != nil {
+		return "", fmt.Errorf("上传内嵌图片失败: %w", err)
+	}
+	return fileToken, nil
+}

--- a/internal/client/mail_inline.go
+++ b/internal/client/mail_inline.go
@@ -35,6 +35,15 @@ var imgSrcRegexp = regexp.MustCompile(`(?i)<img\b[^>]*\bsrc\s*=\s*(?:"([^"]+)"|'
 // inlineURISchemeRegexp 检测带 scheme 的 URL（已经是 cid:/http(s):/data: 不再扫描）
 var inlineURISchemeRegexp = regexp.MustCompile(`(?i)^[a-z][a-z0-9+.\-]*:`)
 
+// isWindowsDrivePath 检测 Windows 驱动器路径（如 C:\file.png / d:/x），避免被 scheme 正则误判为 URI scheme
+func isWindowsDrivePath(s string) bool {
+	if len(s) < 2 || s[1] != ':' {
+		return false
+	}
+	c := s[0]
+	return (c >= 'A' && c <= 'Z') || (c >= 'a' && c <= 'z')
+}
+
 // ScanInlineImagePaths 扫描 HTML body 中的 <img src="local-path">，仅返回本地路径
 // 已经是 cid:/http:/https:/data: 等 scheme 的会跳过
 // 同一文件路径只返回一次（去重）
@@ -60,8 +69,9 @@ func ScanInlineImagePaths(body string) []string {
 		if strings.HasPrefix(src, "//") {
 			continue
 		}
-		// 有 scheme（http:/https:/data:/cid: ...）跳过
-		if inlineURISchemeRegexp.MatchString(src) {
+		// 有 scheme（http:/https:/data:/cid: ...）跳过；
+		// 但 Windows 驱动器路径（C:\x.png）形似 scheme，先放行视为本地路径
+		if !isWindowsDrivePath(src) && inlineURISchemeRegexp.MatchString(src) {
 			continue
 		}
 		if seen[src] {
@@ -142,10 +152,19 @@ func guessMIMEByExt(name string) string {
 // LoadInlineImageBytes 读取本地文件并填充 FileName/Bytes/MIME
 // 用于 EML builder 构造 multipart/related part；调用方可选择只用 FileToken
 // 而不读盘（如已经走 drive 上传完毕、只需 cid 替换）
+//
+// 安全：拒绝路径遍历（`..` 片段）+ 限制 abs 必须落在 cwd 或 home 子树内，
+// 防止恶意 HTML `<img src="../../.ssh/id_rsa">` 把敏感文件作为附件外发。
 func LoadInlineImageBytes(ref *MailInlineImageRef) error {
+	if err := validateInlineImagePath(ref.LocalPath); err != nil {
+		return err
+	}
 	abs, err := filepath.Abs(ref.LocalPath)
 	if err != nil {
 		return fmt.Errorf("解析路径失败 %s: %w", ref.LocalPath, err)
+	}
+	if err := assertPathInSafeRoots(abs); err != nil {
+		return err
 	}
 	data, err := os.ReadFile(abs)
 	if err != nil {
@@ -159,4 +178,50 @@ func LoadInlineImageBytes(ref *MailInlineImageRef) error {
 		ref.MIME = guessMIMEByExt(ref.FileName)
 	}
 	return nil
+}
+
+// validateInlineImagePath 拒绝任何包含 ".." 片段的路径（防路径遍历）。
+// 注意：直接拒绝 `..` 比 `filepath.Clean` 后比较更严，避免 symlink 绕过。
+func validateInlineImagePath(p string) error {
+	if p == "" {
+		return fmt.Errorf("内嵌图片路径为空")
+	}
+	// 兼容 Windows 路径，统一替换分隔符再切分
+	norm := strings.ReplaceAll(p, "\\", "/")
+	for _, seg := range strings.Split(norm, "/") {
+		if seg == ".." {
+			return fmt.Errorf("内嵌图片路径不允许包含 `..`（防路径遍历）: %s", p)
+		}
+	}
+	return nil
+}
+
+// assertPathInSafeRoots 要求 abs 必须落在当前工作目录或 user home 子树内。
+// 在没有任一根可解析时（罕见）放行，避免误伤；但 `..` 已在前一步拦截。
+func assertPathInSafeRoots(abs string) error {
+	roots := make([]string, 0, 2)
+	if cwd, err := os.Getwd(); err == nil && cwd != "" {
+		if r, err2 := filepath.Abs(cwd); err2 == nil {
+			roots = append(roots, r)
+		}
+	}
+	if home, err := os.UserHomeDir(); err == nil && home != "" {
+		if r, err2 := filepath.Abs(home); err2 == nil {
+			roots = append(roots, r)
+		}
+	}
+	if len(roots) == 0 {
+		return nil
+	}
+	for _, r := range roots {
+		// 用 filepath.Rel 兼容跨平台分隔符；rel 不含 ".." 即在子树内
+		rel, err := filepath.Rel(r, abs)
+		if err != nil {
+			continue
+		}
+		if rel == "." || (!strings.HasPrefix(rel, "..") && !filepath.IsAbs(rel)) {
+			return nil
+		}
+	}
+	return fmt.Errorf("内嵌图片路径必须落在当前目录或 home 子树内: %s", abs)
 }

--- a/internal/client/mail_inline.go
+++ b/internal/client/mail_inline.go
@@ -1,0 +1,162 @@
+package client
+
+import (
+	"crypto/rand"
+	"encoding/hex"
+	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+)
+
+// MailInlineImageRef 描述 body 中一个本地图片引用的扫描结果
+// RawSrc:     原 HTML 中 <img src="..."> 里的字面值
+// LocalPath:  解析后的绝对路径
+// CID:        生成的唯一 CID（不含 "<>" 包裹，不含 "cid:" 前缀）
+// FileToken:  上传到 drive 后返回的 file_token（用于附件回写 EML body part）
+// FileName:   原始文件名
+// Bytes:      文件内容（构造 multipart/related 时使用）
+// MIME:       内容类型（image/png 等，按扩展名兜底为 application/octet-stream）
+type MailInlineImageRef struct {
+	RawSrc    string
+	LocalPath string
+	CID       string
+	FileToken string
+	FileName  string
+	Bytes     []byte
+	MIME      string
+}
+
+// imgSrcRegexp 抓 <img ...src="...">，捕获 src 的字面值
+// 不区分大小写，兼容 <IMG SRC='...'>，单/双引号皆可
+var imgSrcRegexp = regexp.MustCompile(`(?i)<img\b[^>]*\bsrc\s*=\s*(?:"([^"]+)"|'([^']+)')[^>]*>`)
+
+// inlineURISchemeRegexp 检测带 scheme 的 URL（已经是 cid:/http(s):/data: 不再扫描）
+var inlineURISchemeRegexp = regexp.MustCompile(`(?i)^[a-z][a-z0-9+.\-]*:`)
+
+// ScanInlineImagePaths 扫描 HTML body 中的 <img src="local-path">，仅返回本地路径
+// 已经是 cid:/http:/https:/data: 等 scheme 的会跳过
+// 同一文件路径只返回一次（去重）
+func ScanInlineImagePaths(body string) []string {
+	matches := imgSrcRegexp.FindAllStringSubmatch(body, -1)
+	if len(matches) == 0 {
+		return nil
+	}
+	seen := make(map[string]bool)
+	var out []string
+	for _, m := range matches {
+		var src string
+		if len(m) >= 2 && m[1] != "" {
+			src = m[1]
+		} else if len(m) >= 3 && m[2] != "" {
+			src = m[2]
+		}
+		src = strings.TrimSpace(src)
+		if src == "" {
+			continue
+		}
+		// 协议无关 URL（//cdn.com/x.png）跳过
+		if strings.HasPrefix(src, "//") {
+			continue
+		}
+		// 有 scheme（http:/https:/data:/cid: ...）跳过
+		if inlineURISchemeRegexp.MatchString(src) {
+			continue
+		}
+		if seen[src] {
+			continue
+		}
+		seen[src] = true
+		out = append(out, src)
+	}
+	return out
+}
+
+// ReplaceInlineImageSrc 把 body 中所有匹配 rawSrc 的 <img src="rawSrc"> 替换为 cid:cid
+// 使用倒序替换以保持索引稳定
+func ReplaceInlineImageSrc(body string, refs []MailInlineImageRef) string {
+	if len(refs) == 0 {
+		return body
+	}
+	matches := imgSrcRegexp.FindAllStringSubmatchIndex(body, -1)
+	if len(matches) == 0 {
+		return body
+	}
+	srcToCID := make(map[string]string, len(refs))
+	for _, r := range refs {
+		srcToCID[r.RawSrc] = r.CID
+	}
+	// 倒序，避免 index 漂移
+	out := body
+	for i := len(matches) - 1; i >= 0; i-- {
+		m := matches[i]
+		// m[2]:m[3] 为双引号 src；m[4]:m[5] 为单引号 src
+		var s, e int
+		if m[2] >= 0 {
+			s, e = m[2], m[3]
+		} else if m[4] >= 0 {
+			s, e = m[4], m[5]
+		} else {
+			continue
+		}
+		srcVal := strings.TrimSpace(out[s:e])
+		cid, ok := srcToCID[srcVal]
+		if !ok {
+			continue
+		}
+		out = out[:s] + "cid:" + cid + out[e:]
+	}
+	return out
+}
+
+// GenerateMailCID 生成一个 20-hex CID（与 lark-cli 风格一致）
+func GenerateMailCID() (string, error) {
+	var b [10]byte
+	if _, err := rand.Read(b[:]); err != nil {
+		return "", fmt.Errorf("生成 CID 失败: %w", err)
+	}
+	return hex.EncodeToString(b[:]), nil
+}
+
+// guessMIMEByExt 按扩展名兜底 MIME（避免 multipart/related 缺 Content-Type）
+func guessMIMEByExt(name string) string {
+	switch strings.ToLower(filepath.Ext(name)) {
+	case ".png":
+		return "image/png"
+	case ".jpg", ".jpeg":
+		return "image/jpeg"
+	case ".gif":
+		return "image/gif"
+	case ".webp":
+		return "image/webp"
+	case ".bmp":
+		return "image/bmp"
+	case ".svg":
+		return "image/svg+xml"
+	default:
+		return "application/octet-stream"
+	}
+}
+
+// LoadInlineImageBytes 读取本地文件并填充 FileName/Bytes/MIME
+// 用于 EML builder 构造 multipart/related part；调用方可选择只用 FileToken
+// 而不读盘（如已经走 drive 上传完毕、只需 cid 替换）
+func LoadInlineImageBytes(ref *MailInlineImageRef) error {
+	abs, err := filepath.Abs(ref.LocalPath)
+	if err != nil {
+		return fmt.Errorf("解析路径失败 %s: %w", ref.LocalPath, err)
+	}
+	data, err := os.ReadFile(abs)
+	if err != nil {
+		return fmt.Errorf("读取本地图片失败 %s: %w", abs, err)
+	}
+	ref.Bytes = data
+	if ref.FileName == "" {
+		ref.FileName = filepath.Base(abs)
+	}
+	if ref.MIME == "" {
+		ref.MIME = guessMIMEByExt(ref.FileName)
+	}
+	return nil
+}

--- a/internal/client/mail_inline_test.go
+++ b/internal/client/mail_inline_test.go
@@ -1,0 +1,83 @@
+package client
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// TestLoadInlineImageBytes_RejectPathTraversal 验证路径遍历被拒绝
+// 攻击场景：<img src="../../../../etc/passwd"> 会让 builder 读敏感文件附进 EML 发到外部
+func TestLoadInlineImageBytes_RejectPathTraversal(t *testing.T) {
+	cases := []string{
+		"../etc/passwd",
+		"./foo/../../bar.png",
+		"a/../../b.png",
+		`..\windows\system32\config\sam`,
+	}
+	for _, p := range cases {
+		ref := &MailInlineImageRef{LocalPath: p}
+		err := LoadInlineImageBytes(ref)
+		if err == nil {
+			t.Errorf("路径 %q 应被拒绝但通过了", p)
+			continue
+		}
+		if !strings.Contains(err.Error(), "..") && !strings.Contains(err.Error(), "路径遍历") {
+			t.Errorf("路径 %q 的错误信息未提到 `..`/路径遍历: %v", p, err)
+		}
+	}
+}
+
+// TestLoadInlineImageBytes_RejectOutsideSafeRoots 验证 abs 在 cwd/home 之外被拒绝
+func TestLoadInlineImageBytes_RejectOutsideSafeRoots(t *testing.T) {
+	// /etc/hosts 通常不在 cwd 或 home 子树
+	ref := &MailInlineImageRef{LocalPath: "/etc/hosts"}
+	err := LoadInlineImageBytes(ref)
+	if err == nil {
+		t.Fatal("/etc/hosts 应该被 safe-roots 拒绝")
+	}
+	if !strings.Contains(err.Error(), "当前目录") && !strings.Contains(err.Error(), "home") {
+		t.Errorf("错误信息未提到 safe-roots 约束: %v", err)
+	}
+}
+
+// TestLoadInlineImageBytes_AllowInCwd 验证 cwd 内的合法路径可以读到
+func TestLoadInlineImageBytes_AllowInCwd(t *testing.T) {
+	dir := t.TempDir()
+	// 临时切到 dir 让它作为 cwd
+	oldCwd, _ := os.Getwd()
+	defer os.Chdir(oldCwd)
+	if err := os.Chdir(dir); err != nil {
+		t.Fatalf("chdir: %v", err)
+	}
+	fp := filepath.Join(dir, "x.png")
+	if err := os.WriteFile(fp, []byte{0x89, 0x50, 0x4e, 0x47}, 0o600); err != nil {
+		t.Fatalf("write fixture: %v", err)
+	}
+	ref := &MailInlineImageRef{LocalPath: "x.png"}
+	if err := LoadInlineImageBytes(ref); err != nil {
+		t.Fatalf("合法 cwd 路径被拒绝: %v", err)
+	}
+	if len(ref.Bytes) != 4 {
+		t.Errorf("Bytes 长度异常: %d", len(ref.Bytes))
+	}
+	if ref.MIME != "image/png" {
+		t.Errorf("MIME 未按扩展名兜底: %s", ref.MIME)
+	}
+}
+
+// TestScanInlineImagePaths_WindowsDrive 验证 Windows 驱动器路径不被 scheme 正则误判
+func TestScanInlineImagePaths_WindowsDrive(t *testing.T) {
+	html := `<img src="C:\photos\a.png"><img src="d:/x.jpg"><img src="http://cdn/y.png">`
+	got := ScanInlineImagePaths(html)
+	if len(got) != 2 {
+		t.Fatalf("got %d items %v, want 2 (Windows 驱动器路径)", len(got), got)
+	}
+	if got[0] != `C:\photos\a.png` {
+		t.Errorf("[0] got %q, want C:\\photos\\a.png", got[0])
+	}
+	if got[1] != "d:/x.jpg" {
+		t.Errorf("[1] got %q, want d:/x.jpg", got[1])
+	}
+}

--- a/skills/feishu-cli-mail/SKILL.md
+++ b/skills/feishu-cli-mail/SKILL.md
@@ -149,3 +149,48 @@ feishu-cli mail draft-edit --draft-id $DRAFT_ID --to user@example.com --subject 
 - **In-Reply-To / References**：`reply/reply-all` 自动从原邮件的 `smtp_message_id` / `references` 继承，确保邮件客户端正确展示对话线程。
 - **附件 / CID 图片暂不支持**：首期 EML builder 是简化版。如需附件，请在 feishu Web 手动处理或等后续迭代。
 - **批量 messages 上限**：取决于飞书 API 端；本命令不做数量校验，但通常建议 ≤50 条。
+
+## 高级能力（v1.23+ mail-advanced）
+
+### CID 内联图片自动扫描
+
+`mail send --inline-images-auto-scan` 自动扫描 HTML body 中
+`<img src="本地路径">` → 上传 drive (parent_type=email) → 重写为 `cid:xxx` →
+multipart/related 拼装。
+
+- 路径安全：拒 `..` 路径遍历；限 cwd / home 子树内
+- 多媒体合规：RFC 2046 multipart/related CRLF 严格（每 part body 末尾 `\r\n` + 边界前 `\r\n` 隔离）
+- 跳过已有 scheme：`cid:` / `http(s):` / `data:` / `//cdn` 等不重复上传
+- 仅 HTML body 生效；纯文本下静默跳过
+- 需要 `auth login` 缓存里有当前用户 `open_id`（drive upload 的 `parent_node` 必填）
+
+```bash
+# 自动扫描内嵌图，HTML body 中 <img src="./figs/chart.png"> 会被改写为 cid:xxx
+feishu-cli mail send --to user@example.com --subject "周报" \
+  --body "$(cat report.html)" --html --inline-images-auto-scan --confirm-send
+```
+
+### 邮件模板 CRUD
+
+```bash
+# 创建模板（body 支持 @file 读盘）
+feishu-cli mail template create --name "周报模板" \
+  --subject "本周进度" --body @template.html
+
+# 列出全部模板（接口不分页，一次性返回 id+name）
+feishu-cli mail template list
+feishu-cli mail template list -o json
+```
+
+⚠️ **mail scope 字节租户未开放**：`mail:user.email.template` 在字节租户暂未开放，
+UAT 调用可能返回 401 / scope 校验失败。建议先预检：
+
+```bash
+feishu-cli auth check --scope "mail:user_mailbox:readonly mail:user_mailbox.message:modify mail:user.email.template"
+```
+
+功能代码已完整，等飞书侧开放 scope 后即可使用；其他租户（如个人 lark）通常可用。
+
+### 未做（暂未 MVP）
+
+receipt send/decline / watch (WebSocket) / share-to-chat / template update / template delete


### PR DESCRIPTION
## 背景

feishu-cli 已有 \`mail send/reply/forward/triage\` 等基础邮件能力，缺少 lark-cli 的 2 类高级能力：

1. **CID 内联图片**：HTML body 中 \`<img src=\"./local.png\">\` 自动扫描 → drive upload → EML 多部分（multipart/related）+ \`Content-ID\` 头 + src 改写为 \`cid:xxx\`。AI agent 一行命令发图文邮件，不用手敲 EML。

2. **邮件模板 CRUD**：template create/list，便于团队复用邮件骨架（请假通知/发版通告/审批催办）。

⚠️ **字节租户 \`mail:user.email.template\` scope 暂未开放** — 代码完整实现，等 scope 开通即可用；help text 和 CHANGELOG 都明示。

## 新增能力

### 1. \`mail send --inline-images-auto-scan\`

```bash
feishu-cli mail send \\
  --to user@example.com \\
  --subject "周报附图" \\
  --html-body '<p>本周数据 <img src=\"./chart.png\"></p>' \\
  --inline-images-auto-scan
```

扫描行为：
- 只在 \`--html-body\` 且 \`--inline-images-auto-scan\` 时启用
- 同一本地路径去重，只上传一次
- scheme 前缀（http://、cid:、data:）跳过

EML 输出：
- 切到 \`multipart/related\` 容器
- 每张图独立 part：\`Content-ID: <cid_xxx>\` + \`Content-Disposition: inline\` + base64
- HTML 中 \`src\` 改写为 \`cid:xxx\`（无 \`<>\` 包裹）

### 2. \`mail template create / list\`

```bash
feishu-cli mail template create \\
  --name \"weekly-report\" \\
  --subject \"周报 {{date}}\" \\
  --body \"<p>本周完成...</p>\" \\
  [--to A,B --cc C --bcc D --mailbox me@example.com]

feishu-cli mail template list [--mailbox me@example.com]
```

接口 \`/open-apis/mail/v1/user_mailboxes/{id}/templates\`，client 层已实现 Get/Update/Delete（CLI 暂未暴露）。

## 实现要点

- \`internal/client/mail_inline.go\`：scanner（scheme 跳过 + 去重）+ uploader（drive UploadAll，\`parent_type=email\`，\`parent_node\` 取 user_profile.json 缓存的 open_id）
- \`internal/client/mail_advanced.go\`：template HTTP 直调
- \`cmd/mail_common.go\`：EML 加 multipart/related 分支 + mailBoundary 助手 + InlineImages 字段
- 修了原桩代码：\`uploadDriveMediaWithParent\` 未定义 → 改用 \`client.UploadMedia\` 走 SDK \`UploadAll\`

## Scope

- \`drive:drive\` (内联图片走 drive upload)
- \`mail:user_mailbox.message:send_as_user\` (send)
- \`mail:user.email.template\` (template，⚠️ 字节租户未开)

## 测试

- 6 个新 case 全过：scanner（scheme 跳过+去重）、src→cid 改写、multipart/related EML 结构（PNG 头字节）、纯 HTML 仍走单 part、\`\"Name <email>\"\` 拆分、CID 唯一性 + 长度
- \`go test ./... -count=1\` 全绿
- \`go vet ./...\` 无警告

## 边界（不在本 PR）

按 MVP：未做 receipt / watch / share-to-chat / template update。后续 PR 可补。