### PR TITLE
fix(install): 日志写 stderr，修复 fallback 污染版本号导致 curl bad range

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -6,9 +6,10 @@ BINARY_NAME="feishu-cli"
 DEFAULT_INSTALL_DIR="/usr/local/bin"
 tmpdir=""
 
-# 颜色输出
-info()  { printf "\033[34m[INFO]\033[0m  %s\n" "$*"; }
-ok()    { printf "\033[32m[OK]\033[0m    %s\n" "$*"; }
+# 颜色输出（全部走 stderr：stdout 仅保留给函数通过 $(...) 返回数据，
+# 避免日志被 version=$(get_latest_version) 之类的命令替换捕获，污染下载 URL）
+info()  { printf "\033[34m[INFO]\033[0m  %s\n" "$*" >&2; }
+ok()    { printf "\033[32m[OK]\033[0m    %s\n" "$*" >&2; }
 err()   { printf "\033[31m[ERROR]\033[0m %s\n" "$*" >&2; }
 
 # 检测操作系统
@@ -91,6 +92,16 @@ get_latest_version() {
         err "无法获取最新版本号（GitHub API 可能已达速率限制，可设置 GITHUB_TOKEN 环境变量提升配额到 5000/小时）"
         exit 1
     fi
+
+    # 去除可能混入的空白/控制字符，并校验版本号格式（防御性兜底）：
+    # 一旦版本号被异常内容污染（如日志、HTML），此处提前报错，
+    # 而不是带着脏字符去拼接 download_url 让 curl 报 "bad range in URL"。
+    version=$(printf '%s' "$version" | tr -d '[:space:][:cntrl:]')
+    if ! printf '%s' "$version" | grep -qE '^v?[0-9]+\.[0-9]+\.[0-9]+([.-][0-9A-Za-z.-]+)?$'; then
+        err "获取到的版本号格式异常: '${version}'（期望形如 v1.2.3）"
+        exit 1
+    fi
+
     echo "$version"
 }
 


### PR DESCRIPTION
## 背景

通过 `curl -fsSL .../install.sh | bash` 安装时，在**代理 / CI / 容器**等环境中会报：

```
curl: (3) bad range in URL position 60:
https://github.com/riba2534/feishu-cli/releases/download/<ESC>[34m[INFO]<ESC>[0m  302 redirect 未获取到版本号...
```

## 根因

`install.sh` 的日志助手 `info()` / `ok()` 打到 **stdout**，而 `get_latest_version()` 是靠 stdout 返回版本号的（`version=$(get_latest_version)`）。

当方式 1（302 redirect 提取 tag）失败、回退 GitHub API 时，`get_latest_version()` 内部第 61 行执行：

```bash
info "302 redirect 未获取到版本号，回退到 GitHub API..."
```

这行日志连同 ANSI 颜色符一并被命令替换吞进 `$version`，于是：

- `$version` = `<ESC>[34m[INFO]<ESC>[0m  302 redirect ...\nv1.34.0`
- 拼进 `download_url` 后，`[` 被 curl 当作 URL globbing 的 range 语法 → `bad range in URL`

`err()` 本身是 `>&2` 的，所以错误日志不受影响——只有 `info()`/`ok()` 漏了重定向。该 fallback 恰恰在 302 探测拿不到 `Location` 头的环境（拦截代理 / 出口防火墙 / `curl -sI` 被 `2>/dev/null` 吞错）最容易触发，也就是 fallback 最该可靠工作的时候。

## 改动

- `info()` / `ok()` 改为写 `>&2`，与 `err()` 对齐：stdout 只保留给函数通过 `$(...)` 返回数据。这是修复根因的最小改动。
- `get_latest_version()` 返回前去除空白 / 控制字符并校验版本号格式（`^v?[0-9]+\.[0-9]+\.[0-9]+...`），脏数据提前以清晰错误退出，而不是带进 URL 让 curl 报费解的 `bad range`（防御性兜底，纵深防御）。

## 验证（本地，无 CI）

- `bash -n install.sh` 语法通过
- **happy path**（真实 302 redirect）：`get_latest_version` 返回干净的 `v1.34.0`
- **强制 fallback**（方式 1 返回空，stub API 返回 tag）：`info` 日志改走 stderr，`$version` 干净（`v1.34.0`），不再污染 URL
- **校验兜底**：被 ANSI/日志污染的版本号被拒绝并以非零退出 + 清晰错误；`v1.34.0` / `1.34.0` / `v2.0.0-rc1` 等正常通过

修复前后对比（强制 fallback 时捕获的 `$version` 字节）：

```
# 修复前： \033 [ 3 4 m [ I N F O ] ... v 1 . 3 4 . 0   ← 污染
# 修复后： v 1 . 3 4 . 0                                 ← 干净
```