### PR TITLE
fix: resolve open doc export and message issues

### DIFF
--- a/cmd/doc_content_update.go
+++ b/cmd/doc_content_update.go
@@ -119,11 +119,18 @@ func runDocContentUpdate(cmd *cobra.Command, args []string) error {
 
 // resolveMarkdownContent 从 --markdown 或 --markdown-file 获取内容
 func resolveMarkdownContent(markdownStr, markdownFile string) (string, error) {
-	content, err := loadJSONInput(markdownStr, markdownFile, "markdown", "markdown-file", "Markdown 内容")
+	if markdownStr != "" && markdownFile != "" {
+		return "", fmt.Errorf("--markdown 和 --markdown-file 不能同时使用")
+	}
+	if markdownFile != "" {
+		return loadJSONInput("", markdownFile, "markdown", "markdown-file", "Markdown 内容")
+	}
+
+	content, err := loadJSONInput(markdownStr, "", "markdown", "markdown-file", "Markdown 内容")
 	if err != nil {
 		return "", err
 	}
-	// 处理命令行中的 \n 转义（仅内联输入时有意义，文件读取不受影响）
+	// 处理命令行中的 \n 转义；文件读取必须保持 LaTeX 反斜杠原样。
 	return strings.ReplaceAll(content, "\\n", "\n"), nil
 }
 

--- a/cmd/doc_content_update_test.go
+++ b/cmd/doc_content_update_test.go
@@ -1,0 +1,34 @@
+package cmd
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestResolveMarkdownContentInlineUnescapesNewlines(t *testing.T) {
+	got, err := resolveMarkdownContent("# 标题\\n\\n内容", "")
+	if err != nil {
+		t.Fatalf("resolveMarkdownContent() 返回错误: %v", err)
+	}
+	want := "# 标题\n\n内容"
+	if got != want {
+		t.Fatalf("resolveMarkdownContent() = %q，期望 %q", got, want)
+	}
+}
+
+func TestResolveMarkdownContentFilePreservesLatexBackslash(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "content.md")
+	want := "$$\n\\nu + 1\n$$"
+	if err := os.WriteFile(path, []byte(want), 0644); err != nil {
+		t.Fatalf("写入测试文件失败: %v", err)
+	}
+
+	got, err := resolveMarkdownContent("", path)
+	if err != nil {
+		t.Fatalf("resolveMarkdownContent() 返回错误: %v", err)
+	}
+	if got != want {
+		t.Fatalf("resolveMarkdownContent() = %q，期望 %q", got, want)
+	}
+}

--- a/cmd/export_wiki.go
+++ b/cmd/export_wiki.go
@@ -6,6 +6,7 @@ import (
 	"path/filepath"
 	"strings"
 
+	larkdocx "github.com/larksuite/oapi-sdk-go/v3/service/docx/v1"
 	"github.com/riba2534/feishu-cli/internal/client"
 	"github.com/riba2534/feishu-cli/internal/config"
 	"github.com/riba2534/feishu-cli/internal/converter"
@@ -31,6 +32,7 @@ var exportWikiCmd = &cobra.Command{
   url               知识库文档 URL
   --output, -o      输出文件路径
   --download-images 下载文档中的图片
+  --expand-mentions 展开 @用户为友好格式；关闭时保留可导入还原的标签
 
 示例:
   # 导出到默认路径
@@ -144,21 +146,42 @@ func exportDocxToMarkdownWithAssets(docToken, userAccessToken string, cmd *cobra
 	if assetsDirOverride != "" {
 		assetsDir = assetsDirOverride
 	}
+	expandMentions := readExpandMentionsFlag(cmd)
 	cfg := config.Get()
 
-	conv := converter.NewBlockToMarkdown(blocks, converter.ConvertOptions{
+	options := converter.ConvertOptions{
 		DocumentID:      docToken,
 		DownloadImages:  downloadImages,
 		AssetsDir:       assetsDir,
 		UserAccessToken: userAccessToken,
 		Debug:           cfg.Debug,
+		ExpandMentions:  expandMentions,
 		ExpandSheets:    expandSheets,
-	})
+	}
+	conv := newExportBlockToMarkdownConverter(blocks, options, &FeishuUserResolver{})
 	md, err := conv.Convert()
 	if err != nil {
 		return "", fmt.Errorf("转换为 Markdown 失败: %w", err)
 	}
 	return md, nil
+}
+
+func readExpandMentionsFlag(cmd *cobra.Command) bool {
+	if cmd == nil || cmd.Flags().Lookup("expand-mentions") == nil {
+		return true
+	}
+	expandMentions, err := cmd.Flags().GetBool("expand-mentions")
+	if err != nil {
+		return true
+	}
+	return expandMentions
+}
+
+func newExportBlockToMarkdownConverter(blocks []*larkdocx.Block, options converter.ConvertOptions, resolver converter.UserResolver) *converter.BlockToMarkdown {
+	if options.ExpandMentions {
+		return converter.NewBlockToMarkdownWithResolver(blocks, options, resolver)
+	}
+	return converter.NewBlockToMarkdown(blocks, options)
 }
 
 // exportSheetToMarkdown 导出 sheet 类型文档为 Markdown
@@ -198,5 +221,6 @@ func init() {
 	exportWikiCmd.Flags().Bool("download-images", false, "下载图片到本地目录")
 	exportWikiCmd.Flags().String("assets-dir", "./assets", "下载资源的保存目录")
 	exportWikiCmd.Flags().Bool("expand-sheets", true, "展开内嵌电子表格为 Markdown 表格（false 时保留 <sheet/> 引用）")
+	exportWikiCmd.Flags().Bool("expand-mentions", true, "展开 @用户为友好格式（false 时保留 <mention-user/> 标签以支持导入还原）")
 	exportWikiCmd.Flags().String("user-access-token", "", "User Access Token（可选，用于访问个人知识库）")
 }

--- a/cmd/export_wiki_test.go
+++ b/cmd/export_wiki_test.go
@@ -1,0 +1,153 @@
+package cmd
+
+import (
+	"strings"
+	"testing"
+
+	larkdocx "github.com/larksuite/oapi-sdk-go/v3/service/docx/v1"
+	"github.com/riba2534/feishu-cli/internal/converter"
+	"github.com/spf13/cobra"
+)
+
+type fakeExportUserResolver struct {
+	users map[string]converter.MentionUserInfo
+	calls int
+	ids   []string
+}
+
+func (r *fakeExportUserResolver) BatchResolve(userIDs []string) map[string]converter.MentionUserInfo {
+	r.calls++
+	r.ids = append([]string(nil), userIDs...)
+
+	result := make(map[string]converter.MentionUserInfo)
+	for _, id := range userIDs {
+		if info, ok := r.users[id]; ok {
+			result[id] = info
+		}
+	}
+	return result
+}
+
+func TestReadExpandMentionsFlagDefaultsToTrue(t *testing.T) {
+	if !readExpandMentionsFlag(nil) {
+		t.Fatal("nil command should default expand-mentions to true")
+	}
+
+	cmdWithoutFlag := &cobra.Command{}
+	if !readExpandMentionsFlag(cmdWithoutFlag) {
+		t.Fatal("missing expand-mentions flag should default to true")
+	}
+
+	cmdWithFlag := &cobra.Command{}
+	cmdWithFlag.Flags().Bool("expand-mentions", true, "")
+	if !readExpandMentionsFlag(cmdWithFlag) {
+		t.Fatal("default expand-mentions flag value should be true")
+	}
+
+	if err := cmdWithFlag.Flags().Set("expand-mentions", "false"); err != nil {
+		t.Fatalf("set flag: %v", err)
+	}
+	if readExpandMentionsFlag(cmdWithFlag) {
+		t.Fatal("explicit expand-mentions=false should be respected")
+	}
+}
+
+func TestWikiExportCommandsRegisterExpandMentions(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		cmd  *cobra.Command
+	}{
+		{name: "wiki export", cmd: exportWikiCmd},
+		{name: "wiki export-tree", cmd: exportWikiTreeCmd},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if tc.cmd.Flags().Lookup("expand-mentions") == nil {
+				t.Fatal("expand-mentions flag is not registered")
+			}
+			got, err := tc.cmd.Flags().GetBool("expand-mentions")
+			if err != nil {
+				t.Fatalf("get expand-mentions flag: %v", err)
+			}
+			if !got {
+				t.Fatal("expand-mentions should default to true")
+			}
+		})
+	}
+}
+
+func TestNewExportBlockToMarkdownConverterExpandMentions(t *testing.T) {
+	resolver := &fakeExportUserResolver{
+		users: map[string]converter.MentionUserInfo{
+			"ou_123": {Name: "张三", Email: "user@example.com"},
+		},
+	}
+
+	conv := newExportBlockToMarkdownConverter(
+		createExportMentionUserBlocks("ou_123"),
+		converter.ConvertOptions{ExpandMentions: true},
+		resolver,
+	)
+	got, err := conv.Convert()
+	if err != nil {
+		t.Fatalf("convert: %v", err)
+	}
+
+	if !strings.Contains(got, "[@张三](mailto:user@example.com)") {
+		t.Fatalf("mention should be expanded, got: %s", got)
+	}
+	if resolver.calls != 1 {
+		t.Fatalf("resolver calls = %d, want 1", resolver.calls)
+	}
+	if len(resolver.ids) != 1 || resolver.ids[0] != "ou_123" {
+		t.Fatalf("resolver ids = %v, want [ou_123]", resolver.ids)
+	}
+}
+
+func TestNewExportBlockToMarkdownConverterPreservesMentionTagsWhenDisabled(t *testing.T) {
+	resolver := &fakeExportUserResolver{
+		users: map[string]converter.MentionUserInfo{
+			"ou_123": {Name: "张三", Email: "user@example.com"},
+		},
+	}
+
+	conv := newExportBlockToMarkdownConverter(
+		createExportMentionUserBlocks("ou_123"),
+		converter.ConvertOptions{ExpandMentions: false},
+		resolver,
+	)
+	got, err := conv.Convert()
+	if err != nil {
+		t.Fatalf("convert: %v", err)
+	}
+
+	if !strings.Contains(got, `<mention-user id="ou_123"/>`) {
+		t.Fatalf("mention tag should be preserved for roundtrip, got: %s", got)
+	}
+	if strings.Contains(got, "mailto:") || strings.Contains(got, "@张三") {
+		t.Fatalf("mention should not be expanded when disabled, got: %s", got)
+	}
+	if resolver.calls != 0 {
+		t.Fatalf("resolver calls = %d, want 0", resolver.calls)
+	}
+}
+
+func createExportMentionUserBlocks(userID string) []*larkdocx.Block {
+	blockType := int(converter.BlockTypeText)
+	return []*larkdocx.Block{
+		{
+			BlockId:   exportStringPtr("block1"),
+			BlockType: &blockType,
+			Text: &larkdocx.Text{
+				Elements: []*larkdocx.TextElement{
+					{TextRun: &larkdocx.TextRun{Content: exportStringPtr("你好 ")}},
+					{MentionUser: &larkdocx.MentionUser{UserId: exportStringPtr(userID)}},
+					{TextRun: &larkdocx.TextRun{Content: exportStringPtr(" 请查看")}},
+				},
+			},
+		},
+	}
+}
+
+func exportStringPtr(s string) *string {
+	return &s
+}

--- a/cmd/export_wiki_tree.go
+++ b/cmd/export_wiki_tree.go
@@ -52,7 +52,10 @@ var exportWikiTreeCmd = &cobra.Command{
   feishu-cli wiki export-tree <token> -o ./backup --download-images --assets-dir ./backup/assets
 
   # 内嵌 Sheet 读取失败时保留 <sheet/> 引用
-  feishu-cli wiki export-tree <token> -o ./backup --expand-sheets=false`,
+  feishu-cli wiki export-tree <token> -o ./backup --expand-sheets=false
+
+  # 保留 @用户为可导入还原的标签
+  feishu-cli wiki export-tree <token> -o ./backup --expand-mentions=false`,
 	Args: cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		if err := config.Validate(); err != nil {
@@ -421,6 +424,7 @@ func init() {
 	exportWikiTreeCmd.Flags().Bool("download-images", false, "下载图片到本地目录（透传给底层 export）")
 	exportWikiTreeCmd.Flags().String("assets-dir", "./assets", "图片下载目录（透传给底层 export）")
 	exportWikiTreeCmd.Flags().Bool("expand-sheets", true, "展开内嵌电子表格为 Markdown 表格（false 时保留 <sheet/> 引用）")
+	exportWikiTreeCmd.Flags().Bool("expand-mentions", true, "展开 @用户为友好格式（false 时保留 <mention-user/> 标签以支持导入还原）")
 	exportWikiTreeCmd.Flags().Bool("skip-existing", false, "已存在且非空的 md 跳过（适合增量同步）")
 	exportWikiTreeCmd.Flags().Bool("continue-on-error", true, "单个节点导出失败时是否继续后续节点")
 	exportWikiTreeCmd.Flags().String("user-access-token", "", "User Access Token（可选；默认优先使用 auth login 登录态，失败时回退 App Token）")

--- a/cmd/get_message.go
+++ b/cmd/get_message.go
@@ -41,10 +41,7 @@ var getMessageCmd = &cobra.Command{
 			return err
 		}
 
-		token, err := resolveRequiredUserToken(cmd)
-		if err != nil {
-			return err
-		}
+		token := resolveOptionalUserToken(cmd)
 
 		messageID := args[0]
 

--- a/cmd/get_message_history.go
+++ b/cmd/get_message_history.go
@@ -49,11 +49,6 @@ var getMessageHistoryCmd = &cobra.Command{
 			return err
 		}
 
-		token, err := resolveRequiredUserToken(cmd)
-		if err != nil {
-			return err
-		}
-
 		containerIDType, _ := cmd.Flags().GetString("container-id-type")
 		containerID, _ := cmd.Flags().GetString("container-id")
 		userID, _ := cmd.Flags().GetString("user-id")
@@ -85,6 +80,17 @@ var getMessageHistoryCmd = &cobra.Command{
 		}
 		if entryCount > 1 {
 			return fmt.Errorf("--container-id / --user-id / --user-email 互斥，只能指定一个")
+		}
+
+		var token string
+		if userID != "" || userEmail != "" {
+			var tokenErr error
+			token, tokenErr = resolveRequiredUserToken(cmd)
+			if tokenErr != nil {
+				return tokenErr
+			}
+		} else {
+			token = resolveOptionalUserToken(cmd)
 		}
 
 		// --user-email：搜索用户 → open_id

--- a/cmd/import_markdown.go
+++ b/cmd/import_markdown.go
@@ -37,11 +37,11 @@ func syncPrintf(format string, a ...any) {
 
 // segment 表示 Markdown 中的一个片段
 type segment struct {
-	kind    string // "markdown"、"mermaid"、"plantuml"、"svg" 或 "equation"
+	kind    string // "markdown"、"mermaid"、"plantuml" 或 "svg"
 	content string
 }
 
-// parseMarkdownSegments 将 Markdown 解析为片段，分离出 mermaid 和 plantuml 代码块
+// parseMarkdownSegments 将 Markdown 解析为片段，分离出 mermaid、plantuml 和 svg 代码块
 // countLeadingBackticks 返回行首反引号数量（去除前导空格后）
 func countLeadingBackticks(line string) int {
 	trimmed := strings.TrimSpace(line)
@@ -80,32 +80,6 @@ func parseMarkdownSegments(markdown string) []segment {
 			}
 			buf = append(buf, line)
 			i++
-			continue
-		}
-
-		// 检查块级公式 $$ 开始
-		if trimmed == "$$" {
-			// 先保存之前的普通内容
-			if len(buf) > 0 {
-				segments = append(segments, segment{kind: "markdown", content: strings.Join(buf, "\n")})
-				buf = nil
-			}
-
-			// 收集公式内容
-			i++
-			var equationLines []string
-			for i < len(lines) && strings.TrimSpace(lines[i]) != "$$" {
-				equationLines = append(equationLines, lines[i])
-				i++
-			}
-			// 跳过结束的 $$
-			if i < len(lines) {
-				i++
-			}
-
-			if len(equationLines) > 0 {
-				segments = append(segments, segment{kind: "equation", content: strings.Join(equationLines, "\n")})
-			}
 			continue
 		}
 
@@ -749,38 +723,6 @@ func phase1CreateBlocks(
 
 			iTasks = appendImageTasks(iTasks, result.BlockNodes, createdBlockIDs, nestedCreatedByTop, result.ImageSources, basePath)
 			vTasks = appendVideoTasks(vTasks, result.BlockNodes, createdBlockIDs, nestedCreatedByTop, result.VideoSources, basePath)
-
-		} else if seg.kind == "equation" {
-			// 块级公式：飞书 API 不支持创建 Equation 块（type=16），
-			// 降级为包含行内 Equation 元素的 Text 块，保留公式语义
-			textBlockType := 2 // BlockTypeText
-			equationContent := seg.content
-			equationBlocks := []*larkdocx.Block{
-				{
-					BlockType: &textBlockType,
-					Text: &larkdocx.Text{
-						Elements: []*larkdocx.TextElement{
-							{
-								Equation: &larkdocx.Equation{
-									Content: &equationContent,
-								},
-							},
-						},
-					},
-				},
-			}
-
-			createdBlocks, _, err := client.CreateBlock(documentID, documentID, equationBlocks, -1, userAccessToken)
-			if err != nil {
-				if verbose {
-					stats.progressf("  ⚠ 公式块创建失败: %v\n", err)
-				}
-			} else {
-				stats.totalBlocks += len(createdBlocks)
-				if verbose {
-					stats.progressf("  [公式] 创建 %d 个块（行内公式）\n", len(createdBlocks))
-				}
-			}
 
 		} else if seg.kind == "mermaid" || seg.kind == "plantuml" || seg.kind == "svg" {
 			diagramIdx++

--- a/cmd/list_messages.go
+++ b/cmd/list_messages.go
@@ -45,10 +45,7 @@ var listMessagesCmd = &cobra.Command{
 			return err
 		}
 
-		token, err := resolveRequiredUserToken(cmd)
-		if err != nil {
-			return err
-		}
+		token := resolveOptionalUserToken(cmd)
 
 		containerID, _ := cmd.Flags().GetString("container-id")
 		containerIDType, _ := cmd.Flags().GetString("container-id-type")

--- a/cmd/msg_token_mode_test.go
+++ b/cmd/msg_token_mode_test.go
@@ -1,0 +1,276 @@
+package cmd
+
+import (
+	"fmt"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/riba2534/feishu-cli/internal/client"
+	"github.com/spf13/cobra"
+)
+
+const (
+	testChatID     = "oc_test_chat"
+	testMessageID  = "om_test_message"
+	testUserToken  = "u-test-token"
+	testTenantAuth = "Bearer t-fake"
+)
+
+func isolateMsgTokenTestEnv(t *testing.T) {
+	t.Helper()
+	t.Setenv("HOME", t.TempDir())
+	t.Setenv("FEISHU_USER_ACCESS_TOKEN", "")
+	t.Setenv("FEISHU_BASE_URL", "")
+	t.Setenv("FEISHU_APP_ID", "")
+	t.Setenv("FEISHU_APP_SECRET", "")
+}
+
+func tenantTokenHandler(t *testing.T, business http.HandlerFunc) http.HandlerFunc {
+	t.Helper()
+	return func(w http.ResponseWriter, r *http.Request) {
+		if strings.HasPrefix(r.URL.Path, "/open-apis/auth/v3/tenant_access_token/internal") {
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = fmt.Fprint(w, `{"code":0,"msg":"ok","tenant_access_token":"t-fake","expire":7200}`)
+			return
+		}
+		business(w, r)
+	}
+}
+
+func newListMessagesTestCmd() *cobra.Command {
+	cmd := &cobra.Command{}
+	cmd.Flags().String("container-id", "", "")
+	cmd.Flags().String("container-id-type", "chat", "")
+	cmd.Flags().String("start-time", "", "")
+	cmd.Flags().String("end-time", "", "")
+	cmd.Flags().String("sort-type", "", "")
+	cmd.Flags().Int("page-size", 20, "")
+	cmd.Flags().String("page-token", "", "")
+	cmd.Flags().StringP("output", "o", "", "")
+	cmd.Flags().String("user-access-token", "", "")
+	addCardContentTypeFlag(cmd)
+	return cmd
+}
+
+func newGetMessageTestCmd() *cobra.Command {
+	cmd := &cobra.Command{}
+	cmd.Flags().StringP("output", "o", "", "")
+	cmd.Flags().String("user-access-token", "", "")
+	addCardContentTypeFlag(cmd)
+	return cmd
+}
+
+func newGetMessageHistoryTestCmd() *cobra.Command {
+	cmd := &cobra.Command{}
+	cmd.Flags().String("container-id-type", "chat", "")
+	cmd.Flags().String("container-id", "", "")
+	cmd.Flags().String("user-id", "", "")
+	cmd.Flags().String("user-email", "", "")
+	cmd.Flags().String("start-time", "", "")
+	cmd.Flags().String("end-time", "", "")
+	cmd.Flags().String("sort-type", "ByCreateTimeDesc", "")
+	cmd.Flags().Int("page-size", 50, "")
+	cmd.Flags().String("page-token", "", "")
+	cmd.Flags().StringP("output", "o", "", "")
+	cmd.Flags().String("user-access-token", "", "")
+	addCardContentTypeFlag(cmd)
+	return cmd
+}
+
+func mustSetFlag(t *testing.T, cmd *cobra.Command, name, value string) {
+	t.Helper()
+	if err := cmd.Flags().Set(name, value); err != nil {
+		t.Fatalf("设置 flag %s 失败: %v", name, err)
+	}
+}
+
+func TestMsgListContainerIDDefaultsToTenantToken(t *testing.T) {
+	isolateMsgTokenTestEnv(t)
+	var capturedAuth string
+	var searchCalled bool
+
+	cleanup := stubCmdFeishuServer(t, tenantTokenHandler(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/open-apis/search/v2/message" {
+			searchCalled = true
+		}
+		if r.URL.Path != "/open-apis/im/v1/messages" {
+			http.Error(w, "unexpected path "+r.URL.Path, http.StatusNotFound)
+			return
+		}
+		capturedAuth = r.Header.Get("Authorization")
+		if got := r.URL.Query().Get("card_msg_content_type"); got != client.CardMsgContentTypeUser {
+			t.Errorf("card_msg_content_type = %q, want %q", got, client.CardMsgContentTypeUser)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = fmt.Fprint(w, `{"code":0,"msg":"success","data":{"items":[],"has_more":true,"page_token":"next"}}`)
+	}))
+	defer cleanup()
+
+	cmd := newListMessagesTestCmd()
+	mustSetFlag(t, cmd, "container-id", testChatID)
+	if err := listMessagesCmd.RunE(cmd, nil); err != nil {
+		t.Fatalf("msg list 返回错误: %v", err)
+	}
+	if capturedAuth != testTenantAuth {
+		t.Fatalf("Authorization = %q, want %q", capturedAuth, testTenantAuth)
+	}
+	if searchCalled {
+		t.Fatalf("未显式 User Token 时不应触发 search fallback")
+	}
+}
+
+func TestMsgGetDefaultsToTenantToken(t *testing.T) {
+	isolateMsgTokenTestEnv(t)
+	var capturedAuth string
+
+	cleanup := stubCmdFeishuServer(t, tenantTokenHandler(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/open-apis/im/v1/messages/"+testMessageID {
+			http.Error(w, "unexpected path "+r.URL.Path, http.StatusNotFound)
+			return
+		}
+		capturedAuth = r.Header.Get("Authorization")
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = fmt.Fprintf(w, `{"code":0,"msg":"success","data":{"items":[{"message_id":"%s","msg_type":"text","sender":{"id":"ou_sender","sender_type":"user"},"body":{"content":"{\"text\":\"hi\"}"}}]}}`, testMessageID)
+	}))
+	defer cleanup()
+
+	cmd := newGetMessageTestCmd()
+	if err := getMessageCmd.RunE(cmd, []string{testMessageID}); err != nil {
+		t.Fatalf("msg get 返回错误: %v", err)
+	}
+	if capturedAuth != testTenantAuth {
+		t.Fatalf("Authorization = %q, want %q", capturedAuth, testTenantAuth)
+	}
+}
+
+func TestMsgHistoryContainerIDDefaultsToTenantToken(t *testing.T) {
+	isolateMsgTokenTestEnv(t)
+	var capturedAuth string
+	var searchCalled bool
+	var contactCalled bool
+
+	cleanup := stubCmdFeishuServer(t, tenantTokenHandler(t, func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.URL.Path == "/open-apis/search/v2/message":
+			searchCalled = true
+		case strings.HasPrefix(r.URL.Path, "/open-apis/contact/"):
+			contactCalled = true
+		case r.URL.Path == "/open-apis/im/v1/messages":
+			capturedAuth = r.Header.Get("Authorization")
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = fmt.Fprint(w, `{"code":0,"msg":"success","data":{"items":[{"message_id":"om_1","msg_type":"text","sender":{"id":"ou_sender","sender_type":"user"},"body":{"content":"{\"text\":\"hi\"}"}}],"has_more":true,"page_token":"next"}}`)
+			return
+		default:
+			http.Error(w, "unexpected path "+r.URL.Path, http.StatusNotFound)
+			return
+		}
+		http.Error(w, "unexpected path "+r.URL.Path, http.StatusNotFound)
+	}))
+	defer cleanup()
+
+	cmd := newGetMessageHistoryTestCmd()
+	mustSetFlag(t, cmd, "container-id", testChatID)
+	if err := getMessageHistoryCmd.RunE(cmd, nil); err != nil {
+		t.Fatalf("msg history 返回错误: %v", err)
+	}
+	if capturedAuth != testTenantAuth {
+		t.Fatalf("Authorization = %q, want %q", capturedAuth, testTenantAuth)
+	}
+	if searchCalled {
+		t.Fatalf("未显式 User Token 时不应触发 search fallback")
+	}
+	if contactCalled {
+		t.Fatalf("未显式 User Token 时 sender name 解析不应调用 contact API")
+	}
+}
+
+func TestMsgContainerCommandsUseExplicitUserToken(t *testing.T) {
+	tests := []struct {
+		name string
+		run  func(t *testing.T)
+	}{
+		{
+			name: "list",
+			run: func(t *testing.T) {
+				cmd := newListMessagesTestCmd()
+				mustSetFlag(t, cmd, "container-id", testChatID)
+				mustSetFlag(t, cmd, "user-access-token", testUserToken)
+				if err := listMessagesCmd.RunE(cmd, nil); err != nil {
+					t.Fatalf("msg list 返回错误: %v", err)
+				}
+			},
+		},
+		{
+			name: "get",
+			run: func(t *testing.T) {
+				cmd := newGetMessageTestCmd()
+				mustSetFlag(t, cmd, "user-access-token", testUserToken)
+				if err := getMessageCmd.RunE(cmd, []string{testMessageID}); err != nil {
+					t.Fatalf("msg get 返回错误: %v", err)
+				}
+			},
+		},
+		{
+			name: "history",
+			run: func(t *testing.T) {
+				cmd := newGetMessageHistoryTestCmd()
+				mustSetFlag(t, cmd, "container-id", testChatID)
+				mustSetFlag(t, cmd, "user-access-token", testUserToken)
+				if err := getMessageHistoryCmd.RunE(cmd, nil); err != nil {
+					t.Fatalf("msg history 返回错误: %v", err)
+				}
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			isolateMsgTokenTestEnv(t)
+			var capturedAuth string
+
+			cleanup := stubCmdFeishuServer(t, func(w http.ResponseWriter, r *http.Request) {
+				if strings.HasPrefix(r.URL.Path, "/open-apis/auth/v3/tenant_access_token/internal") {
+					t.Errorf("%s 显式 User Token 时不应请求 tenant token", tt.name)
+					http.Error(w, "unexpected tenant token request", http.StatusInternalServerError)
+					return
+				}
+				capturedAuth = r.Header.Get("Authorization")
+				w.Header().Set("Content-Type", "application/json")
+				switch r.URL.Path {
+				case "/open-apis/im/v1/messages":
+					_, _ = fmt.Fprint(w, `{"code":0,"msg":"success","data":{"items":[],"has_more":false,"page_token":""}}`)
+				case "/open-apis/im/v1/messages/" + testMessageID:
+					_, _ = fmt.Fprintf(w, `{"code":0,"msg":"success","data":{"items":[{"message_id":"%s","msg_type":"text","body":{"content":"{\"text\":\"hi\"}"}}]}}`, testMessageID)
+				default:
+					http.Error(w, "unexpected path "+r.URL.Path, http.StatusNotFound)
+				}
+			})
+			defer cleanup()
+
+			tt.run(t)
+			if capturedAuth != "Bearer "+testUserToken {
+				t.Fatalf("Authorization = %q, want %q", capturedAuth, "Bearer "+testUserToken)
+			}
+		})
+	}
+}
+
+func TestMsgHistoryUserEntrypointsStillRequireUserToken(t *testing.T) {
+	isolateMsgTokenTestEnv(t)
+
+	cleanup := stubCmdFeishuServer(t, func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "unexpected path "+r.URL.Path, http.StatusNotFound)
+	})
+	defer cleanup()
+
+	cmd := newGetMessageHistoryTestCmd()
+	mustSetFlag(t, cmd, "user-id", "ou_test_user")
+	err := getMessageHistoryCmd.RunE(cmd, nil)
+	if err == nil {
+		t.Fatal("--user-id 未提供 User Token 时应返回错误")
+	}
+	if !strings.Contains(err.Error(), "缺少 User Access Token") {
+		t.Fatalf("错误 = %q, want 包含 缺少 User Access Token", err.Error())
+	}
+}

--- a/internal/converter/block_to_markdown.go
+++ b/internal/converter/block_to_markdown.go
@@ -1622,7 +1622,7 @@ func (c *BlockToMarkdown) formatStyledText(text string, style *larkdocx.TextElem
 
 func normalizeMarkdownLinkURL(linkURL string) string {
 	// 解码完全 URL 编码的链接（如 https%3A%2F%2F...），提升可读性
-	if decoded, err := url.QueryUnescape(linkURL); err == nil && decoded != linkURL {
+	if decoded, err := url.PathUnescape(linkURL); err == nil && decoded != linkURL {
 		linkURL = decoded
 	}
 	// URL 中的括号编码，避免破坏 Markdown 链接语法

--- a/internal/converter/block_to_markdown.go
+++ b/internal/converter/block_to_markdown.go
@@ -1511,59 +1511,7 @@ func (c *BlockToMarkdown) convertTextElements(elements []*larkdocx.TextElement) 
 				text = *elem.TextRun.Content
 			}
 
-			// Apply styles in correct order (innermost to outermost)
-			if elem.TextRun.TextElementStyle != nil {
-				style := elem.TextRun.TextElementStyle
-
-				// Handle inline code first (innermost) — 不转义内部文本
-				if style.InlineCode != nil && *style.InlineCode {
-					text = "`" + text + "`"
-				} else {
-					hasLink := style.Link != nil && style.Link.Url != nil
-
-					// 对非链接、非行内代码的纯文本转义特殊字符
-					if !hasLink {
-						text = escapeMarkdown(text)
-					}
-
-					// Apply text formatting styles (not applicable to inline code)
-					if style.Bold != nil && *style.Bold {
-						text = "**" + text + "**"
-					}
-					if style.Italic != nil && *style.Italic {
-						text = "*" + text + "*"
-					}
-					if style.Strikethrough != nil && *style.Strikethrough {
-						text = "~~" + text + "~~"
-					}
-					if style.Underline != nil && *style.Underline {
-						text = "<u>" + text + "</u>"
-					}
-				}
-
-				// Handle link last (outermost)
-				if style.Link != nil && style.Link.Url != nil {
-					linkURL := *style.Link.Url
-					// 解码完全 URL 编码的链接（如 https%3A%2F%2F...），提升可读性
-					if decoded, err := url.QueryUnescape(linkURL); err == nil && decoded != linkURL {
-						linkURL = decoded
-					}
-					// URL 中的括号编码，避免破坏 Markdown 链接语法
-					linkURL = strings.ReplaceAll(linkURL, "(", "%28")
-					linkURL = strings.ReplaceAll(linkURL, ")", "%29")
-					text = fmt.Sprintf("[%s](%s)", text, linkURL)
-				}
-
-				// 高亮颜色导出（最外层包装）
-				if c.options.Highlight {
-					text = c.wrapHighlightSpan(style, text)
-				}
-			} else {
-				// 无样式的纯文本也需要转义
-				text = escapeMarkdown(text)
-			}
-
-			result.WriteString(text)
+			result.WriteString(c.formatStyledText(text, elem.TextRun.TextElementStyle, nil))
 		}
 
 		if elem.MentionUser != nil {
@@ -1610,9 +1558,91 @@ func (c *BlockToMarkdown) convertTextElements(elements []*larkdocx.TextElement) 
 			}
 			result.WriteString("$" + content + "$")
 		}
+
+		if elem.LinkPreview != nil {
+			text, linkURL := inlineLinkPreviewTextAndURL(elem.LinkPreview)
+			if text == "" {
+				continue
+			}
+			result.WriteString(c.formatStyledText(text, elem.LinkPreview.TextElementStyle, linkURL))
+		}
 	}
 
 	return result.String()
+}
+
+func (c *BlockToMarkdown) formatStyledText(text string, style *larkdocx.TextElementStyle, fallbackLinkURL *string) string {
+	linkURL := fallbackLinkURL
+	if linkURL == nil && style != nil && style.Link != nil && style.Link.Url != nil {
+		linkURL = style.Link.Url
+	}
+	hasLink := linkURL != nil && *linkURL != ""
+
+	// Apply styles in correct order (innermost to outermost)
+	if style != nil {
+		// Handle inline code first (innermost) — 不转义内部文本
+		if style.InlineCode != nil && *style.InlineCode {
+			text = "`" + text + "`"
+		} else {
+			// 对非链接、非行内代码的纯文本转义特殊字符
+			if !hasLink {
+				text = escapeMarkdown(text)
+			}
+
+			// Apply text formatting styles (not applicable to inline code)
+			if style.Bold != nil && *style.Bold {
+				text = "**" + text + "**"
+			}
+			if style.Italic != nil && *style.Italic {
+				text = "*" + text + "*"
+			}
+			if style.Strikethrough != nil && *style.Strikethrough {
+				text = "~~" + text + "~~"
+			}
+			if style.Underline != nil && *style.Underline {
+				text = "<u>" + text + "</u>"
+			}
+		}
+	} else {
+		text = escapeMarkdown(text)
+	}
+
+	// Handle link last (outermost)
+	if hasLink {
+		text = fmt.Sprintf("[%s](%s)", text, normalizeMarkdownLinkURL(*linkURL))
+	}
+
+	// 高亮颜色导出（最外层包装）
+	if style != nil && c.options.Highlight {
+		text = c.wrapHighlightSpan(style, text)
+	}
+
+	return text
+}
+
+func normalizeMarkdownLinkURL(linkURL string) string {
+	// 解码完全 URL 编码的链接（如 https%3A%2F%2F...），提升可读性
+	if decoded, err := url.QueryUnescape(linkURL); err == nil && decoded != linkURL {
+		linkURL = decoded
+	}
+	// URL 中的括号编码，避免破坏 Markdown 链接语法
+	linkURL = strings.ReplaceAll(linkURL, "(", "%28")
+	linkURL = strings.ReplaceAll(linkURL, ")", "%29")
+	return linkURL
+}
+
+func inlineLinkPreviewTextAndURL(linkPreview *larkdocx.InlineLinkPreview) (string, *string) {
+	if linkPreview == nil {
+		return "", nil
+	}
+	text := ""
+	if linkPreview.Title != nil {
+		text = *linkPreview.Title
+	}
+	if text == "" && linkPreview.Url != nil {
+		text = *linkPreview.Url
+	}
+	return text, linkPreview.Url
 }
 
 // wrapHighlightSpan 将带颜色的文本包装为 HTML span 标签
@@ -1692,6 +1722,10 @@ func (c *BlockToMarkdown) convertTextElementsRaw(elements []*larkdocx.TextElemen
 		}
 		if elem.Equation != nil && elem.Equation.Content != nil {
 			result.WriteString(*elem.Equation.Content)
+		}
+		if elem.LinkPreview != nil {
+			text, _ := inlineLinkPreviewTextAndURL(elem.LinkPreview)
+			result.WriteString(text)
 		}
 	}
 

--- a/internal/converter/block_to_markdown_util_test.go
+++ b/internal/converter/block_to_markdown_util_test.go
@@ -570,6 +570,27 @@ func TestConvertTextElementsRaw(t *testing.T) {
 			want:    "x^2 + y^2 = z^2",
 		},
 		{
+			name: "InlineLinkPreview优先输出标题",
+			elements: []*larkdocx.TextElement{
+				{LinkPreview: &larkdocx.InlineLinkPreview{
+					Title: strPtr("项目主页"),
+					Url:   strPtr("https://example.com/project"),
+				}},
+			},
+			options: ConvertOptions{},
+			want:    "项目主页",
+		},
+		{
+			name: "InlineLinkPreview无标题时输出URL",
+			elements: []*larkdocx.TextElement{
+				{LinkPreview: &larkdocx.InlineLinkPreview{
+					Url: strPtr("https://example.com/project"),
+				}},
+			},
+			options: ConvertOptions{},
+			want:    "https://example.com/project",
+		},
+		{
 			name: "混合元素",
 			elements: []*larkdocx.TextElement{
 				{TextRun: &larkdocx.TextRun{Content: strPtr("hello ")}},
@@ -656,6 +677,41 @@ func TestConvertTextElements(t *testing.T) {
 			},
 			options: ConvertOptions{},
 			want:    "[链接](https://example.com/page%281%29)",
+		},
+		{
+			name: "InlineLinkPreview输出Markdown链接",
+			elements: []*larkdocx.TextElement{
+				{LinkPreview: &larkdocx.InlineLinkPreview{
+					Title: strPtr("项目主页"),
+					Url:   strPtr("https%3A%2F%2Fexample.com%2Fpage(1)"),
+				}},
+			},
+			options: ConvertOptions{},
+			want:    "[项目主页](https://example.com/page%281%29)",
+		},
+		{
+			name: "InlineLinkPreview无标题时使用URL作为文本",
+			elements: []*larkdocx.TextElement{
+				{LinkPreview: &larkdocx.InlineLinkPreview{
+					Url: strPtr("https://example.com/page(1)"),
+				}},
+			},
+			options: ConvertOptions{},
+			want:    "[https://example.com/page(1)](https://example.com/page%281%29)",
+		},
+		{
+			name: "InlineLinkPreview复用TextElementStyle",
+			elements: []*larkdocx.TextElement{
+				{LinkPreview: &larkdocx.InlineLinkPreview{
+					Title: strPtr("项目主页"),
+					Url:   strPtr("https://example.com/project"),
+					TextElementStyle: &larkdocx.TextElementStyle{
+						Bold: boolPtr(true),
+					},
+				}},
+			},
+			options: ConvertOptions{},
+			want:    "[**项目主页**](https://example.com/project)",
 		},
 		{
 			name: "无样式纯文本转义",

--- a/internal/converter/block_to_markdown_util_test.go
+++ b/internal/converter/block_to_markdown_util_test.go
@@ -690,6 +690,17 @@ func TestConvertTextElements(t *testing.T) {
 			want:    "[项目主页](https://example.com/page%281%29)",
 		},
 		{
+			name: "InlineLinkPreview保留URL加号",
+			elements: []*larkdocx.TextElement{
+				{LinkPreview: &larkdocx.InlineLinkPreview{
+					Title: strPtr("项目主页"),
+					Url:   strPtr("https://example.com/a+b?sig=x+y"),
+				}},
+			},
+			options: ConvertOptions{},
+			want:    "[项目主页](https://example.com/a+b?sig=x+y)",
+		},
+		{
 			name: "InlineLinkPreview无标题时使用URL作为文本",
 			elements: []*larkdocx.TextElement{
 				{LinkPreview: &larkdocx.InlineLinkPreview{

--- a/internal/converter/markdown_to_block.go
+++ b/internal/converter/markdown_to_block.go
@@ -2,6 +2,7 @@ package converter
 
 import (
 	"bytes"
+	"encoding/base64"
 	"fmt"
 	"net/url"
 	"path/filepath"
@@ -239,11 +240,6 @@ func normalizeBlockquoteEnding(source []byte) []byte {
 	return []byte(strings.Join(result, "\n"))
 }
 
-type blockEquationSegment struct {
-	kind    string
-	content string
-}
-
 func createTextEquationBlock(formula string) *larkdocx.Block {
 	blockType := int(BlockTypeText)
 	return &larkdocx.Block{
@@ -256,43 +252,178 @@ func createTextEquationBlock(formula string) *larkdocx.Block {
 	}
 }
 
+const blockEquationHTMLTag = "block-equation"
+
+type rawHTMLBlockMode int
+
+const (
+	rawHTMLBlockNone rawHTMLBlockMode = iota
+	rawHTMLBlockUntilBlank
+	rawHTMLBlockUntilClosingTag
+	rawHTMLBlockUntilCommentEnd
+	rawHTMLBlockUntilProcessingEnd
+	rawHTMLBlockUntilCDATAEnd
+	rawHTMLBlockUntilDeclarationEnd
+)
+
+type rawHTMLBlockState struct {
+	mode rawHTMLBlockMode
+	tag  string
+}
+
+var commonMarkHTMLBlockTags = map[string]struct{}{
+	"address": {}, "article": {}, "aside": {}, "base": {}, "basefont": {},
+	"blockquote": {}, "body": {}, "caption": {}, "center": {}, "col": {},
+	"colgroup": {}, "dd": {}, "details": {}, "dialog": {}, "dir": {},
+	"div": {}, "dl": {}, "dt": {}, "fieldset": {}, "figcaption": {},
+	"figure": {}, "footer": {}, "form": {}, "frame": {}, "frameset": {},
+	"h1": {}, "h2": {}, "h3": {}, "h4": {}, "h5": {}, "h6": {},
+	"head": {}, "header": {}, "hr": {}, "html": {}, "iframe": {},
+	"legend": {}, "li": {}, "link": {}, "main": {}, "menu": {},
+	"menuitem": {}, "nav": {}, "noframes": {}, "ol": {}, "optgroup": {},
+	"option": {}, "p": {}, "param": {}, "section": {}, "source": {},
+	"summary": {}, "table": {}, "tbody": {}, "td": {}, "tfoot": {},
+	"th": {}, "thead": {}, "title": {}, "tr": {}, "track": {}, "ul": {},
+}
+
 func parseFenceMarker(line string) (byte, int, string) {
-	trimmed := strings.TrimSpace(line)
-	if len(trimmed) == 0 {
+	indent := 0
+	for indent < len(line) && line[indent] == ' ' {
+		indent++
+	}
+	if indent > 3 {
 		return 0, 0, ""
 	}
-	marker := trimmed[0]
+
+	restLine := line[indent:]
+	if len(restLine) == 0 {
+		return 0, 0, ""
+	}
+	marker := restLine[0]
 	if marker != '`' && marker != '~' {
 		return 0, 0, ""
 	}
 	count := 0
-	for count < len(trimmed) && trimmed[count] == marker {
+	for count < len(restLine) && restLine[count] == marker {
 		count++
 	}
 	if count < 3 {
 		return 0, 0, ""
 	}
-	return marker, count, trimmed[count:]
+	return marker, count, restLine[count:]
 }
 
-func splitBlockEquationSegments(source []byte) ([]blockEquationSegment, bool) {
+func commonMarkBlockStartText(line string) (string, bool) {
+	indent := 0
+	for indent < len(line) && line[indent] == ' ' {
+		indent++
+	}
+	if indent > 3 {
+		return "", false
+	}
+	return strings.TrimSpace(line[indent:]), true
+}
+
+func rawHTMLBlockStart(line string) (rawHTMLBlockState, bool) {
+	trimmed, ok := commonMarkBlockStartText(line)
+	if !ok || trimmed == "" || trimmed[0] != '<' {
+		return rawHTMLBlockState{}, false
+	}
+
+	lower := strings.ToLower(trimmed)
+	switch {
+	case strings.HasPrefix(lower, "<!--"):
+		return rawHTMLBlockState{mode: rawHTMLBlockUntilCommentEnd}, true
+	case strings.HasPrefix(lower, "<?"):
+		return rawHTMLBlockState{mode: rawHTMLBlockUntilProcessingEnd}, true
+	case strings.HasPrefix(lower, "<![cdata["):
+		return rawHTMLBlockState{mode: rawHTMLBlockUntilCDATAEnd}, true
+	case len(lower) >= 3 && strings.HasPrefix(lower, "<!") && lower[2] >= 'a' && lower[2] <= 'z':
+		return rawHTMLBlockState{mode: rawHTMLBlockUntilDeclarationEnd}, true
+	}
+
+	nameStart := 1
+	if len(lower) > 1 && lower[1] == '/' {
+		nameStart = 2
+	}
+	nameEnd := nameStart
+	for nameEnd < len(lower) {
+		ch := lower[nameEnd]
+		if (ch >= 'a' && ch <= 'z') || (ch >= '0' && ch <= '9') {
+			nameEnd++
+			continue
+		}
+		break
+	}
+	if nameEnd == nameStart {
+		return rawHTMLBlockState{}, false
+	}
+
+	tag := lower[nameStart:nameEnd]
+	if _, ok := commonMarkHTMLBlockTags[tag]; ok {
+		return rawHTMLBlockState{mode: rawHTMLBlockUntilBlank}, true
+	}
+	switch tag {
+	case "pre", "script", "style", "textarea":
+		return rawHTMLBlockState{mode: rawHTMLBlockUntilClosingTag, tag: tag}, true
+	}
+	return rawHTMLBlockState{}, false
+}
+
+func rawHTMLBlockClosed(line string, state rawHTMLBlockState) bool {
+	lower := strings.ToLower(line)
+	switch state.mode {
+	case rawHTMLBlockUntilBlank:
+		return strings.TrimSpace(line) == ""
+	case rawHTMLBlockUntilClosingTag:
+		return strings.Contains(lower, "</"+state.tag+">")
+	case rawHTMLBlockUntilCommentEnd:
+		return strings.Contains(lower, "-->")
+	case rawHTMLBlockUntilProcessingEnd:
+		return strings.Contains(lower, "?>")
+	case rawHTMLBlockUntilCDATAEnd:
+		return strings.Contains(lower, "]]>")
+	case rawHTMLBlockUntilDeclarationEnd:
+		return strings.Contains(lower, ">")
+	default:
+		return true
+	}
+}
+
+func encodeBlockEquationHTML(formula string) string {
+	encoded := base64.StdEncoding.EncodeToString([]byte(formula))
+	return fmt.Sprintf("<%s data-base64=\"%s\"/>", blockEquationHTMLTag, encoded)
+}
+
+func decodeBlockEquationHTML(tag *HTMLTag) (string, bool) {
+	if tag == nil || tag.Name != blockEquationHTMLTag {
+		return "", false
+	}
+	if encoded := tag.Attrs["data-base64"]; encoded != "" {
+		decoded, err := base64.StdEncoding.DecodeString(encoded)
+		if err == nil {
+			return string(decoded), true
+		}
+	}
+	if tag.Content != "" {
+		return strings.TrimSpace(tag.Content), true
+	}
+	return "", false
+}
+
+func rewriteBlockEquationsToHTML(source []byte) ([]byte, bool) {
 	lines := strings.Split(string(source), "\n")
-	segments := make([]blockEquationSegment, 0, 1)
-	var buf []string
+	out := make([]string, 0, len(lines))
 	foundEquation := false
 	inFence := false
 	var fenceMarker byte
 	fenceLen := 0
+	rawHTMLState := rawHTMLBlockState{}
 
-	flushMarkdown := func() {
-		if len(buf) == 0 {
-			return
+	appendBlankIfNeeded := func() {
+		if len(out) > 0 && strings.TrimSpace(out[len(out)-1]) != "" {
+			out = append(out, "")
 		}
-		segments = append(segments, blockEquationSegment{
-			kind:    "markdown",
-			content: strings.Join(buf, "\n"),
-		})
-		buf = nil
 	}
 
 	for i := 0; i < len(lines); {
@@ -300,7 +431,7 @@ func splitBlockEquationSegments(source []byte) ([]blockEquationSegment, bool) {
 		trimmed := strings.TrimSpace(line)
 
 		if inFence {
-			buf = append(buf, line)
+			out = append(out, line)
 			if marker, count, rest := parseFenceMarker(line); marker == fenceMarker && count >= fenceLen && strings.TrimSpace(rest) == "" {
 				inFence = false
 				fenceMarker = 0
@@ -310,23 +441,42 @@ func splitBlockEquationSegments(source []byte) ([]blockEquationSegment, bool) {
 			continue
 		}
 
+		if rawHTMLState.mode != rawHTMLBlockNone {
+			out = append(out, line)
+			if rawHTMLBlockClosed(line, rawHTMLState) {
+				rawHTMLState = rawHTMLBlockState{}
+			}
+			i++
+			continue
+		}
+
 		if trimmed == "$$" {
-			flushMarkdown()
 			i++
 			var equationLines []string
-			for i < len(lines) && strings.TrimSpace(lines[i]) != "$$" {
+			closed := false
+			for i < len(lines) {
+				if strings.TrimSpace(lines[i]) == "$$" {
+					closed = true
+					i++
+					break
+				}
 				equationLines = append(equationLines, lines[i])
 				i++
 			}
-			if i < len(lines) {
-				i++
-			}
-			if len(equationLines) > 0 {
+			formula := strings.Join(equationLines, "\n")
+			if closed && strings.TrimSpace(formula) != "" {
 				foundEquation = true
-				segments = append(segments, blockEquationSegment{
-					kind:    "equation",
-					content: strings.Join(equationLines, "\n"),
-				})
+				appendBlankIfNeeded()
+				out = append(out, encodeBlockEquationHTML(formula))
+				if i < len(lines) && strings.TrimSpace(lines[i]) != "" {
+					out = append(out, "")
+				}
+			} else {
+				out = append(out, "$$")
+				out = append(out, equationLines...)
+				if closed {
+					out = append(out, "$$")
+				}
 			}
 			continue
 		}
@@ -335,31 +485,20 @@ func splitBlockEquationSegments(source []byte) ([]blockEquationSegment, bool) {
 			inFence = true
 			fenceMarker = marker
 			fenceLen = count
+		} else if state, ok := rawHTMLBlockStart(line); ok {
+			rawHTMLState = state
+			if rawHTMLBlockClosed(line, rawHTMLState) {
+				rawHTMLState = rawHTMLBlockState{}
+			}
 		}
-		buf = append(buf, line)
+		out = append(out, line)
 		i++
 	}
 
-	flushMarkdown()
-	return segments, foundEquation
-}
-
-func mergeConvertResult(dst *ConvertResult, src *ConvertResult) {
-	if dst == nil || src == nil {
-		return
+	if !foundEquation {
+		return source, false
 	}
-	dst.BlockNodes = append(dst.BlockNodes, src.BlockNodes...)
-	dst.TableDatas = append(dst.TableDatas, src.TableDatas...)
-	dst.ImageSources = append(dst.ImageSources, src.ImageSources...)
-	dst.VideoSources = append(dst.VideoSources, src.VideoSources...)
-	dst.ImageStats.Total += src.ImageStats.Total
-	dst.ImageStats.Success += src.ImageStats.Success
-	dst.ImageStats.Failed += src.ImageStats.Failed
-	dst.ImageStats.Skipped += src.ImageStats.Skipped
-	dst.VideoStats.Total += src.VideoStats.Total
-	dst.VideoStats.Success += src.VideoStats.Success
-	dst.VideoStats.Failed += src.VideoStats.Failed
-	dst.VideoStats.Skipped += src.VideoStats.Skipped
+	return []byte(strings.Join(out, "\n")), true
 }
 
 // ConvertWithTableData converts Markdown to Feishu blocks and returns table data for content filling
@@ -367,30 +506,7 @@ func (c *MarkdownToBlock) ConvertWithTableData() (*ConvertResult, error) {
 	// 预处理：确保引用块后有空行分隔，避免 goldmark 的 lazy continuation
 	c.source = normalizeBlockquoteEnding(c.source)
 
-	if segments, hasEquation := splitBlockEquationSegments(c.source); hasEquation {
-		result := &ConvertResult{}
-		for _, seg := range segments {
-			switch seg.kind {
-			case "markdown":
-				if strings.TrimSpace(seg.content) == "" {
-					continue
-				}
-				inner := NewMarkdownToBlock([]byte(seg.content), c.options, c.basePath)
-				innerResult, err := inner.ConvertWithTableData()
-				if err != nil {
-					return nil, err
-				}
-				mergeConvertResult(result, innerResult)
-			case "equation":
-				result.BlockNodes = append(result.BlockNodes, &BlockNode{Block: createTextEquationBlock(seg.content)})
-			}
-		}
-		c.imageStats = result.ImageStats
-		c.imageSources = result.ImageSources
-		c.videoStats = result.VideoStats
-		c.videoSources = result.VideoSources
-		return result, nil
-	}
+	c.source, _ = rewriteBlockEquationsToHTML(c.source)
 
 	md := goldmark.New(
 		goldmark.WithExtensions(extension.GFM),
@@ -2326,6 +2442,11 @@ func (c *MarkdownToBlock) handleInlineHTMLTag(tag *HTMLTag, inUnderline *bool) [
 // 支持 <image/>, <callout>, <grid>, <whiteboard/>, <sheet/>, <bitable/>, <file/>
 func (c *MarkdownToBlock) handleBlockHTMLTag(tag *HTMLTag) []*BlockNode {
 	switch tag.Name {
+	case blockEquationHTMLTag:
+		if formula, ok := decodeBlockEquationHTML(tag); ok {
+			return []*BlockNode{{Block: createTextEquationBlock(formula)}}
+		}
+		return nil
 	case "image":
 		return c.handleHTMLImageBlock(tag)
 	case "callout":

--- a/internal/converter/markdown_to_block.go
+++ b/internal/converter/markdown_to_block.go
@@ -239,10 +239,158 @@ func normalizeBlockquoteEnding(source []byte) []byte {
 	return []byte(strings.Join(result, "\n"))
 }
 
+type blockEquationSegment struct {
+	kind    string
+	content string
+}
+
+func createTextEquationBlock(formula string) *larkdocx.Block {
+	blockType := int(BlockTypeText)
+	return &larkdocx.Block{
+		BlockType: &blockType,
+		Text: &larkdocx.Text{
+			Elements: []*larkdocx.TextElement{
+				{Equation: &larkdocx.Equation{Content: &formula}},
+			},
+		},
+	}
+}
+
+func parseFenceMarker(line string) (byte, int, string) {
+	trimmed := strings.TrimSpace(line)
+	if len(trimmed) == 0 {
+		return 0, 0, ""
+	}
+	marker := trimmed[0]
+	if marker != '`' && marker != '~' {
+		return 0, 0, ""
+	}
+	count := 0
+	for count < len(trimmed) && trimmed[count] == marker {
+		count++
+	}
+	if count < 3 {
+		return 0, 0, ""
+	}
+	return marker, count, trimmed[count:]
+}
+
+func splitBlockEquationSegments(source []byte) ([]blockEquationSegment, bool) {
+	lines := strings.Split(string(source), "\n")
+	segments := make([]blockEquationSegment, 0, 1)
+	var buf []string
+	foundEquation := false
+	inFence := false
+	var fenceMarker byte
+	fenceLen := 0
+
+	flushMarkdown := func() {
+		if len(buf) == 0 {
+			return
+		}
+		segments = append(segments, blockEquationSegment{
+			kind:    "markdown",
+			content: strings.Join(buf, "\n"),
+		})
+		buf = nil
+	}
+
+	for i := 0; i < len(lines); {
+		line := lines[i]
+		trimmed := strings.TrimSpace(line)
+
+		if inFence {
+			buf = append(buf, line)
+			if marker, count, rest := parseFenceMarker(line); marker == fenceMarker && count >= fenceLen && strings.TrimSpace(rest) == "" {
+				inFence = false
+				fenceMarker = 0
+				fenceLen = 0
+			}
+			i++
+			continue
+		}
+
+		if trimmed == "$$" {
+			flushMarkdown()
+			i++
+			var equationLines []string
+			for i < len(lines) && strings.TrimSpace(lines[i]) != "$$" {
+				equationLines = append(equationLines, lines[i])
+				i++
+			}
+			if i < len(lines) {
+				i++
+			}
+			if len(equationLines) > 0 {
+				foundEquation = true
+				segments = append(segments, blockEquationSegment{
+					kind:    "equation",
+					content: strings.Join(equationLines, "\n"),
+				})
+			}
+			continue
+		}
+
+		if marker, count, _ := parseFenceMarker(line); count >= 3 {
+			inFence = true
+			fenceMarker = marker
+			fenceLen = count
+		}
+		buf = append(buf, line)
+		i++
+	}
+
+	flushMarkdown()
+	return segments, foundEquation
+}
+
+func mergeConvertResult(dst *ConvertResult, src *ConvertResult) {
+	if dst == nil || src == nil {
+		return
+	}
+	dst.BlockNodes = append(dst.BlockNodes, src.BlockNodes...)
+	dst.TableDatas = append(dst.TableDatas, src.TableDatas...)
+	dst.ImageSources = append(dst.ImageSources, src.ImageSources...)
+	dst.VideoSources = append(dst.VideoSources, src.VideoSources...)
+	dst.ImageStats.Total += src.ImageStats.Total
+	dst.ImageStats.Success += src.ImageStats.Success
+	dst.ImageStats.Failed += src.ImageStats.Failed
+	dst.ImageStats.Skipped += src.ImageStats.Skipped
+	dst.VideoStats.Total += src.VideoStats.Total
+	dst.VideoStats.Success += src.VideoStats.Success
+	dst.VideoStats.Failed += src.VideoStats.Failed
+	dst.VideoStats.Skipped += src.VideoStats.Skipped
+}
+
 // ConvertWithTableData converts Markdown to Feishu blocks and returns table data for content filling
 func (c *MarkdownToBlock) ConvertWithTableData() (*ConvertResult, error) {
 	// 预处理：确保引用块后有空行分隔，避免 goldmark 的 lazy continuation
 	c.source = normalizeBlockquoteEnding(c.source)
+
+	if segments, hasEquation := splitBlockEquationSegments(c.source); hasEquation {
+		result := &ConvertResult{}
+		for _, seg := range segments {
+			switch seg.kind {
+			case "markdown":
+				if strings.TrimSpace(seg.content) == "" {
+					continue
+				}
+				inner := NewMarkdownToBlock([]byte(seg.content), c.options, c.basePath)
+				innerResult, err := inner.ConvertWithTableData()
+				if err != nil {
+					return nil, err
+				}
+				mergeConvertResult(result, innerResult)
+			case "equation":
+				result.BlockNodes = append(result.BlockNodes, &BlockNode{Block: createTextEquationBlock(seg.content)})
+			}
+		}
+		c.imageStats = result.ImageStats
+		c.imageSources = result.ImageSources
+		c.videoStats = result.VideoStats
+		c.videoSources = result.VideoSources
+		return result, nil
+	}
 
 	md := goldmark.New(
 		goldmark.WithExtensions(extension.GFM),

--- a/internal/converter/markdown_to_block_test.go
+++ b/internal/converter/markdown_to_block_test.go
@@ -3,6 +3,8 @@ package converter
 import (
 	"strings"
 	"testing"
+
+	larkdocx "github.com/larksuite/oapi-sdk-go/v3/service/docx/v1"
 )
 
 func TestNewMarkdownToBlock(t *testing.T) {
@@ -129,6 +131,80 @@ func TestConvert_BlockEquationIgnoredInsideFence(t *testing.T) {
 	if got != want {
 		t.Fatalf("代码块内容 = %q，期望 %q", got, want)
 	}
+}
+
+func TestConvert_BlockEquationAfterIndentedFenceLikeText(t *testing.T) {
+	markdown := "    ```\n\n$$\nE = mc^2\n$$"
+
+	converter := NewMarkdownToBlock([]byte(markdown), ConvertOptions{}, "")
+	blocks, err := converter.Convert()
+	if err != nil {
+		t.Fatalf("Convert() 返回错误: %v", err)
+	}
+	if countEquationElements(blocks) != 1 {
+		t.Fatalf("公式元素数量 = %d，期望 1", countEquationElements(blocks))
+	}
+}
+
+func TestConvert_BlockEquationPreservesReferenceLinkContext(t *testing.T) {
+	markdown := "[ref]: https://example.com/path\n\n$$\nE = mc^2\n$$\n\nSee [ref]"
+
+	converter := NewMarkdownToBlock([]byte(markdown), ConvertOptions{}, "")
+	blocks, err := converter.Convert()
+	if err != nil {
+		t.Fatalf("Convert() 返回错误: %v", err)
+	}
+	if countEquationElements(blocks) != 1 {
+		t.Fatalf("公式元素数量 = %d，期望 1", countEquationElements(blocks))
+	}
+
+	for _, block := range blocks {
+		if block.Text == nil {
+			continue
+		}
+		for _, elem := range block.Text.Elements {
+			if elem.TextRun == nil || elem.TextRun.Content == nil || *elem.TextRun.Content != "ref" {
+				continue
+			}
+			style := elem.TextRun.TextElementStyle
+			if style == nil || style.Link == nil || style.Link.Url == nil {
+				t.Fatal("引用式链接在公式拆分后丢失了 Link 样式")
+			}
+			if *style.Link.Url != "https://example.com/path" {
+				t.Fatalf("链接 URL = %q，期望 https://example.com/path", *style.Link.Url)
+			}
+			return
+		}
+	}
+	t.Fatal("未找到引用式链接文本")
+}
+
+func TestConvert_BlockEquationIgnoredInsideRawHTMLBlock(t *testing.T) {
+	markdown := "<pre>\n$$\nliteral\n$$\n</pre>\n\n$$\nreal\n$$"
+
+	converter := NewMarkdownToBlock([]byte(markdown), ConvertOptions{}, "")
+	blocks, err := converter.Convert()
+	if err != nil {
+		t.Fatalf("Convert() 返回错误: %v", err)
+	}
+	if countEquationElements(blocks) != 1 {
+		t.Fatalf("公式元素数量 = %d，期望 1", countEquationElements(blocks))
+	}
+}
+
+func countEquationElements(blocks []*larkdocx.Block) int {
+	count := 0
+	for _, block := range blocks {
+		if block == nil || block.Text == nil {
+			continue
+		}
+		for _, elem := range block.Text.Elements {
+			if elem != nil && elem.Equation != nil {
+				count++
+			}
+		}
+	}
+	return count
 }
 
 func TestConvert_ConsecutiveLinesBecomeSeparateBlocks(t *testing.T) {

--- a/internal/converter/markdown_to_block_test.go
+++ b/internal/converter/markdown_to_block_test.go
@@ -79,6 +79,58 @@ func TestConvert_Paragraph(t *testing.T) {
 	}
 }
 
+func TestConvert_BlockEquationCreatesTextEquation(t *testing.T) {
+	markdown := "前言\n\n$$\nE = mc^2\n\\nu + 1\n$$\n\n后记"
+
+	converter := NewMarkdownToBlock([]byte(markdown), ConvertOptions{}, "")
+	blocks, err := converter.Convert()
+	if err != nil {
+		t.Fatalf("Convert() 返回错误: %v", err)
+	}
+	if len(blocks) != 3 {
+		t.Fatalf("blocks 数量 = %d，期望 3", len(blocks))
+	}
+
+	if blocks[1].BlockType == nil || *blocks[1].BlockType != int(BlockTypeText) {
+		t.Fatalf("公式块类型 = %v，期望 Text", blocks[1].BlockType)
+	}
+	if blocks[1].Text == nil || len(blocks[1].Text.Elements) != 1 {
+		t.Fatalf("公式块元素数量异常: %#v", blocks[1].Text)
+	}
+	eq := blocks[1].Text.Elements[0].Equation
+	if eq == nil || eq.Content == nil {
+		t.Fatal("公式块应包含 Equation 元素")
+	}
+	want := "E = mc^2\n\\nu + 1"
+	if *eq.Content != want {
+		t.Fatalf("公式内容 = %q，期望 %q", *eq.Content, want)
+	}
+}
+
+func TestConvert_BlockEquationIgnoredInsideFence(t *testing.T) {
+	markdown := "```latex\n$$\n\\nu + 1\n$$\n```"
+
+	converter := NewMarkdownToBlock([]byte(markdown), ConvertOptions{}, "")
+	blocks, err := converter.Convert()
+	if err != nil {
+		t.Fatalf("Convert() 返回错误: %v", err)
+	}
+	if len(blocks) != 1 {
+		t.Fatalf("blocks 数量 = %d，期望 1", len(blocks))
+	}
+	if blocks[0].BlockType == nil || *blocks[0].BlockType != int(BlockTypeCode) {
+		t.Fatalf("块类型 = %v，期望 Code", blocks[0].BlockType)
+	}
+	if blocks[0].Code == nil || len(blocks[0].Code.Elements) != 1 || blocks[0].Code.Elements[0].TextRun == nil {
+		t.Fatalf("代码块内容异常: %#v", blocks[0].Code)
+	}
+	got := *blocks[0].Code.Elements[0].TextRun.Content
+	want := "$$\n\\nu + 1\n$$"
+	if got != want {
+		t.Fatalf("代码块内容 = %q，期望 %q", got, want)
+	}
+}
+
 func TestConvert_ConsecutiveLinesBecomeSeparateBlocks(t *testing.T) {
 	// 回归测试：连续行（无空行分隔）应生成独立 Text 块，而非合并为一段
 	// 典型场景：**A派**：xxx\n**B派**：yyy 导入飞书后应为两行


### PR DESCRIPTION
## Summary

Fixes the current open issues:

- Fixes #145 by moving block-level `$$...$$` equation parsing into the shared Markdown converter and preserving LaTeX backslashes for `doc content-update --markdown-file`.
- Fixes #146 by adding `--expand-mentions` to `wiki export` and `wiki export-tree`, defaulting to the same friendly mention expansion behavior as `doc export`.
- Fixes #147 by exporting inline `text.elements[].link_preview` as Markdown links instead of dropping the element.
- Fixes #148 by allowing `msg list`, `msg get`, and `msg history --container-id` to use App/Tenant Token by default while preserving explicit User Token behavior.

## Tests

- `gofmt -l cmd internal`
- `git diff --check`
- `go test ./internal/converter ./internal/client ./cmd`
- `go test ./...`
- `go vet ./...`
- `go build -o /tmp/feishu-cli-fix-issues .`

## Real Binary Verification

Used `/tmp/feishu-cli-fix-issues` built from this branch against real Feishu examples:

- #145: real doc import + `doc add --content-type markdown` + `doc content-update --markdown-file`; resulting blocks had 3 equation elements, 0 `$$` text runs, and 0 split LaTeX fragments.
- #146: real wiki docx node with a real mention; default export expanded mention, `--expand-mentions=false` preserved `<mention-user/>`.
- #147: real doc with API-returned inline `link_preview`; exported Markdown contained both preview title and URL.
- #148: real test chat/message; `msg list`, `msg get`, and `msg history --container-id` succeeded with no User Token in `HOME`/env, exercising Tenant Token path.
