### PR TITLE
fix(comment): delete 给出诚实指引而非永远报错的死 stub

### DIFF
--- a/cmd/comment.go
+++ b/cmd/comment.go
@@ -13,7 +13,7 @@ var commentCmd = &cobra.Command{
   list        列出文档评论
   add         添加评论
   get         获取评论详情
-  delete      删除评论
+  delete      删除评论（飞书不支持整条删除，改用 reply delete / resolve）
   resolve     标记评论为已解决
   unresolve   标记评论为未解决
   reply       评论回复管理（list/add/delete）

--- a/cmd/delete_comment.go
+++ b/cmd/delete_comment.go
@@ -3,53 +3,46 @@ package cmd
 import (
 	"fmt"
 
-	"github.com/riba2534/feishu-cli/internal/client"
-	"github.com/riba2534/feishu-cli/internal/config"
 	"github.com/spf13/cobra"
 )
 
+// deleteCommentUnsupportedMsg 说明飞书没有「删除整条评论」的 Open API，并给出可行替代方案。
+// 飞书的「评论」是一条回复线程：只能删除其中的单条回复（且仅回复作者本人可删），
+// 没有删除整条评论的端点（SDK fileComment 仅有 BatchQuery/Create/Get/List/Patch，无 Delete）。
+const deleteCommentUnsupportedMsg = `飞书 Open API 不支持删除整条评论线程，本命令不会执行任何删除操作。
+
+可用替代方案:
+  • 删除自己发布的回复（评论线程仅含你这一条回复时，删除它即等于删掉该评论）:
+      feishu-cli comment reply list <file_token> <comment_id> --type <type>
+      feishu-cli comment reply delete <file_token> <comment_id> <reply_id> --type <type>
+  • 将评论标记为已解决（保留记录、折叠显示）:
+      feishu-cli comment resolve <file_token> <comment_id> --type <type>
+
+注意: 飞书只允许回复作者本人删除自己的回复，需以该作者的 User Token 发起
+（先 feishu-cli auth login）；App/Bot 身份会返回 1069303 forbidden。`
+
 var deleteCommentCmd = &cobra.Command{
 	Use:   "delete <file_token> <comment_id>",
-	Short: "删除评论",
-	Long: `删除文档中的指定评论。
+	Short: "删除评论（飞书不支持整条删除，改用 reply delete / resolve）",
+	Long: `删除文档评论。
 
-参数:
-  file_token    文档 Token
-  comment_id    评论 ID
-  --type        文件类型（必填）
+⚠ 飞书 Open API 没有「删除整条评论」的端点，因此本命令不执行删除，仅给出替代方案指引。
+飞书的「评论」本质是一条回复线程，只能删除其中的单条回复（且仅回复作者本人可删），
+或将整条评论标记为已解决。
 
-文件类型:
-  doc       旧版文档
-  docx      新版文档
-  sheet     电子表格
-  bitable   多维表格
-
-示例:
-  # 删除评论
-  feishu-cli comment delete doccnXXX comment123 --type docx`,
-	Args: cobra.ExactArgs(2),
+替代命令:
+  feishu-cli comment reply delete <file_token> <comment_id> <reply_id> --type docx
+  feishu-cli comment resolve <file_token> <comment_id> --type docx`,
+	// 不限制参数个数：无论是否带 <file_token> <comment_id>，都给出统一指引而非参数报错。
+	Args: cobra.ArbitraryArgs,
 	RunE: func(cmd *cobra.Command, args []string) error {
-		if err := config.Validate(); err != nil {
-			return err
-		}
-
-		fileToken := args[0]
-		commentID := args[1]
-		fileType, _ := cmd.Flags().GetString("type")
-
-		if err := client.DeleteComment(fileToken, commentID, fileType); err != nil {
-			return err
-		}
-
-		fmt.Printf("评论删除成功！\n")
-		fmt.Printf("  文档 Token: %s\n", fileToken)
-		fmt.Printf("  评论 ID:    %s\n", commentID)
-		return nil
+		return fmt.Errorf("%s", deleteCommentUnsupportedMsg)
 	},
 }
 
 func init() {
 	commentCmd.AddCommand(deleteCommentCmd)
-	deleteCommentCmd.Flags().String("type", "", "文件类型（必填: doc/docx/sheet/bitable）")
-	mustMarkFlagRequired(deleteCommentCmd, "type")
+	// --type 保留为可选项，仅为兼容历史调用写法（如 `comment delete X Y --type docx`），
+	// 避免老脚本因 "unknown flag: --type" 报错，看不到上面的替代方案指引。
+	deleteCommentCmd.Flags().String("type", "", "文件类型（doc/docx/sheet/bitable）；本命令仅作兼容占位，不生效")
 }

--- a/cmd/delete_comment_test.go
+++ b/cmd/delete_comment_test.go
@@ -1,0 +1,61 @@
+package cmd
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestDeleteCommentCmdRegistered 验证 delete 子命令仍注册在 comment 命令组下，且对外可见。
+func TestDeleteCommentCmdRegistered(t *testing.T) {
+	if deleteCommentCmd.Use != "delete <file_token> <comment_id>" {
+		t.Fatalf("Use = %q", deleteCommentCmd.Use)
+	}
+	if deleteCommentCmd.Hidden {
+		t.Error("delete 命令应保持可见，便于用户/Agent 在 help 中看到替代方案")
+	}
+	found := false
+	for _, sub := range commentCmd.Commands() {
+		if sub == deleteCommentCmd {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatal("deleteCommentCmd 应是 commentCmd 的子命令")
+	}
+}
+
+// TestDeleteCommentReturnsGuidance 验证无论是否带参数，delete 都返回可执行的替代方案指引，
+// 而不是去调用一个并不存在的「删除整条评论」API。
+func TestDeleteCommentReturnsGuidance(t *testing.T) {
+	cases := [][]string{
+		{},
+		{"doccnXXX"},
+		{"doccnXXX", "cmt123", "--type", "docx"},
+	}
+	for _, args := range cases {
+		err := deleteCommentCmd.RunE(deleteCommentCmd, args)
+		if err == nil {
+			t.Fatalf("args=%v: 期望返回指引错误，得到 nil", args)
+		}
+		msg := err.Error()
+		for _, want := range []string{"comment reply delete", "comment resolve", "不支持"} {
+			if !strings.Contains(msg, want) {
+				t.Errorf("args=%v: 错误信息缺少 %q，实际: %s", args, want, msg)
+			}
+		}
+	}
+}
+
+// TestDeleteCommentTypeFlagOptional 验证 --type 仅作兼容占位、非必填，
+// 这样历史调用写法不会因 "unknown flag" 报错，从而能看到指引。
+func TestDeleteCommentTypeFlagOptional(t *testing.T) {
+	f := deleteCommentCmd.Flags().Lookup("type")
+	if f == nil {
+		t.Fatal("--type flag 应存在（兼容占位）")
+	}
+	ann := f.Annotations["cobra_annotation_bash_completion_one_required_flag"]
+	if len(ann) != 0 && ann[0] == "true" {
+		t.Error("--type 不应为必填")
+	}
+}

--- a/internal/client/comment.go
+++ b/internal/client/comment.go
@@ -183,11 +183,10 @@ func GetComment(fileToken string, commentID string, fileType string, userAccessT
 	}, nil
 }
 
-// DeleteComment 删除评论
-// 注意：当前飞书 SDK 版本不支持删除评论 API
-func DeleteComment(fileToken string, commentID string, fileType string) error {
-	return fmt.Errorf("删除评论功能暂不支持：当前 SDK 版本未提供删除评论 API")
-}
+// 飞书 Open API 没有「删除整条评论」的端点（SDK fileComment 仅有
+// BatchQuery/Create/Get/List/Patch，无 Delete）。评论本质是一条回复线程，
+// 只能通过 DeleteCommentReply 删除单条回复，或用 PatchComment 标记已解决。
+// 因此此处不提供 DeleteComment，相关指引见 cmd/delete_comment.go。
 
 // PatchComment 更新评论解决状态
 // userAccessToken 非空时使用 User Token，否则使用 App Token。


### PR DESCRIPTION
## 背景

`feishu-cli comment delete <file_token> <comment_id>` 在 `--help` 里看起来是个正常命令，但任何调用都失败：

```
$ feishu-cli comment delete <doc> <cmt> --type docx
删除评论功能暂不支持：当前 SDK 版本未提供删除评论 API
```

它调用的 `client.DeleteComment` 是个**永远返回错误的 stub**。这是个 UX 陷阱：命令存在但永不工作，且错误信息把锅甩给「SDK 版本」，没给用户任何出路。

实际起因在一次排查飞书文档**划线评论**时暴露：`comment list/add/get/resolve/reply` 都已在 #151 支持 User Token，唯独 `delete` 还是这个死 stub，是「评论走用户权限」故事里唯一没闭环的命令。

## 根因

飞书 Open API **本就没有**「删除整条评论」的端点：

- SDK `larksuite/oapi-sdk-go/v3@v3.5.3` 的 `fileComment` 资源只有 `BatchQuery/Create/Get/List/Patch`，**无 `Delete`**；只有 `fileCommentReply` 有 `Delete`（`DELETE /open-apis/drive/v1/files/:file_token/comments/:comment_id/replies/:reply_id`）。
- 官方文档亦只暴露回复级操作。一条「评论」本质是一条**回复线程**，只能删除其中的单条回复（且飞书仅允许**回复作者本人**删除，App/Bot 身份会 `1069303 forbidden`），或将评论**标记为已解决**。

所以实现 `DeleteComment` 是不可能的——API 不存在。正确做法是诚实地把这件事告诉用户，并指向真正可用的能力。

## 改动

- `comment delete` **保留为可见命令**（便于用户/Agent 在 help 中直接看到替代方案），`RunE` 直接返回可执行的中文指引，指向：
  - `comment reply delete`（删除自己的回复；线程仅含本人一条回复时即等于删掉该评论）
  - `comment resolve`（标记已解决）
  - 并说明权限现实：只有回复作者本人 User Token 能删，App/Bot 身份 `1069303 forbidden`。
- 删除死代码 `client.DeleteComment`（无人再调用）。
- 放开 `delete` 的参数校验（`ArbitraryArgs`）与 `--type`（降级为可选兼容占位），让历史写法 `comment delete X Y --type docx` 也能看到指引，而非先撞 `unknown flag` / 参数报错。
- 更新 `comment` 命令组 help 的 `delete` 行说明。
- 退出码保持**非零**，脚本/Agent 能据此判断未发生删除。

> 设计上也评估过「让 `comment delete` 去删除该评论线程的所有回复」：因会跨多人删除、易部分失败、语义意外、且破坏性强，故放弃；保持单一职责，删回复请显式用 `comment reply delete`。

## 测试

- 新增 `cmd/delete_comment_test.go`：命令注册可见、任意参数下都返回含 `comment reply delete` / `comment resolve` / `不支持` 的指引、`--type` 非必填。
- `gofmt -l` 干净、`go vet ./...` 通过、`go test ./...` 全绿。
- 真实飞书 API round-trip 验证（针对实际文档）：`comment delete` 退出码 = 1 并打印指引；对照 `comment list` 退出码 = 0；指引中推荐的 `comment reply list` 实测可正常拉到回复。

## 关于 CHANGELOG

按本仓库惯例 CHANGELOG 在发版时统一批量记录（见历次 `docs(changelog): 记录 vX.Y.Z`），故本 PR 未单独改动 CHANGELOG，可在下次发版批次中并入。如需我现在补一条 `[Unreleased]` 条目，告知即可。

🤖 Generated with [Claude Code](https://claude.com/claude-code)