### PR TITLE
fix: add wiki:node:update to wiki domain scopes

### DIFF
--- a/internal/registry/domain_alias.go
+++ b/internal/registry/domain_alias.go
@@ -113,9 +113,9 @@ var extraDomainScopes = map[string][]string{
 		"calendar:calendar.free_busy:read", // +freebusy, +room-find, +suggestion
 	},
 
-	// wiki shortcuts: +node-create, +move-docs-to-wiki
+	// wiki shortcuts: +node-create, +move-docs-to-wiki, +update
 	"wiki": {
-		"wiki:node:create", "wiki:node:read", "wiki:space:read",
+		"wiki:node:create", "wiki:node:read", "wiki:node:update", "wiki:space:read",
 		"wiki:node:move", // wiki move-docs 需要
 	},
 


### PR DESCRIPTION
## 问题

- `wiki:node:update` 未被收录进 wiki domain 的 scope 列表
- 导致 `auth login --domain wiki` 无法获取该权限
- 使得 `wiki update` 命令因 `99991679 Unauthorized` 报错
- 用户需要手动 `auth login --scope "wiki:node:update"` 才能使用

## 修复

在 `internal/registry/domain_alias.go` 的 `extraDomainScopes["wiki"]` 列表中添加 `"wiki:node:update"`。