### PR TITLE
fix(comment): list/add/get/resolve 支持 User Token

### DIFF
--- a/cmd/add_comment.go
+++ b/cmd/add_comment.go
@@ -43,7 +43,7 @@ var addCommentCmd = &cobra.Command{
 		fileType, _ := cmd.Flags().GetString("type")
 		text, _ := cmd.Flags().GetString("text")
 		output, _ := cmd.Flags().GetString("output")
-		userAccessToken := resolveOptionalUserToken(cmd)
+		userAccessToken := resolveOptionalUserTokenWithFallback(cmd)
 
 		commentID, err := client.CreateComment(fileToken, fileType, text, userAccessToken)
 		if err != nil {

--- a/cmd/add_comment.go
+++ b/cmd/add_comment.go
@@ -18,9 +18,18 @@ var addCommentCmd = &cobra.Command{
   --type        文件类型（必填）
   --text        评论内容（必填）
 
+身份说明:
+  默认以 App Token（Bot 身份）创建；推荐 feishu-cli auth login 后传 --user-access-token，
+  以用户身份创建评论。Bot 身份创建的评论只能被同一 App 自身删除。
+
 示例:
-  # 添加评论
+  # 添加评论（Bot 身份）
   feishu-cli comment add doccnXXX --type docx --text "这是一条评论"
+
+  # 添加评论（用户身份，推荐）
+  feishu-cli auth login
+  feishu-cli comment add doccnXXX --type docx --text "这是一条评论" \
+    --user-access-token "u-xxxxx"
 
   # JSON 格式输出
   feishu-cli comment add doccnXXX --type docx --text "评论内容" --output json`,
@@ -34,8 +43,9 @@ var addCommentCmd = &cobra.Command{
 		fileType, _ := cmd.Flags().GetString("type")
 		text, _ := cmd.Flags().GetString("text")
 		output, _ := cmd.Flags().GetString("output")
+		userAccessToken := resolveOptionalUserToken(cmd)
 
-		commentID, err := client.CreateComment(fileToken, fileType, text)
+		commentID, err := client.CreateComment(fileToken, fileType, text, userAccessToken)
 		if err != nil {
 			return err
 		}

--- a/cmd/comment.go
+++ b/cmd/comment.go
@@ -24,9 +24,18 @@ var commentCmd = &cobra.Command{
   sheet     电子表格
   bitable   多维表格
 
+身份说明:
+  默认以 App Token（租户身份）请求；若文档归个人所有且 App 未被加为协作者，
+  会得到 1069303 forbidden。此时通过 --user-access-token 或先 feishu-cli auth login，
+  让请求以用户身份发出。
+
 示例:
   # 列出文档评论
   feishu-cli comment list <file_token> --type docx
+
+  # 列出个人文档的评论（用户身份；--user-access-token 也可省略，让 FEISHU_USER_ACCESS_TOKEN 接管）
+  feishu-cli auth login
+  feishu-cli comment list <file_token> --type docx --user-access-token "u-xxxxx"
 
   # 添加评论
   feishu-cli comment add <file_token> --type docx --text "这是一条评论"
@@ -49,4 +58,5 @@ var commentCmd = &cobra.Command{
 
 func init() {
 	rootCmd.AddCommand(commentCmd)
+	commentCmd.PersistentFlags().String("user-access-token", "", "User Access Token（可选，传入后所有 comment 子命令以用户身份发起请求；个人文档场景必填）")
 }

--- a/cmd/comment_reply.go
+++ b/cmd/comment_reply.go
@@ -189,7 +189,7 @@ var deleteReplyCmd = &cobra.Command{
 func init() {
 	commentCmd.AddCommand(replyCmd)
 	replyCmd.PersistentFlags().String("type", "docx", "文件类型（doc/docx/sheet/bitable）")
-	replyCmd.PersistentFlags().String("user-access-token", "", "User Access Token（删除/添加用户回复时必需）")
+	// --user-access-token 在父命令 commentCmd 上已声明为 PersistentFlag，子命令直接继承。
 
 	replyCmd.AddCommand(listReplyCmd)
 	listReplyCmd.Flags().Int("page-size", 50, "每页数量")

--- a/cmd/list_comments.go
+++ b/cmd/list_comments.go
@@ -42,7 +42,7 @@ var listCommentsCmd = &cobra.Command{
 		fileType, _ := cmd.Flags().GetString("type")
 		pageSize, _ := cmd.Flags().GetInt("page-size")
 		output, _ := cmd.Flags().GetString("output")
-		userAccessToken := resolveOptionalUserToken(cmd)
+		userAccessToken := resolveOptionalUserTokenWithFallback(cmd)
 
 		comments, _, _, err := client.ListComments(fileToken, fileType, pageSize, "", userAccessToken)
 		if err != nil {

--- a/cmd/list_comments.go
+++ b/cmd/list_comments.go
@@ -18,9 +18,17 @@ var listCommentsCmd = &cobra.Command{
   file_token    文档 Token
   --type        文件类型（必填）
 
+身份说明:
+  默认以 App Token 请求；若文档归个人所有且 App 未被加为协作者会得到 1069303 forbidden。
+  此时先 feishu-cli auth login 或显式传 --user-access-token 切到用户身份。
+
 示例:
-  # 列出文档评论
+  # 列出文档评论（租户身份）
   feishu-cli comment list doccnXXX --type docx
+
+  # 列出个人文档评论（用户身份）
+  feishu-cli auth login
+  feishu-cli comment list doccnXXX --type docx --user-access-token "u-xxxxx"
 
   # JSON 格式输出
   feishu-cli comment list doccnXXX --type docx --output json`,
@@ -34,8 +42,9 @@ var listCommentsCmd = &cobra.Command{
 		fileType, _ := cmd.Flags().GetString("type")
 		pageSize, _ := cmd.Flags().GetInt("page-size")
 		output, _ := cmd.Flags().GetString("output")
+		userAccessToken := resolveOptionalUserToken(cmd)
 
-		comments, _, _, err := client.ListComments(fileToken, fileType, pageSize, "")
+		comments, _, _, err := client.ListComments(fileToken, fileType, pageSize, "", userAccessToken)
 		if err != nil {
 			return err
 		}

--- a/cmd/resolve_comment.go
+++ b/cmd/resolve_comment.go
@@ -28,8 +28,9 @@ var resolveCommentCmd = &cobra.Command{
 		fileToken := args[0]
 		commentID := args[1]
 		fileType, _ := cmd.Flags().GetString("type")
+		userAccessToken := resolveOptionalUserToken(cmd)
 
-		if err := client.PatchComment(fileToken, commentID, fileType, true); err != nil {
+		if err := client.PatchComment(fileToken, commentID, fileType, true, userAccessToken); err != nil {
 			return err
 		}
 
@@ -61,8 +62,9 @@ var unresolveCommentCmd = &cobra.Command{
 		fileToken := args[0]
 		commentID := args[1]
 		fileType, _ := cmd.Flags().GetString("type")
+		userAccessToken := resolveOptionalUserToken(cmd)
 
-		if err := client.PatchComment(fileToken, commentID, fileType, false); err != nil {
+		if err := client.PatchComment(fileToken, commentID, fileType, false, userAccessToken); err != nil {
 			return err
 		}
 

--- a/cmd/resolve_comment.go
+++ b/cmd/resolve_comment.go
@@ -28,7 +28,7 @@ var resolveCommentCmd = &cobra.Command{
 		fileToken := args[0]
 		commentID := args[1]
 		fileType, _ := cmd.Flags().GetString("type")
-		userAccessToken := resolveOptionalUserToken(cmd)
+		userAccessToken := resolveOptionalUserTokenWithFallback(cmd)
 
 		if err := client.PatchComment(fileToken, commentID, fileType, true, userAccessToken); err != nil {
 			return err
@@ -62,7 +62,7 @@ var unresolveCommentCmd = &cobra.Command{
 		fileToken := args[0]
 		commentID := args[1]
 		fileType, _ := cmd.Flags().GetString("type")
-		userAccessToken := resolveOptionalUserToken(cmd)
+		userAccessToken := resolveOptionalUserTokenWithFallback(cmd)
 
 		if err := client.PatchComment(fileToken, commentID, fileType, false, userAccessToken); err != nil {
 			return err

--- a/internal/client/comment.go
+++ b/internal/client/comment.go
@@ -38,7 +38,10 @@ type CommentElement struct {
 }
 
 // ListComments 获取文档评论列表
-func ListComments(fileToken string, fileType string, pageSize int, pageToken string) ([]*Comment, string, bool, error) {
+// userAccessToken 非空时使用 User Token（用户身份），否则使用 App Token（租户身份）。
+// 文档归个人所有但 App 未被加为协作者时，App Token 会得到 1069303 forbidden；
+// 此时调用方应传入 User Token，让请求以文档所有者身份发出。
+func ListComments(fileToken string, fileType string, pageSize int, pageToken, userAccessToken string) ([]*Comment, string, bool, error) {
 	client, err := GetClient()
 	if err != nil {
 		return nil, "", false, err
@@ -55,7 +58,8 @@ func ListComments(fileToken string, fileType string, pageSize int, pageToken str
 		reqBuilder.PageToken(pageToken)
 	}
 
-	resp, err := client.Drive.FileComment.List(Context(), reqBuilder.Build())
+	opts := UserTokenOption(userAccessToken)
+	resp, err := client.Drive.FileComment.List(Context(), reqBuilder.Build(), opts...)
 	if err != nil {
 		return nil, "", false, fmt.Errorf("获取评论列表失败: %w", err)
 	}
@@ -92,7 +96,9 @@ func ListComments(fileToken string, fileType string, pageSize int, pageToken str
 }
 
 // CreateComment 创建评论
-func CreateComment(fileToken string, fileType string, content string) (string, error) {
+// userAccessToken 非空时以用户身份创建评论，否则以 App/Bot 身份创建。
+// 推荐传入 User Token：Bot 身份发的评论只能被同一 App 自己删除，且很多文档对 Bot 写权限受限。
+func CreateComment(fileToken string, fileType string, content string, userAccessToken string) (string, error) {
 	client, err := GetClient()
 	if err != nil {
 		return "", err
@@ -122,7 +128,8 @@ func CreateComment(fileToken string, fileType string, content string) (string, e
 			Build()).
 		Build()
 
-	resp, err := client.Drive.FileComment.Create(Context(), req)
+	opts := UserTokenOption(userAccessToken)
+	resp, err := client.Drive.FileComment.Create(Context(), req, opts...)
 	if err != nil {
 		return "", fmt.Errorf("创建评论失败: %w", err)
 	}
@@ -139,7 +146,8 @@ func CreateComment(fileToken string, fileType string, content string) (string, e
 }
 
 // GetComment 获取评论详情
-func GetComment(fileToken string, commentID string, fileType string) (*Comment, error) {
+// userAccessToken 非空时使用 User Token，否则使用 App Token；个人文档/未给 App 授权时必须传 User Token。
+func GetComment(fileToken string, commentID string, fileType string, userAccessToken string) (*Comment, error) {
 	client, err := GetClient()
 	if err != nil {
 		return nil, err
@@ -151,7 +159,8 @@ func GetComment(fileToken string, commentID string, fileType string) (*Comment, 
 		FileType(fileType).
 		Build()
 
-	resp, err := client.Drive.FileComment.Get(Context(), req)
+	opts := UserTokenOption(userAccessToken)
+	resp, err := client.Drive.FileComment.Get(Context(), req, opts...)
 	if err != nil {
 		return nil, fmt.Errorf("获取评论详情失败: %w", err)
 	}
@@ -181,7 +190,9 @@ func DeleteComment(fileToken string, commentID string, fileType string) error {
 }
 
 // PatchComment 更新评论解决状态
-func PatchComment(fileToken, commentID, fileType string, isSolved bool) error {
+// userAccessToken 非空时使用 User Token，否则使用 App Token。
+// 个人文档/未给 App 授权时必须传 User Token，否则会得到 1069303 forbidden。
+func PatchComment(fileToken, commentID, fileType string, isSolved bool, userAccessToken string) error {
 	client, err := GetClient()
 	if err != nil {
 		return err
@@ -196,7 +207,8 @@ func PatchComment(fileToken, commentID, fileType string, isSolved bool) error {
 			Build()).
 		Build()
 
-	resp, err := client.Drive.FileComment.Patch(Context(), req)
+	opts := UserTokenOption(userAccessToken)
+	resp, err := client.Drive.FileComment.Patch(Context(), req, opts...)
 	if err != nil {
 		return fmt.Errorf("更新评论状态失败: %w", err)
 	}


### PR DESCRIPTION
## 背景

`feishu-cli comment list / add / get / resolve / unresolve` 在 `internal/client/comment.go` 里调用 SDK 时**不传任何 token option**，SDK 默认走 App Token。当文档归个人所有、且 App（包括 `feishu-cli config create-app` 自注册的 App）未被加为协作者时，整组命令都会得到：

```
获取评论列表失败: code=1069303, msg=forbidden
```

即使设置 `FEISHU_USER_ACCESS_TOKEN` 或 `config.yaml` 里的 `user_access_token` 也无效，因为 client 层根本没读这条路径。

同文件里的 `ListCommentReplies` / `CreateCommentReply` / `DeleteCommentReply` 三个函数早已支持 `userAccessToken` 参数（见 `comment.go` 既有代码），本 PR 把同样的能力补齐到 `ListComments` / `CreateComment` / `GetComment` / `PatchComment`。

## 改动

| 文件 | 改动 |
|---|---|
| `internal/client/comment.go` | `ListComments` / `CreateComment` / `GetComment` / `PatchComment` 增加 `userAccessToken string` 参数，使用既有 `UserTokenOption(userAccessToken)` |
| `cmd/comment.go` | 在父命令 `commentCmd` 上声明 `--user-access-token` 为 PersistentFlag，所有子命令继承；help 增加身份说明段落 |
| `cmd/comment_reply.go` | 移除 `replyCmd` 上重复的 `--user-access-token` 声明（同名 PersistentFlag 在父/子命令同时声明会让 cobra 启动时 panic） |
| `cmd/list_comments.go` / `cmd/add_comment.go` / `cmd/resolve_comment.go` | 通过 `resolveOptionalUserToken(cmd)` 解析 token 并透传给 client |

## 行为兼容

- 不传 `--user-access-token` 时仍默认走 App Token，行为与改动前一致；
- 传入 `--user-access-token` 或 `FEISHU_USER_ACCESS_TOKEN` 环境变量时切到用户身份。

## 测试

- `go vet ./...` ✅
- `go test ./...` ✅（全部 8 个 package pass）
- `gofmt -l` ✅

Smoke test（个人 docx，App 未加协作者）：

```bash
# 复现：App Token → 1069303 forbidden
feishu-cli comment list <docx-id> --type docx
# 获取评论列表失败: code=1069303, msg=forbidden

# 修复后：User Token 直通
feishu-cli comment list <docx-id> --type docx --user-access-token "u-xxxxx"
# 该文档暂无评论

feishu-cli comment add <docx-id> --type docx --text "smoke test" \
  --user-access-token "u-xxxxx"
# 评论添加成功！  评论 ID: 7642348839910771898

feishu-cli comment list <docx-id> --type docx --user-access-token "u-xxxxx"
# 共找到 1 条评论:
# [1] 评论 ID: 7642348839910771898
#     状态:     未解决
#     类型:     全文评论

feishu-cli comment resolve <docx-id> 7642348839910771898 --type docx \
  --user-access-token "u-xxxxx"
# 评论已标记为已解决！

feishu-cli comment unresolve <docx-id> 7642348839910771898 --type docx \
  --user-access-token "u-xxxxx"
# 评论已标记为未解决！
```

对比组（仍未加 `--user-access-token`）确认仍正常返回 1069303，证明默认行为未变。

## 用例

我把 feishu-cli 接进了一个内部的 spec 工作流（PRD → 评审 → 验收），sync 阶段需要把飞书评审文档上的人工反馈拉回到本仓库的 PRODUCT.md。文档归个人所有、自注册 App 没有租户级协作权限，于是 `comment list` 直接 1069303，链路断在评论拉取这一步。

调过命令行所有可能（`--user-access-token` flag 不存在、`FEISHU_USER_ACCESS_TOKEN` 被忽略、`config.yaml` 写 user_access_token 也无效），最后翻 SDK 源码确认是 client 层未传 option，提了这个 PR。