### PR TITLE
fix: msg resource download with user token

### DIFF
--- a/README.md
+++ b/README.md
@@ -481,6 +481,7 @@ feishu-cli file mkdir "新文件夹" --parent <folder_token>
 # 上传 / 下载
 feishu-cli file upload local_file.pdf --parent FOLDER_TOKEN
 feishu-cli file download <file_token> -o output.pdf
+feishu-cli file download <file_token> -o large.zip --user-access-token u-xxx --timeout 30m  # 大文件自动 Range 分片兜底
 
 # 版本管理
 feishu-cli file version list <doc_token> --doc-type docx
@@ -718,6 +719,7 @@ feishu-cli bitable role list --base-token bscnxxxx
 # 云盘增强（drive）
 feishu-cli drive upload --file big.zip --folder-token fldxxx
 feishu-cli drive download --file-token boxxxx --output ./downloads/ --overwrite
+feishu-cli drive download --file-token boxxxx --output ./big.zip --timeout 30m  # 大文件自动 Range 分片兜底
 feishu-cli drive export --token docxxxx --doc-type docx --file-extension markdown --output-dir ./exports
 feishu-cli drive export --token sheetxxxx --doc-type sheet --file-extension csv --sub-id sheet_1 --output-dir ./out
 feishu-cli drive import --file report.docx --type docx --folder-token fldxxx
@@ -777,6 +779,7 @@ feishu-cli tasklist member add <tasklist_guid> --members ou_xxx
 feishu-cli msg mget --message-ids om_xxx,om_yyy
 feishu-cli msg resource-download <message_id> <file_key> --type image -o photo.png
 feishu-cli msg resource-download <message_id> <file_key> --type file --user-access-token u-xxx -o attachment.bin  # 用户可见但 Bot 不可见的资源
+feishu-cli msg resource-download <message_id> <file_key> --type file --user-access-token u-xxx -o large.bin --timeout 30m  # 大文件自动 Range 分片兜底
 feishu-cli msg thread-messages <thread_id> --page-size 20
 feishu-cli msg flag create om_xxx                                  # 收藏消息
 feishu-cli msg flag create om_xxx --flag-type feed                 # feed 层自动识别 thread/msg_thread

--- a/README.md
+++ b/README.md
@@ -776,6 +776,7 @@ feishu-cli tasklist member add <tasklist_guid> --members ou_xxx
 # 消息增强
 feishu-cli msg mget --message-ids om_xxx,om_yyy
 feishu-cli msg resource-download <message_id> <file_key> --type image -o photo.png
+feishu-cli msg resource-download <message_id> <file_key> --type file --user-access-token u-xxx -o attachment.bin  # 用户可见但 Bot 不可见的资源
 feishu-cli msg thread-messages <thread_id> --page-size 20
 feishu-cli msg flag create om_xxx                                  # 收藏消息
 feishu-cli msg flag create om_xxx --flag-type feed                 # feed 层自动识别 thread/msg_thread

--- a/cmd/download_file.go
+++ b/cmd/download_file.go
@@ -13,6 +13,7 @@ var downloadFileCmd = &cobra.Command{
 	Use:   "download <file_token>",
 	Short: "下载云空间文件",
 	Long: `从云空间下载文件到本地。
+使用用户身份下载时，如遇到飞书大文件限制，会自动使用 HTTP Range 分片下载并合并。
 
 参数:
   file_token    文件的 Token

--- a/cmd/drive_download.go
+++ b/cmd/drive_download.go
@@ -15,6 +15,7 @@ var driveDownloadCmd = &cobra.Command{
 	Use:   "download",
 	Short: "下载云盘文件到本地",
 	Long: `下载云盘文件到本地。
+如遇到飞书大文件限制，会自动使用 HTTP Range 分片下载并合并。
 
 必填:
   --file-token    云盘文件 token

--- a/cmd/msg_resource_download.go
+++ b/cmd/msg_resource_download.go
@@ -22,6 +22,7 @@ var msgResourceDownloadCmd = &cobra.Command{
   --type       资源类型（image 或 file，必填）
   -o, --output 输出文件路径（默认使用 file_key）
   --timeout    下载超时时间（默认 5m，大文件可设置更长如 30m、1h）
+  --user-access-token  使用用户身份下载用户可见、但 Bot 不可见的历史消息资源
 
 示例:
   # 下载图片
@@ -29,6 +30,9 @@ var msgResourceDownloadCmd = &cobra.Command{
 
   # 下载文件
   feishu-cli msg resource-download om_xxx file_xxx --type file -o document.pdf
+
+  # 使用用户身份下载
+  feishu-cli msg resource-download om_xxx file_xxx --type file --user-access-token u-xxx -o document.pdf
 
   # 大文件下载，设置 30 分钟超时
   feishu-cli msg resource-download om_xxx file_xxx --type file -o large.zip --timeout 30m`,

--- a/cmd/msg_resource_download.go
+++ b/cmd/msg_resource_download.go
@@ -13,6 +13,7 @@ var msgResourceDownloadCmd = &cobra.Command{
 	Use:   "resource-download <message_id> <file_key>",
 	Short: "下载消息中的资源文件（图片/文件）",
 	Long: `下载消息中的图片或文件资源。
+使用用户身份直连下载时，如遇到飞书大文件限制，会自动使用 HTTP Range 分片下载并合并。
 
 参数:
   message_id  消息 ID（om_xxx 格式）

--- a/internal/client/drive.go
+++ b/internal/client/drive.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"net/url"
 	"os"
 	"path/filepath"
 	"strings"
@@ -14,6 +15,7 @@ import (
 
 	larkcore "github.com/larksuite/oapi-sdk-go/v3/core"
 	larkdrive "github.com/larksuite/oapi-sdk-go/v3/service/drive/v1"
+	"github.com/riba2534/feishu-cli/internal/config"
 )
 
 // 最大下载文件大小限制 (100MB)
@@ -656,6 +658,11 @@ func DownloadFileWithToken(fileToken, outputPath, userAccessToken string, timeou
 		return err
 	}
 
+	t := resolveTimeout(downloadTimeout, timeout)
+	if userAccessToken != "" {
+		return downloadDriveFileWithUserTokenRaw(fileToken, outputPath, userAccessToken, t)
+	}
+
 	client, err := GetClient()
 	if err != nil {
 		return err
@@ -665,7 +672,7 @@ func DownloadFileWithToken(fileToken, outputPath, userAccessToken string, timeou
 		FileToken(fileToken).
 		Build()
 
-	resp, err := client.Drive.File.Download(ContextWithTimeout(resolveTimeout(downloadTimeout, timeout)), req, UserTokenOption(userAccessToken)...)
+	resp, err := client.Drive.File.Download(ContextWithTimeout(t), req, UserTokenOption(userAccessToken)...)
 	if err != nil {
 		return fmt.Errorf("下载文件失败: %w", err)
 	}
@@ -674,7 +681,59 @@ func DownloadFileWithToken(fileToken, outputPath, userAccessToken string, timeou
 		return fmt.Errorf("下载文件失败: code=%d, msg=%s", resp.Code, resp.Msg)
 	}
 
-	return saveToFile(resp.File, outputPath)
+	return writeStreamToFile(resp.File, outputPath)
+}
+
+func downloadDriveFileWithUserTokenRaw(fileToken, outputPath, userAccessToken string, timeout time.Duration) error {
+	reqURL := buildDriveFileDownloadURL(fileToken)
+	httpClient := &http.Client{Timeout: timeout}
+	req, err := newBearerDownloadRequest(reqURL, userAccessToken, "")
+	if err != nil {
+		return fmt.Errorf("下载文件失败: %w", err)
+	}
+
+	httpResp, err := httpClient.Do(req)
+	if err != nil {
+		return fmt.Errorf("下载文件失败: %w", err)
+	}
+	defer httpResp.Body.Close()
+
+	if httpResp.StatusCode != http.StatusOK {
+		apiErr, parseErr := parseDownloadAPIError("下载文件", httpResp)
+		if parseErr != nil {
+			return parseErr
+		}
+		if isDownloadFileSizeLimitError(apiErr.Code, apiErr.Msg, nil) {
+			return downloadBearerURLByRange("下载文件", reqURL, outputPath, userAccessToken, timeout)
+		}
+		return fmt.Errorf("下载文件失败: code=%d, msg=%s", apiErr.Code, apiErr.Msg)
+	}
+
+	if err := writeStreamToFile(httpResp.Body, outputPath); err != nil {
+		return fmt.Errorf("保存文件失败: %w", err)
+	}
+	return nil
+}
+
+func buildDriveFileDownloadURL(fileToken string) string {
+	cfg := config.Get()
+	baseURL := cfg.BaseURL
+	if baseURL == "" {
+		baseURL = "https://open.feishu.cn"
+	}
+	return fmt.Sprintf("%s/open-apis/drive/v1/files/%s/download", baseURL, url.PathEscape(fileToken))
+}
+
+func isDownloadFileSizeLimitError(code int, msg string, err error) bool {
+	if code == messageResourceFileSizeExceedsLimitCode {
+		return true
+	}
+	text := strings.ToLower(msg)
+	if err != nil {
+		text += " " + strings.ToLower(err.Error())
+	}
+	return strings.Contains(text, "downloaded file size exceeds limit") ||
+		(strings.Contains(text, "file size") && strings.Contains(text, "exceed"))
 }
 
 // maxSingleUploadSize 单次上传的文件大小上限（20MB），超过此大小需使用分片上传

--- a/internal/client/message.go
+++ b/internal/client/message.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"net/http"
 	"net/url"
+	"os"
 	"strconv"
 	"strings"
 	"sync"
@@ -1214,6 +1215,10 @@ func ListPins(chatID string, startTime, endTime, pageToken string, pageSize int,
 
 // DownloadMessageResource 下载消息中的资源文件（图片/文件）
 func DownloadMessageResource(messageID, fileKey, resourceType, outputPath, userAccessToken string, timeout ...time.Duration) error {
+	if userAccessToken != "" {
+		return downloadMessageResourceWithUserToken(messageID, fileKey, resourceType, outputPath, userAccessToken, timeout...)
+	}
+
 	client, err := GetClient()
 	if err != nil {
 		return err
@@ -1239,6 +1244,59 @@ func DownloadMessageResource(messageID, fileKey, resourceType, outputPath, userA
 		return fmt.Errorf("保存文件失败: %w", err)
 	}
 
+	return nil
+}
+
+// downloadMessageResourceWithUserToken calls the message resource API directly.
+// The generated SDK currently marks this endpoint as tenant-token only, but the
+// OpenAPI accepts user_access_token for resources visible to the user.
+func downloadMessageResourceWithUserToken(messageID, fileKey, resourceType, outputPath, userAccessToken string, timeout ...time.Duration) error {
+	cfg := config.Get()
+	baseURL := cfg.BaseURL
+	if baseURL == "" {
+		baseURL = "https://open.feishu.cn"
+	}
+
+	params := url.Values{}
+	params.Set("type", resourceType)
+	reqURL := fmt.Sprintf("%s/open-apis/im/v1/messages/%s/resources/%s?%s",
+		baseURL,
+		url.PathEscape(messageID),
+		url.PathEscape(fileKey),
+		params.Encode(),
+	)
+
+	req, err := http.NewRequestWithContext(ContextWithTimeout(resolveTimeout(downloadTimeout, timeout)), http.MethodGet, reqURL, nil)
+	if err != nil {
+		return fmt.Errorf("下载消息资源失败: %w", err)
+	}
+	req.Header.Set("Authorization", "Bearer "+userAccessToken)
+
+	httpResp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return fmt.Errorf("下载消息资源失败: %w", err)
+	}
+	defer httpResp.Body.Close()
+
+	body, err := io.ReadAll(httpResp.Body)
+	if err != nil {
+		return fmt.Errorf("下载消息资源失败: 读取响应失败: %w", err)
+	}
+
+	if httpResp.StatusCode != http.StatusOK {
+		var resp struct {
+			Code int    `json:"code"`
+			Msg  string `json:"msg"`
+		}
+		if err := json.Unmarshal(body, &resp); err == nil && resp.Code != 0 {
+			return fmt.Errorf("下载消息资源失败: code=%d, msg=%s", resp.Code, resp.Msg)
+		}
+		return fmt.Errorf("下载消息资源失败: HTTP %d, body: %s", httpResp.StatusCode, strings.TrimSpace(string(body)))
+	}
+
+	if err := os.WriteFile(outputPath, body, 0666); err != nil {
+		return fmt.Errorf("保存文件失败: %w", err)
+	}
 	return nil
 }
 

--- a/internal/client/message.go
+++ b/internal/client/message.go
@@ -7,7 +7,6 @@ import (
 	"io"
 	"net/http"
 	"net/url"
-	"os"
 	"strconv"
 	"strings"
 	"sync"
@@ -31,6 +30,8 @@ const (
 	CardMsgContentTypeUser = "user_card_content"
 	CardMsgContentTypeRaw  = "raw_card_content"
 )
+
+const messageResourceFileSizeExceedsLimitCode = 234037
 
 // SendMessage sends a message to a user or chat
 func SendMessage(receiveIDType string, receiveID string, msgType string, content string, userAccessToken string) (string, error) {
@@ -1251,6 +1252,39 @@ func DownloadMessageResource(messageID, fileKey, resourceType, outputPath, userA
 // The generated SDK currently marks this endpoint as tenant-token only, but the
 // OpenAPI accepts user_access_token for resources visible to the user.
 func downloadMessageResourceWithUserToken(messageID, fileKey, resourceType, outputPath, userAccessToken string, timeout ...time.Duration) error {
+	reqURL := buildMessageResourceURL(messageID, fileKey, resourceType)
+	t := resolveTimeout(downloadTimeout, timeout)
+
+	httpClient := &http.Client{Timeout: t}
+	req, err := newBearerDownloadRequest(reqURL, userAccessToken, "")
+	if err != nil {
+		return fmt.Errorf("下载消息资源失败: %w", err)
+	}
+
+	httpResp, err := httpClient.Do(req)
+	if err != nil {
+		return fmt.Errorf("下载消息资源失败: %w", err)
+	}
+	defer httpResp.Body.Close()
+
+	if httpResp.StatusCode != http.StatusOK {
+		apiErr, parseErr := parseDownloadAPIError("下载消息资源", httpResp)
+		if parseErr != nil {
+			return parseErr
+		}
+		if apiErr.Code == messageResourceFileSizeExceedsLimitCode {
+			return downloadBearerURLByRange("下载消息资源", reqURL, outputPath, userAccessToken, t)
+		}
+		return fmt.Errorf("下载消息资源失败: code=%d, msg=%s", apiErr.Code, apiErr.Msg)
+	}
+
+	if err := writeStreamToFile(httpResp.Body, outputPath); err != nil {
+		return fmt.Errorf("保存文件失败: %w", err)
+	}
+	return nil
+}
+
+func buildMessageResourceURL(messageID, fileKey, resourceType string) string {
 	cfg := config.Get()
 	baseURL := cfg.BaseURL
 	if baseURL == "" {
@@ -1259,45 +1293,12 @@ func downloadMessageResourceWithUserToken(messageID, fileKey, resourceType, outp
 
 	params := url.Values{}
 	params.Set("type", resourceType)
-	reqURL := fmt.Sprintf("%s/open-apis/im/v1/messages/%s/resources/%s?%s",
+	return fmt.Sprintf("%s/open-apis/im/v1/messages/%s/resources/%s?%s",
 		baseURL,
 		url.PathEscape(messageID),
 		url.PathEscape(fileKey),
 		params.Encode(),
 	)
-
-	req, err := http.NewRequestWithContext(ContextWithTimeout(resolveTimeout(downloadTimeout, timeout)), http.MethodGet, reqURL, nil)
-	if err != nil {
-		return fmt.Errorf("下载消息资源失败: %w", err)
-	}
-	req.Header.Set("Authorization", "Bearer "+userAccessToken)
-
-	httpResp, err := http.DefaultClient.Do(req)
-	if err != nil {
-		return fmt.Errorf("下载消息资源失败: %w", err)
-	}
-	defer httpResp.Body.Close()
-
-	body, err := io.ReadAll(httpResp.Body)
-	if err != nil {
-		return fmt.Errorf("下载消息资源失败: 读取响应失败: %w", err)
-	}
-
-	if httpResp.StatusCode != http.StatusOK {
-		var resp struct {
-			Code int    `json:"code"`
-			Msg  string `json:"msg"`
-		}
-		if err := json.Unmarshal(body, &resp); err == nil && resp.Code != 0 {
-			return fmt.Errorf("下载消息资源失败: code=%d, msg=%s", resp.Code, resp.Msg)
-		}
-		return fmt.Errorf("下载消息资源失败: HTTP %d, body: %s", httpResp.StatusCode, strings.TrimSpace(string(body)))
-	}
-
-	if err := os.WriteFile(outputPath, body, 0666); err != nil {
-		return fmt.Errorf("保存文件失败: %w", err)
-	}
-	return nil
 }
 
 // BatchGetMessagesResult 是 BatchGetMessages 的返回值。

--- a/internal/client/message_test.go
+++ b/internal/client/message_test.go
@@ -201,6 +201,76 @@ func TestDownloadMessageResourceWithUserToken_ApiError(t *testing.T) {
 	}
 }
 
+func TestDownloadMessageResourceWithUserToken_RangeFallback(t *testing.T) {
+	const (
+		messageID = "om_xxx"
+		fileKey   = "file_v3_xxx"
+		userToken = "u-test-token"
+	)
+
+	oldChunkSize := rangeDownloadChunkSize
+	rangeDownloadChunkSize = 5
+	defer func() {
+		rangeDownloadChunkSize = oldChunkSize
+	}()
+
+	wantBody := []byte("0123456789abcdef")
+	var capturedRanges []string
+
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		if strings.HasPrefix(r.URL.Path, "/open-apis/auth/v3/tenant_access_token/internal") {
+			t.Fatal("显式 User Token 下载资源时不应请求 tenant token")
+		}
+		if r.Header.Get("Authorization") != "Bearer "+userToken {
+			t.Errorf("Authorization header: got %q, want %q", r.Header.Get("Authorization"), "Bearer "+userToken)
+		}
+
+		rangeHeader := r.Header.Get("Range")
+		if rangeHeader == "" {
+			w.WriteHeader(http.StatusBadRequest)
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = fmt.Fprintf(w, `{"code":%d,"msg":"Downloaded file size exceeds limit"}`, messageResourceFileSizeExceedsLimitCode)
+			return
+		}
+
+		var start, end int
+		if _, err := fmt.Sscanf(rangeHeader, "bytes=%d-%d", &start, &end); err != nil {
+			t.Fatalf("Range header 格式非法: %q", rangeHeader)
+		}
+		if start < 0 || start >= len(wantBody) {
+			w.WriteHeader(http.StatusRequestedRangeNotSatisfiable)
+			return
+		}
+		if end >= len(wantBody) {
+			end = len(wantBody) - 1
+		}
+		capturedRanges = append(capturedRanges, rangeHeader)
+		w.Header().Set("Content-Range", fmt.Sprintf("bytes %d-%d/%d", start, end, len(wantBody)))
+		w.WriteHeader(http.StatusPartialContent)
+		_, _ = w.Write(wantBody[start : end+1])
+	}
+
+	_, cleanup := stubFeishuServer(t, handler)
+	defer cleanup()
+
+	outputPath := t.TempDir() + "/large.bin"
+	if err := DownloadMessageResource(messageID, fileKey, "file", outputPath, userToken); err != nil {
+		t.Fatalf("DownloadMessageResource 返回错误: %v", err)
+	}
+	gotBody, err := os.ReadFile(outputPath)
+	if err != nil {
+		t.Fatalf("读取下载文件失败: %v", err)
+	}
+	if string(gotBody) != string(wantBody) {
+		t.Fatalf("下载内容 = %q, want %q", gotBody, wantBody)
+	}
+
+	wantRanges := []string{"bytes=0-4", "bytes=5-9", "bytes=10-14", "bytes=15-19"}
+	if strings.Join(capturedRanges, ",") != strings.Join(wantRanges, ",") {
+		t.Fatalf("Range 请求序列 = %v, want %v", capturedRanges, wantRanges)
+	}
+}
+
 // tenantRouteHandler 封装 tenant 模式 stub：识别 SDK 自动发起的 tenant_access_token
 // 取 token 请求并回 fake token；其他路径转交给业务 handler。
 func tenantRouteHandler(t *testing.T, business http.HandlerFunc) http.HandlerFunc {

--- a/internal/client/message_test.go
+++ b/internal/client/message_test.go
@@ -135,6 +135,72 @@ func TestGetMessageWithUserToken_ApiErrorPropagated(t *testing.T) {
 	}
 }
 
+func TestDownloadMessageResourceWithUserToken_RawHTTP(t *testing.T) {
+	const (
+		messageID = "om_xxx"
+		fileKey   = "file_v3_xxx"
+		userToken = "u-test-token"
+	)
+	wantBody := []byte("fake-video")
+
+	var capturedAuth string
+	var capturedPath string
+	var capturedType string
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		if strings.HasPrefix(r.URL.Path, "/open-apis/auth/v3/tenant_access_token/internal") {
+			t.Fatal("显式 User Token 下载资源时不应请求 tenant token")
+		}
+		capturedAuth = r.Header.Get("Authorization")
+		capturedPath = r.URL.Path
+		capturedType = r.URL.Query().Get("type")
+		w.Header().Set("Content-Type", "video/quicktime")
+		_, _ = w.Write(wantBody)
+	}
+
+	_, cleanup := stubFeishuServer(t, handler)
+	defer cleanup()
+
+	outputPath := t.TempDir() + "/video.mov"
+	if err := DownloadMessageResource(messageID, fileKey, "file", outputPath, userToken); err != nil {
+		t.Fatalf("DownloadMessageResource 返回错误: %v", err)
+	}
+	gotBody, err := os.ReadFile(outputPath)
+	if err != nil {
+		t.Fatalf("读取下载文件失败: %v", err)
+	}
+	if string(gotBody) != string(wantBody) {
+		t.Fatalf("下载内容 = %q, want %q", gotBody, wantBody)
+	}
+	if capturedPath != "/open-apis/im/v1/messages/"+messageID+"/resources/"+fileKey {
+		t.Errorf("path = %q, want resource path", capturedPath)
+	}
+	if capturedType != "file" {
+		t.Errorf("type query = %q, want file", capturedType)
+	}
+	if capturedAuth != "Bearer "+userToken {
+		t.Errorf("Authorization header: got %q, want %q", capturedAuth, "Bearer "+userToken)
+	}
+}
+
+func TestDownloadMessageResourceWithUserToken_ApiError(t *testing.T) {
+	handler := func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusBadRequest)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = fmt.Fprint(w, `{"code":234040,"msg":"The message is invisible to the operator."}`)
+	}
+
+	_, cleanup := stubFeishuServer(t, handler)
+	defer cleanup()
+
+	err := DownloadMessageResource("om_xxx", "file_v3_xxx", "file", t.TempDir()+"/video.mov", "u-test-token")
+	if err == nil {
+		t.Fatal("API 返回错误时应返回 error")
+	}
+	if !strings.Contains(err.Error(), "234040") {
+		t.Fatalf("error = %q, want code 234040", err)
+	}
+}
+
 // tenantRouteHandler 封装 tenant 模式 stub：识别 SDK 自动发起的 tenant_access_token
 // 取 token 请求并回 fake token；其他路径转交给业务 handler。
 func tenantRouteHandler(t *testing.T, business http.HandlerFunc) http.HandlerFunc {

--- a/skills/feishu-cli-drive/SKILL.md
+++ b/skills/feishu-cli-drive/SKILL.md
@@ -38,15 +38,16 @@ allowed-tools: Bash(feishu-cli drive:*), Bash(feishu-cli auth:*), Read
 feishu-cli drive upload --file /tmp/report.pdf
 feishu-cli drive upload --file /tmp/big.zip --folder-token fldxxx --name "年度报告.zip"
 
-# 下载（流式 + 路径校验 + --overwrite + --timeout）
+# 下载（流式 + 路径校验 + --overwrite + --timeout，大文件自动 Range 分片兜底）
 feishu-cli drive download --file-token boxcnxxxx --output ./report.pdf
 feishu-cli drive download --file-token boxcnxxxx --output ./downloads/ --overwrite
-feishu-cli drive download --file-token boxcnxxxx --output ./big.zip --timeout 10m
+feishu-cli drive download --file-token boxcnxxxx --output ./big.zip --timeout 30m
 ```
 
 **关键点**：
 - `drive upload` 分块上传每片独立重试 3 次，使用 `io.SectionReader` 外层只打开文件一次
 - `drive download` 的 `--output` 可以是文件路径（直接用）或目录（**文件名用 `file_token` 本身**，暂不从响应头解析）
+- `drive download` 使用用户身份下载时，如果服务端返回大文件限制，会自动使用 HTTP Range 分片下载并合并
 - 如果需要自定义文件名，请显式传完整路径：`--output ./downloads/report.pdf`
 
 ### 2. 文档导出（含 markdown 快捷路径）

--- a/skills/feishu-cli-msg/SKILL.md
+++ b/skills/feishu-cli-msg/SKILL.md
@@ -327,6 +327,9 @@ feishu-cli msg resource-download <message_id> <file_key> --type image -o /tmp/ph
 # 下载消息中的文件
 feishu-cli msg resource-download <message_id> <file_key> --type file -o /tmp/attachment.pdf
 
+# Bot 不可见但当前用户可见的历史消息资源，可显式用 User Token
+feishu-cli msg resource-download <message_id> <file_key> --type file --user-access-token u-xxx -o /tmp/attachment.pdf
+
 # 下载大文件时指定超时时间
 feishu-cli msg resource-download <message_id> <file_key> --type image -o /tmp/photo.png --timeout 10m
 ```
@@ -337,6 +340,7 @@ feishu-cli msg resource-download <message_id> <file_key> --type image -o /tmp/ph
 | `<file_key>` | 资源的 file_key | 必填 |
 | `--type` | 资源类型 `image`/`file` | 必填 |
 | `-o, --output` | 输出文件路径 | — |
+| `--user-access-token` | 使用用户身份下载用户可见、但 Bot 不可见的历史消息资源 | — |
 | `--timeout` | 下载超时时间（Go duration 格式，如 `10m`、`30m`、`1h`） | `5m` |
 
 > **file_key 来源**：通过 `msg get <message_id>` 获取消息详情，从 content 中提取 `image_key` 或 `file_key`。

--- a/skills/feishu-cli-msg/SKILL.md
+++ b/skills/feishu-cli-msg/SKILL.md
@@ -331,7 +331,7 @@ feishu-cli msg resource-download <message_id> <file_key> --type file -o /tmp/att
 feishu-cli msg resource-download <message_id> <file_key> --type file --user-access-token u-xxx -o /tmp/attachment.pdf
 
 # 下载大文件时指定超时时间
-feishu-cli msg resource-download <message_id> <file_key> --type image -o /tmp/photo.png --timeout 10m
+feishu-cli msg resource-download <message_id> <file_key> --type file --user-access-token u-xxx -o /tmp/large.bin --timeout 30m
 ```
 
 | 参数 | 说明 | 默认值 |
@@ -344,6 +344,7 @@ feishu-cli msg resource-download <message_id> <file_key> --type image -o /tmp/ph
 | `--timeout` | 下载超时时间（Go duration 格式，如 `10m`、`30m`、`1h`） | `5m` |
 
 > **file_key 来源**：通过 `msg get <message_id>` 获取消息详情，从 content 中提取 `image_key` 或 `file_key`。
+> 使用用户身份直连下载时，如遇到飞书大文件限制，会自动使用 HTTP Range 分片下载并合并。
 
 ## 话题（Thread）消息
 


### PR DESCRIPTION
## Title

fix(download): support user-token downloads with Range fallback

## Summary

Fix `msg resource-download` when `--user-access-token` is provided, and add large-file Range fallback for both message resources and Drive file downloads.

The generated Lark Go SDK currently marks `MessageResource.Get` as tenant-token only, so passing `WithUserAccessToken(...)` fails with:

    tenant token type not match user access token

However, the raw OpenAPI endpoint:

    GET /open-apis/im/v1/messages/:message_id/resources/:file_key

can download resources with a user access token when the resource is visible to that user.

This PR preserves the existing SDK-based tenant/app-token path by default, and uses raw HTTP only when `--user-access-token` is explicitly provided. It also adds HTTP Range fallback for large downloads when Feishu returns file-size-limit errors.

## Changes

- Use raw HTTP for message resource downloads when a User Token is provided.
- Preserve existing SDK-based tenant/app-token behavior when no User Token is provided.
- Add shared HTTP Range download helper:
  - sends `Range: bytes=start-end`
  - validates `Content-Range`
  - writes chunks sequentially
  - removes partial output on failure
- Apply Range fallback to:
  - `msg resource-download`
  - `file download`
  - `drive download`
  - callers using `DownloadFileWithToken`
- Stream successful raw downloads directly to disk instead of loading the full file into memory.
- Update command help, README, and skill docs with User Token and large-file examples.

## Tests

Added tests for:

- successful User Token message resource download
- API error propagation
- no tenant token request when User Token is explicit
- message resource Range fallback
- Drive file Range fallback

## Verification

- `go test ./internal/client`
- `go test ./cmd`
- `git diff --check`

Manual verification from the User Token resource path:

- Downloaded a real message video resource with `--user-access-token`
- Output content type: `video/quicktime`
- Output size: `3,803,728 bytes`