### PR TITLE
docs(feishu-cli-board): 补充曲线 path 转节点退化的避坑说明

### DIFF
--- a/skills/feishu-cli-board/references/svg-workflow.md
+++ b/skills/feishu-cli-board/references/svg-workflow.md
@@ -58,6 +58,7 @@
   - `<foreignObject>`（飞书不支持 HTML 嵌入）
   - 外链 `<image href="https://...">`（改用 `board upload-image`）
   - 复杂动画 `<animate>` `<animateTransform>`（飞书静态画板不支持）
+  - **用曲线 `<path>`（贝塞尔 `Q`/`C`、弧 `A`）画连接线 / 自环 / 弧线箭头**——whiteboard-cli 转节点时曲率会丢失，退化成直线甚至悬空在节点旁（实测：状态机 `healthy` 自环用 `M..Q..` 画，渲染成一条飘在节点上方、不连回节点的孤立直线）。**画自环 / 弧线 / 曲线连接一律用多段 `<line>` 或 `<polyline>` 折线拼**（直线 → connector，渲染稳定，箭头三角用小 `<polygon>`）。纯装饰性的曲线填充图形（如插画里的山脊、花瓣，非连接语义）可保留，会转 svg 节点。
 
 #### 极坐标 / 三角函数布局（飞轮 / 雷达图）
 
@@ -238,6 +239,7 @@ whiteboard-cli 的翻译规则（实测整理）：
 - `opacity`：转为 `style.fill_opacity` / `style.border_opacity`
 - `font-family`：飞书强制用自家字体（Noto / 苹方），不保留自定义字体
 - `<use>`：不支持（whiteboard-cli 可能展开，可能丢失）
+- 曲线 `<path>`（`Q`/`C` 贝塞尔、`A` 弧）：作**连接线 / 自环**用时曲率易丢、退化为直线或悬空 → 改用多段 `<line>` / `<polyline>` 折线；作**填充形状**用时转 svg 节点尚可保留
 
 ---
 


### PR DESCRIPTION
## 背景

`whiteboard-cli` 把 SVG 转飞书原生节点时，曲线 `<path>`（贝塞尔 `Q`/`C`、弧 `A`）作**连接线 / 自环 / 弧线箭头**用时曲率会丢失，退化成直线甚至悬空在节点旁。

**实测案例**：用 SVG-first 画状态机时，`healthy` 节点的 transient 自环用 `M..Q..` 贝塞尔画，经 whiteboard-cli 转换后渲染成一条飘在节点上方、不连回节点的孤立直线。改用三段 `<line>` 折线拼成 ∏ 形回路后恢复正常。

## 改动

在 `skills/feishu-cli-board/references/svg-workflow.md` 两处各补一条避坑说明：
- **「设计原则 · 避免」清单**：画自环 / 弧线 / 曲线连接一律用多段 `<line>` / `<polyline>` 折线拼（直线 → connector 渲染稳定）；装饰性曲线填充图形不受影响
- **「翻译边界情况」**：曲线 path 作连接线用时易退化，作填充形状用时转 svg 节点尚可保留

纯文档补充，不涉及代码。

🤖 Generated with [Claude Code](https://claude.com/claude-code)