### PR TITLE
feat(messaging): support media replies and thread-safe sending

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,7 +136,7 @@ feishu-cli doc import large-doc.md --title "大文档" \
 | **知识库** | 空间列表、节点增删改查、导出（含整树递归镜像）、**移出知识库到云盘（move-to-drive）**、空间详情、成员管理 |
 | **电子表格** | V2 基础读写 + V3 富文本 API，行列操作、样式、批量样式、合并、查找替换、导出 XLSX/CSV、浮动图片读写、素材上传、单元格写图、筛选视图与筛选条件 CRUD、下拉菜单数据验证、**类型保真整表读写 table-get/table-put（数字/日期/布尔 dtype 保真，支持 get→改→put round-trip）** |
 | **多维表格** | base/v3 + bitable/v1 全覆盖：数据表/字段/记录 CRUD（含批量获取）、记录附件上传/下载/移除、视图配置（filter/sort/group/visible-fields/timebar/card）、仪表盘 CRUD 与智能排版、仪表盘块 CRUD、表单 CRUD 与分享详情/提交、表单问题 CRUD、角色 CRUD 与协作者管理、高级权限、数据聚合、工作流 CRUD、多维表格重命名与权限设置 |
-| **消息** | 发送（text/post/image/file/card 等 11 种类型）、转发、合并转发、回复、Pin、表情回复、消息书签（flag create/list/cancel）、搜索群聊（Bot/User 双身份）、历史记录（群聊 / P2P 私聊，支持 `--user-email` / `--user-id` 自动反查 p2p chat_id）、批量获取、资源下载、话题回复、**发送者名字自动解析**（输出顶层 `sender_names` 映射，覆盖退群成员） |
+| **消息** | 发送与回复共用 text/Markdown/post/image/file/audio/video/card 内容模型（本地媒体自动上传、幂等键）、转发、合并转发、Pin、表情回复、消息书签（flag create/list/cancel）、搜索群聊（Bot/User 双身份）、历史记录（群聊 / P2P 私聊，支持 `--user-email` / `--user-id` 自动反查 p2p chat_id）、批量获取、资源下载、话题回复、**发送者名字自动解析**（输出顶层 `sender_names` 映射，覆盖退群成员） |
 | **群聊** | 创建、获取、更新、删除、分享链接、成员管理、**群列表（chat list，--page-all 全量拉取 + 安全截断告警）** |
 | **邮箱** | 收件箱分类/搜索、邮件详情（单条/批量/线程）、发送（默认草稿，支持 CID 内联图片自动扫描）、草稿管理（创建/编辑/**发送已有草稿**）、回复/全部回复/转发、**批量改 label/移动文件夹、批量软删进废纸篓**、邮件模板 create/list、邮箱签名查看（需 User Token） |
 | **日历** | 日历列表、主日历、日程增删改查、搜索、回复邀请、参与者管理、忙闲查询、日程视图（agenda）、智能时段建议、会议室查找、RSVP |
@@ -439,6 +439,10 @@ feishu-cli msg forward <message_id> --receive-id <id> --receive-id-type email
 
 # 回复消息
 feishu-cli msg reply <message_id> --text "回复内容"
+feishu-cli msg reply <message_id> --image /path/to/photo.png --idempotency-key "photo-reply-001"
+
+# 回复到既有话题：传话题内 om_xxx 消息 ID，不要把 omt_xxx 传给 msg send
+feishu-cli msg reply om_xxx --file /path/to/report.pdf
 
 # 合并转发
 feishu-cli msg merge-forward --receive-id user@example.com --receive-id-type email --message-ids id1,id2

--- a/cmd/command_validation_test.go
+++ b/cmd/command_validation_test.go
@@ -8,10 +8,13 @@ import (
 )
 
 func TestValidateSendReceiveIDType(t *testing.T) {
-	for _, valid := range []string{"email", "open_id", "user_id", "union_id", "chat_id", "thread_id"} {
+	for _, valid := range []string{"email", "open_id", "user_id", "union_id", "chat_id"} {
 		if err := validateSendReceiveIDType(valid); err != nil {
 			t.Fatalf("validateSendReceiveIDType(%q) unexpected error: %v", valid, err)
 		}
+	}
+	if err := validateSendReceiveIDType("thread_id"); err == nil || !strings.Contains(err.Error(), "msg reply") {
+		t.Fatalf("thread_id 应返回迁移提示，实际: %v", err)
 	}
 	if err := validateSendReceiveIDType("bad"); err == nil || !strings.Contains(err.Error(), "--receive-id-type") {
 		t.Fatalf("expected receive-id-type error, got %v", err)

--- a/cmd/msg_content.go
+++ b/cmd/msg_content.go
@@ -1,0 +1,375 @@
+package cmd
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/riba2534/feishu-cli/internal/client"
+	"github.com/spf13/cobra"
+)
+
+// messageContentInput 是 msg send / msg reply 共用的内容输入模型。
+// 快捷参数会推断消息类型；--content / --content-file 则保留显式 --msg-type。
+type messageContentInput struct {
+	msgType        string
+	msgTypeChanged bool
+	content        string
+	contentFile    string
+	text           string
+	markdown       string
+	file           string
+	image          string
+	audio          string
+	video          string
+	videoCover     string
+	uploadImages   bool
+}
+
+var uploadIMFileWithOptions = client.UploadIMFileWithOptions
+
+func addMessageContentFlags(command *cobra.Command) {
+	command.Flags().String("msg-type", "text", "消息类型（text/post/image/file/audio/media/interactive 等）")
+	command.Flags().StringP("content", "c", "", "消息内容 JSON")
+	command.Flags().String("content-file", "", "消息内容 JSON 文件")
+	command.Flags().StringP("text", "t", "", "简单文本消息")
+	command.Flags().String("markdown", "", "Markdown 消息（自动包装为 post）")
+	command.Flags().StringP("file", "f", "", "本地文件路径或 file_key（作为附件发送）")
+	command.Flags().String("image", "", "本地图片路径或 image_key")
+	command.Flags().String("audio", "", "本地 Opus/Ogg Opus 路径或 file_key")
+	command.Flags().String("video", "", "本地 MP4 路径或 file_key（需同时指定 --video-cover）")
+	command.Flags().String("video-cover", "", "视频封面本地图片路径或 image_key（仅与 --video 一起使用）")
+	command.Flags().Bool("upload-images", false, "自动上传 post/interactive 中的 Markdown 与图片字段本地路径")
+}
+
+func readMessageContentInput(command *cobra.Command) messageContentInput {
+	input := messageContentInput{}
+	input.msgType, _ = command.Flags().GetString("msg-type")
+	input.msgTypeChanged = command.Flags().Changed("msg-type")
+	input.content, _ = command.Flags().GetString("content")
+	input.contentFile, _ = command.Flags().GetString("content-file")
+	input.text, _ = command.Flags().GetString("text")
+	input.markdown, _ = command.Flags().GetString("markdown")
+	input.file, _ = command.Flags().GetString("file")
+	input.image, _ = command.Flags().GetString("image")
+	input.audio, _ = command.Flags().GetString("audio")
+	input.video, _ = command.Flags().GetString("video")
+	input.videoCover, _ = command.Flags().GetString("video-cover")
+	input.uploadImages, _ = command.Flags().GetBool("upload-images")
+	return input
+}
+
+func (input messageContentInput) validate() error {
+	if err := validateSendMessageType(input.msgType); err != nil {
+		return err
+	}
+
+	sources := []struct {
+		name  string
+		value string
+	}{
+		{"--content", input.content},
+		{"--content-file", input.contentFile},
+		{"--text", input.text},
+		{"--markdown", input.markdown},
+		{"--file", input.file},
+		{"--image", input.image},
+		{"--audio", input.audio},
+		{"--video", input.video},
+	}
+	var specified []string
+	for _, source := range sources {
+		if source.value != "" {
+			specified = append(specified, source.name)
+		}
+	}
+	if len(specified) == 0 {
+		return fmt.Errorf("必须指定 --content、--content-file、--text、--markdown、--file、--image、--audio 或 --video")
+	}
+	if len(specified) > 1 {
+		return fmt.Errorf("以下内容标志互斥，只能指定其中一个: %s", strings.Join(specified, ", "))
+	}
+	if input.video != "" && input.videoCover == "" {
+		return fmt.Errorf("使用 --video 时必须同时指定 --video-cover")
+	}
+	if input.video == "" && input.videoCover != "" {
+		return fmt.Errorf("--video-cover 只能与 --video 一起使用")
+	}
+
+	inferredType := input.inferredMessageType()
+	if input.msgTypeChanged && inferredType != "" && input.msgType != inferredType {
+		return fmt.Errorf("--msg-type %q 与内容快捷参数推断出的消息类型 %q 冲突", input.msgType, inferredType)
+	}
+
+	switch {
+	case input.content != "":
+		if !json.Valid([]byte(input.content)) {
+			return fmt.Errorf("--content 必须是有效 JSON")
+		}
+	case input.contentFile != "":
+		data, err := os.ReadFile(input.contentFile)
+		if err != nil {
+			return fmt.Errorf("读取内容文件失败: %w", err)
+		}
+		if !json.Valid(data) {
+			return fmt.Errorf("--content-file %s 的内容必须是有效 JSON", input.contentFile)
+		}
+	case input.image != "":
+		if err := validateImageInput("--image", input.image); err != nil {
+			return err
+		}
+	case input.file != "":
+		if err := validateFileInput("--file", input.file, "file"); err != nil {
+			return err
+		}
+	case input.audio != "":
+		if err := validateFileInput("--audio", input.audio, "audio"); err != nil {
+			return err
+		}
+		if !isIMFileKey(input.audio) {
+			ext := strings.ToLower(filepath.Ext(input.audio))
+			if ext != ".opus" && ext != ".ogg" {
+				return fmt.Errorf("--audio 仅支持 Opus（.opus）或 Ogg Opus（.ogg）；其他音频请用 --file 作为附件发送")
+			}
+		}
+	case input.video != "":
+		if err := validateFileInput("--video", input.video, "video"); err != nil {
+			return err
+		}
+		if !isIMFileKey(input.video) && strings.ToLower(filepath.Ext(input.video)) != ".mp4" {
+			return fmt.Errorf("--video 仅支持 MP4 文件；其他视频请先转换为 MP4，或用 --file 作为附件发送")
+		}
+		if err := validateImageInput("--video-cover", input.videoCover); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (input messageContentInput) inferredMessageType() string {
+	switch {
+	case input.text != "":
+		return "text"
+	case input.markdown != "":
+		return "post"
+	case input.image != "":
+		return "image"
+	case input.file != "":
+		return "file"
+	case input.audio != "":
+		return "audio"
+	case input.video != "":
+		return "media"
+	default:
+		return ""
+	}
+}
+
+func isIMImageKey(value string) bool {
+	return strings.HasPrefix(value, "img_")
+}
+
+func isIMFileKey(value string) bool {
+	return strings.HasPrefix(value, "file_")
+}
+
+func rejectRemoteMediaURL(flagName, value string) error {
+	if strings.HasPrefix(value, "http://") || strings.HasPrefix(value, "https://") {
+		return fmt.Errorf("%s 暂不下载远程 URL；请使用本地路径，或先上传后传入飞书资源 key", flagName)
+	}
+	return nil
+}
+
+func resolveStandaloneMediaPath(value string) (string, error) {
+	path, err := resolveLocalPath(value, ".")
+	if err != nil {
+		return "", err
+	}
+	return filepath.Clean(path), nil
+}
+
+func validateImageInput(flagName, value string) error {
+	if isIMImageKey(value) {
+		return nil
+	}
+	if err := rejectRemoteMediaURL(flagName, value); err != nil {
+		return err
+	}
+	path, err := resolveStandaloneMediaPath(value)
+	if err != nil {
+		return fmt.Errorf("解析 %s 路径失败: %w", flagName, err)
+	}
+	if err := validateLocalIMImage(path); err != nil {
+		return fmt.Errorf("%s 图片不可用 %s: %w", flagName, path, err)
+	}
+	return nil
+}
+
+func validateFileInput(flagName, value, label string) error {
+	if isIMFileKey(value) {
+		return nil
+	}
+	if err := rejectRemoteMediaURL(flagName, value); err != nil {
+		return err
+	}
+	path, err := resolveStandaloneMediaPath(value)
+	if err != nil {
+		return fmt.Errorf("解析 %s 路径失败: %w", flagName, err)
+	}
+	info, err := os.Stat(path)
+	if err != nil {
+		return fmt.Errorf("%s %s 不可用 %s: %w", flagName, label, path, err)
+	}
+	if !info.Mode().IsRegular() {
+		return fmt.Errorf("%s %s 不是普通文件: %s", flagName, label, path)
+	}
+	if info.Size() == 0 {
+		return fmt.Errorf("%s %s 不能为空文件: %s", flagName, label, path)
+	}
+	return nil
+}
+
+func (input messageContentInput) resolve() (string, string, error) {
+	msgType := input.msgType
+	var content string
+
+	switch {
+	case input.contentFile != "":
+		data, err := os.ReadFile(input.contentFile)
+		if err != nil {
+			return "", "", fmt.Errorf("读取内容文件失败: %w", err)
+		}
+		content = string(data)
+	case input.content != "":
+		content = input.content
+	case input.text != "":
+		msgType = "text"
+		content = client.CreateTextMessageContent(client.NormalizeAtMentions(input.text))
+	case input.markdown != "":
+		msgType = "post"
+		content = createMarkdownPostContent(input.markdown)
+	case input.image != "":
+		msgType = "image"
+		key, err := resolveImageKey("--image", input.image)
+		if err != nil {
+			return "", "", err
+		}
+		content = marshalMessageKey("image_key", key)
+	case input.file != "":
+		msgType = "file"
+		key, err := resolveFileKey("--file", input.file, fileUploadTypeForAttachment(input.file))
+		if err != nil {
+			return "", "", err
+		}
+		content = marshalMessageKey("file_key", key)
+	case input.audio != "":
+		msgType = "audio"
+		key, err := resolveFileKey("--audio", input.audio, "opus")
+		if err != nil {
+			return "", "", err
+		}
+		content = marshalMessageKey("file_key", key)
+	case input.video != "":
+		msgType = "media"
+		fileKey, err := resolveFileKey("--video", input.video, "mp4")
+		if err != nil {
+			return "", "", err
+		}
+		imageKey, err := resolveImageKey("--video-cover", input.videoCover)
+		if err != nil {
+			return "", "", err
+		}
+		data, _ := json.Marshal(map[string]string{
+			"file_key":  fileKey,
+			"image_key": imageKey,
+		})
+		content = string(data)
+	}
+
+	if input.uploadImages && (msgType == "post" || msgType == "interactive") {
+		basePath := "."
+		if input.contentFile != "" {
+			basePath = filepath.Dir(input.contentFile)
+		}
+		processed, count, err := processAndUploadLocalImages(content, basePath)
+		if err != nil {
+			return "", "", err
+		}
+		if count > 0 {
+			fmt.Fprintf(os.Stderr, "已自动上传 %d 张本地图片\n", count)
+		}
+		content = processed
+	}
+	return msgType, content, nil
+}
+
+func createMarkdownPostContent(markdown string) string {
+	data, _ := json.Marshal(map[string]interface{}{
+		"zh_cn": map[string]interface{}{
+			"title": "",
+			"content": [][]map[string]string{
+				{{"tag": "md", "text": markdown}},
+			},
+		},
+	})
+	return string(data)
+}
+
+func marshalMessageKey(name, value string) string {
+	data, _ := json.Marshal(map[string]string{name: value})
+	return string(data)
+}
+
+func resolveImageKey(flagName, value string) (string, error) {
+	if isIMImageKey(value) {
+		return value, nil
+	}
+	path, err := resolveStandaloneMediaPath(value)
+	if err != nil {
+		return "", fmt.Errorf("解析 %s 路径失败: %w", flagName, err)
+	}
+	fmt.Fprintf(os.Stderr, "正在上传图片: %s\n", filepath.Base(path))
+	key, err := uploadIMImage(path, "")
+	if err != nil {
+		return "", fmt.Errorf("%s 上传失败: %w", flagName, err)
+	}
+	if key == "" {
+		return "", fmt.Errorf("%s 上传成功但未返回 image_key", flagName)
+	}
+	return key, nil
+}
+
+func resolveFileKey(flagName, value, fileType string) (string, error) {
+	if isIMFileKey(value) {
+		return value, nil
+	}
+	path, err := resolveStandaloneMediaPath(value)
+	if err != nil {
+		return "", fmt.Errorf("解析 %s 路径失败: %w", flagName, err)
+	}
+	fmt.Fprintf(os.Stderr, "正在上传文件: %s\n", filepath.Base(path))
+	key, err := uploadIMFileWithOptions(path, "", fileType, 0)
+	if err != nil {
+		return "", fmt.Errorf("%s 上传失败: %w", flagName, err)
+	}
+	if key == "" {
+		return "", fmt.Errorf("%s 上传成功但未返回 file_key", flagName)
+	}
+	return key, nil
+}
+
+func fileUploadTypeForAttachment(value string) string {
+	if isIMFileKey(value) {
+		return ""
+	}
+	switch strings.ToLower(filepath.Ext(value)) {
+	case ".opus", ".ogg", ".mp4":
+		// 飞书要求 opus/mp4 类型的 file_key 分别用于 audio/media。
+		// 用户显式使用 --file 时，应按普通附件上传，避免发送阶段报 230055。
+		return "stream"
+	default:
+		return ""
+	}
+}

--- a/cmd/msg_content_test.go
+++ b/cmd/msg_content_test.go
@@ -1,0 +1,193 @@
+package cmd
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/spf13/cobra"
+)
+
+func newMessageContentTestCommand(t *testing.T, args ...string) (*cobra.Command, messageContentInput) {
+	t.Helper()
+	command := &cobra.Command{Use: "test"}
+	addMessageContentFlags(command)
+	if err := command.ParseFlags(args); err != nil {
+		t.Fatalf("解析测试 flag 失败: %v", err)
+	}
+	return command, readMessageContentInput(command)
+}
+
+func TestMessageContentInputValidation(t *testing.T) {
+	tests := []struct {
+		name    string
+		args    []string
+		wantErr string
+	}{
+		{"text", []string{"--text", "hello"}, ""},
+		{"markdown", []string{"--markdown", "**hello**"}, ""},
+		{"image key", []string{"--image", "img_xxx"}, ""},
+		{"file key", []string{"--file", "file_xxx"}, ""},
+		{"audio key", []string{"--audio", "file_xxx"}, ""},
+		{"video keys", []string{"--video", "file_xxx", "--video-cover", "img_xxx"}, ""},
+		{"mutually exclusive", []string{"--text", "a", "--image", "img_xxx"}, "互斥"},
+		{"missing video cover", []string{"--video", "file_xxx"}, "--video-cover"},
+		{"orphan video cover", []string{"--text", "a", "--video-cover", "img_xxx"}, "只能与 --video"},
+		{"explicit type conflict", []string{"--msg-type", "text", "--image", "img_xxx"}, "冲突"},
+		{"invalid JSON", []string{"--content", "not-json"}, "有效 JSON"},
+		{"remote image rejected", []string{"--image", "https://example.com/a.png"}, "暂不下载远程 URL"},
+		{"invalid audio extension", []string{"--audio", "voice.mp3"}, "不可用"},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			_, input := newMessageContentTestCommand(t, test.args...)
+			err := input.validate()
+			if test.wantErr == "" {
+				if err != nil {
+					t.Fatalf("validate() error = %v", err)
+				}
+				return
+			}
+			if err == nil || !strings.Contains(err.Error(), test.wantErr) {
+				t.Fatalf("validate() error = %v, want contains %q", err, test.wantErr)
+			}
+		})
+	}
+}
+
+func TestMessageContentResolveMarkdownAndExistingKeys(t *testing.T) {
+	_, markdownInput := newMessageContentTestCommand(t, "--markdown", "**hello**")
+	if err := markdownInput.validate(); err != nil {
+		t.Fatal(err)
+	}
+	msgType, content, err := markdownInput.resolve()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if msgType != "post" || !json.Valid([]byte(content)) || !strings.Contains(content, `"tag":"md"`) {
+		t.Fatalf("Markdown 解析结果不正确: type=%s content=%s", msgType, content)
+	}
+
+	_, videoInput := newMessageContentTestCommand(t,
+		"--video", "file_video", "--video-cover", "img_cover")
+	if err := videoInput.validate(); err != nil {
+		t.Fatal(err)
+	}
+	msgType, content, err = videoInput.resolve()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if msgType != "media" ||
+		!strings.Contains(content, `"file_key":"file_video"`) ||
+		!strings.Contains(content, `"image_key":"img_cover"`) {
+		t.Fatalf("视频解析结果不正确: type=%s content=%s", msgType, content)
+	}
+}
+
+func TestMessageContentResolveLocalMedia(t *testing.T) {
+	tempDir := t.TempDir()
+	imagePath := filepath.Join(tempDir, "image.png")
+	if err := os.WriteFile(imagePath, []byte("\x89PNG\r\n\x1a\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	mp4Path := filepath.Join(tempDir, "clip.mp4")
+	if err := os.WriteFile(mp4Path, []byte("fake-mp4"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	oldImageUpload := uploadIMImage
+	oldFileUpload := uploadIMFileWithOptions
+	defer func() {
+		uploadIMImage = oldImageUpload
+		uploadIMFileWithOptions = oldFileUpload
+	}()
+
+	var gotImagePath string
+	uploadIMImage = func(path, imageType string) (string, error) {
+		gotImagePath = path
+		if imageType != "" {
+			t.Fatalf("imageType = %q, want default", imageType)
+		}
+		return "img_uploaded", nil
+	}
+	var gotFileType string
+	uploadIMFileWithOptions = func(path, name, fileType string, duration int) (string, error) {
+		if path != mp4Path {
+			t.Fatalf("path = %q, want %q", path, mp4Path)
+		}
+		gotFileType = fileType
+		return "file_uploaded", nil
+	}
+
+	_, imageInput := newMessageContentTestCommand(t, "--image", imagePath)
+	if err := imageInput.validate(); err != nil {
+		t.Fatal(err)
+	}
+	msgType, content, err := imageInput.resolve()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if gotImagePath != imagePath || msgType != "image" || content != `{"image_key":"img_uploaded"}` {
+		t.Fatalf("图片结果异常: path=%q type=%s content=%s", gotImagePath, msgType, content)
+	}
+
+	_, fileInput := newMessageContentTestCommand(t, "--file", mp4Path)
+	if err := fileInput.validate(); err != nil {
+		t.Fatal(err)
+	}
+	msgType, content, err = fileInput.resolve()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if gotFileType != "stream" || msgType != "file" || content != `{"file_key":"file_uploaded"}` {
+		t.Fatalf("MP4 附件结果异常: fileType=%s type=%s content=%s", gotFileType, msgType, content)
+	}
+}
+
+func TestValidateReplyMessageID(t *testing.T) {
+	if err := validateReplyMessageID("om_xxx"); err != nil {
+		t.Fatalf("om_xxx 应合法: %v", err)
+	}
+	if err := validateReplyMessageID("omt_xxx"); err == nil || !strings.Contains(err.Error(), "thread_id") {
+		t.Fatalf("omt_xxx 应返回 thread_id 提示: %v", err)
+	}
+}
+
+func TestValidateIdempotencyKeyUnicodeCharacters(t *testing.T) {
+	if err := validateIdempotencyKey(strings.Repeat("中", 50)); err != nil {
+		t.Fatalf("50 个 Unicode 字符应合法: %v", err)
+	}
+	if err := validateIdempotencyKey(strings.Repeat("中", 51)); err == nil {
+		t.Fatal("51 个 Unicode 字符应被拒绝")
+	}
+}
+
+func TestSendThreadIDFailsBeforeContentOrUpload(t *testing.T) {
+	threadFlag := sendMessageCmd.Flags().Lookup("thread-id")
+	imageFlag := sendMessageCmd.Flags().Lookup("image")
+	oldThreadValue, oldThreadChanged := threadFlag.Value.String(), threadFlag.Changed
+	oldImageValue, oldImageChanged := imageFlag.Value.String(), imageFlag.Changed
+	defer func() {
+		_ = threadFlag.Value.Set(oldThreadValue)
+		threadFlag.Changed = oldThreadChanged
+		_ = imageFlag.Value.Set(oldImageValue)
+		imageFlag.Changed = oldImageChanged
+	}()
+
+	if err := threadFlag.Value.Set("omt_xxx"); err != nil {
+		t.Fatal(err)
+	}
+	threadFlag.Changed = true
+	if err := imageFlag.Value.Set("/definitely/missing.png"); err != nil {
+		t.Fatal(err)
+	}
+	imageFlag.Changed = true
+
+	err := sendMessageCmd.RunE(sendMessageCmd, nil)
+	if err == nil || !strings.Contains(err.Error(), "msg reply") {
+		t.Fatalf("--thread-id 应在检查图片/配置前失败并提示 reply，实际: %v", err)
+	}
+}

--- a/cmd/reply_msg.go
+++ b/cmd/reply_msg.go
@@ -2,7 +2,7 @@ package cmd
 
 import (
 	"fmt"
-	"os"
+	"strings"
 
 	"github.com/riba2534/feishu-cli/internal/client"
 	"github.com/riba2534/feishu-cli/internal/config"
@@ -11,86 +11,106 @@ import (
 
 var replyMsgCmd = &cobra.Command{
 	Use:   "reply <message_id>",
-	Short: "回复消息",
-	Long: `回复指定的消息。
+	Short: "回复消息（支持话题与媒体）",
+	Long: `回复指定的 om_xxx 消息。发送到既有话题时，应回复话题内任一 om_xxx 消息；
+目标消息已经属于话题时，飞书会默认把回复放入同一话题。不要传 omt_xxx thread_id。
 
-参数:
-  message_id          消息 ID（必填）
-  --msg-type          消息类型（默认 text）
-  --text, -t          简单文本消息（快捷方式）
+内容参数:
+  --text, -t          简单文本
+  --markdown          Markdown（自动包装为 post）
   --content, -c       消息内容 JSON
   --content-file      消息内容 JSON 文件
-  --reply-in-thread   以话题（thread）形式回复；若群聊已是话题模式，则自动回复到消息所在话题
+  --image             本地图片路径或 image_key
+  --file, -f          本地文件路径或 file_key
+  --audio             本地 Opus/Ogg Opus 路径或 file_key
+  --video             本地 MP4 路径或 file_key（需同时指定 --video-cover）
+  --video-cover       视频封面本地图片路径或 image_key
+  --upload-images     上传 post/interactive 中引用的本地图片
 
-消息类型:
-  text         文本消息
-  post         富文本消息
-  interactive  卡片消息
+回复参数:
+  --reply-in-thread   在普通消息群中开启新话题；目标已在话题中时通常无需指定
+  --idempotency-key   幂等键（≤50 字符）；相同键一小时内至多成功回复一条
+  --output, -o        输出格式（json）
 
 示例:
-  # 回复文本消息
+  # 回复文本
   feishu-cli msg reply om_xxx --text "收到，谢谢！"
 
-  # 回复富文本消息
-  feishu-cli msg reply om_xxx --msg-type post --content-file reply.json
+  # 回复本地图片（自动上传后提交 image_key）
+  feishu-cli msg reply om_xxx --image /path/to/screenshot.png \
+    --idempotency-key "reply-image-20260730"
 
-  # 回复卡片消息
-  feishu-cli msg reply om_xxx --msg-type interactive --content '{"type":"template",...}'
+  # 在普通消息群中开启一个新话题
+  feishu-cli msg reply om_xxx --text "这里开个话题" --reply-in-thread
 
-  # 以话题形式回复（在非话题群聊中开启一个新话题）
-  feishu-cli msg reply om_xxx --text "这里开个话题" --reply-in-thread`,
+  # 回复卡片并上传其中的本地图片
+  feishu-cli msg reply om_xxx --msg-type interactive \
+    --content-file card.json --upload-images`,
 	Args: cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
+		messageID := strings.TrimSpace(args[0])
+		if err := validateReplyMessageID(messageID); err != nil {
+			return err
+		}
+		idempotencyKey, _ := cmd.Flags().GetString("idempotency-key")
+		if err := validateIdempotencyKey(idempotencyKey); err != nil {
+			return err
+		}
+		contentInput := readMessageContentInput(cmd)
+		if err := contentInput.validate(); err != nil {
+			return err
+		}
 		if err := config.Validate(); err != nil {
 			return err
 		}
 
-		token := resolveOptionalUserToken(cmd)
-
-		messageID := args[0]
-		msgType, _ := cmd.Flags().GetString("msg-type")
-		content, _ := cmd.Flags().GetString("content")
-		contentFile, _ := cmd.Flags().GetString("content-file")
-		text, _ := cmd.Flags().GetString("text")
-		replyInThread, _ := cmd.Flags().GetBool("reply-in-thread")
-
-		var msgContent string
-		if contentFile != "" {
-			data, err := os.ReadFile(contentFile)
-			if err != nil {
-				return fmt.Errorf("读取内容文件失败: %w", err)
-			}
-			msgContent = string(data)
-		} else if content != "" {
-			msgContent = content
-		} else if text != "" {
-			msgType = "text"
-			// 在 marshal 前规范化 @ 标签，让 json.Marshal 自动转义双引号，避免破坏 JSON。
-			text = client.NormalizeAtMentions(text)
-			msgContent = client.CreateTextMessageContent(text)
-		} else {
-			return fmt.Errorf("必须指定 --content、--content-file 或 --text")
+		msgType, msgContent, err := contentInput.resolve()
+		if err != nil {
+			return err
 		}
-
-		newMessageID, err := client.ReplyMessage(messageID, msgType, msgContent, replyInThread, token)
+		replyInThread, _ := cmd.Flags().GetBool("reply-in-thread")
+		token := resolveOptionalUserToken(cmd)
+		newMessageID, err := client.ReplyMessage(
+			messageID,
+			msgType,
+			msgContent,
+			replyInThread,
+			token,
+			idempotencyKey,
+		)
 		if err != nil {
 			return err
 		}
 
+		output, _ := cmd.Flags().GetString("output")
+		if output == "json" {
+			return printJSON(map[string]string{
+				"message_id":        newMessageID,
+				"parent_message_id": messageID,
+			})
+		}
 		fmt.Printf("消息回复成功！\n")
 		fmt.Printf("  原消息 ID: %s\n", messageID)
 		fmt.Printf("  新消息 ID: %s\n", newMessageID)
-
 		return nil
 	},
 }
 
+func validateReplyMessageID(messageID string) error {
+	if strings.HasPrefix(messageID, "omt_") {
+		return fmt.Errorf("无效的 message_id %q：omt_ 是 thread_id；请传入话题内的 om_xxx 消息 ID", messageID)
+	}
+	if !strings.HasPrefix(messageID, "om_") {
+		return fmt.Errorf("无效的 message_id %q：回复消息需要 om_xxx 消息 ID", messageID)
+	}
+	return nil
+}
+
 func init() {
 	msgCmd.AddCommand(replyMsgCmd)
-	replyMsgCmd.Flags().String("msg-type", "text", "消息类型（text/post/interactive 等）")
-	replyMsgCmd.Flags().StringP("text", "t", "", "简单文本消息")
-	replyMsgCmd.Flags().StringP("content", "c", "", "消息内容 JSON")
-	replyMsgCmd.Flags().String("content-file", "", "消息内容 JSON 文件")
+	addMessageContentFlags(replyMsgCmd)
 	replyMsgCmd.Flags().Bool("reply-in-thread", false, "以话题形式回复（reply_in_thread=true）")
+	replyMsgCmd.Flags().String("idempotency-key", "", "幂等键（≤50 字符），相同键一小时内至多成功回复一条")
+	replyMsgCmd.Flags().StringP("output", "o", "", "输出格式（json）")
 	replyMsgCmd.Flags().String("user-access-token", "", "User Access Token（用户授权令牌）")
 }

--- a/cmd/send_message.go
+++ b/cmd/send_message.go
@@ -21,15 +21,18 @@ var sendMessageCmd = &cobra.Command{
 	Long: `向飞书用户或群组发送消息。
 
 参数:
-  --receive-id-type   接收者类型（与 --thread-id 二选一）
-  --receive-id        接收者标识（与 --thread-id 二选一）
-  --thread-id         话题 ID（omt_xxx），在已有话题内追加一条消息（等价于 receive_id_type=thread_id）
+  --receive-id-type   接收者类型
+  --receive-id        接收者标识
   --msg-type          消息类型（默认: text）
   --content, -c       消息内容 JSON
   --content-file      消息内容 JSON 文件
   --text, -t          简单文本消息（快捷方式）
-  --file, -f          发送本地文件（自动上传并发送，快捷方式）
-  --image             发送本地图片（自动上传并发送，快捷方式）
+  --markdown          Markdown 消息（自动包装为 post）
+  --file, -f          本地文件或 file_key（作为附件发送）
+  --image             本地图片或 image_key
+  --audio             本地 Opus/Ogg Opus 或 file_key
+  --video             本地 MP4 或 file_key（需同时指定 --video-cover）
+  --video-cover       视频封面本地图片或 image_key
   --upload-images     自动上传 Markdown、post image_key 与 Card V2 img_key 中的本地图片
   --idempotency-key   幂等键（≤50 字符），服务端按此键去重，防止重发
   --output, -o        输出格式（json）
@@ -40,7 +43,6 @@ var sendMessageCmd = &cobra.Command{
   user_id     用户 ID
   union_id    Union ID
   chat_id     群组 ID
-  thread_id   话题 ID（在话题内追加消息，通常用 --thread-id 代替）
 
 消息类型:
   text         文本消息
@@ -94,10 +96,9 @@ var sendMessageCmd = &cobra.Command{
     --content-file card.json \
     --upload-images
 
-  # 在已有话题内追加消息
-  feishu-cli msg send \
-    --thread-id omt_xxx \
-    --text "话题内继续聊"
+  # 回复图片并进入既有话题（目标必须是话题内的 om_xxx 消息 ID）
+  feishu-cli msg reply om_xxx \
+    --image /path/to/screenshot.png
 
   # 使用幂等键防止重发（相同 key 重复调用只会发出一条消息）
   feishu-cli msg send \
@@ -109,26 +110,23 @@ var sendMessageCmd = &cobra.Command{
 		receiveIDType, _ := cmd.Flags().GetString("receive-id-type")
 		receiveID, _ := cmd.Flags().GetString("receive-id")
 		threadID, _ := cmd.Flags().GetString("thread-id")
-		msgType, _ := cmd.Flags().GetString("msg-type")
 
 		if threadID != "" {
-			if receiveIDType != "" || receiveID != "" {
-				return fmt.Errorf("--thread-id 与 --receive-id-type/--receive-id 互斥，只能指定一组")
-			}
-			receiveIDType = "thread_id"
-			receiveID = threadID
-		} else if receiveIDType == "" || receiveID == "" {
-			return fmt.Errorf("必须指定 --thread-id，或同时指定 --receive-id-type 和 --receive-id")
+			return fmt.Errorf("--thread-id 不可用于 msg send：飞书 create message 接口不支持 thread_id；请改用 msg reply <om_xxx>（回复既有话题可省略 --reply-in-thread，开启新话题时加 --reply-in-thread）")
+		}
+		if receiveIDType == "" || receiveID == "" {
+			return fmt.Errorf("必须同时指定 --receive-id-type 和 --receive-id")
 		}
 		if err := validateSendReceiveIDType(receiveIDType); err != nil {
-			return err
-		}
-		if err := validateSendMessageType(msgType); err != nil {
 			return err
 		}
 
 		idempotencyKey, _ := cmd.Flags().GetString("idempotency-key")
 		if err := validateIdempotencyKey(idempotencyKey); err != nil {
+			return err
+		}
+		contentInput := readMessageContentInput(cmd)
+		if err := contentInput.validate(); err != nil {
 			return err
 		}
 
@@ -138,109 +136,9 @@ var sendMessageCmd = &cobra.Command{
 
 		token := resolveOptionalUserToken(cmd)
 
-		content, _ := cmd.Flags().GetString("content")
-		contentFile, _ := cmd.Flags().GetString("content-file")
-		text, _ := cmd.Flags().GetString("text")
-		filePath, _ := cmd.Flags().GetString("file")
-		imagePath, _ := cmd.Flags().GetString("image")
-		uploadImages, _ := cmd.Flags().GetBool("upload-images")
-
-		// 互斥校验：5 个内容标志只能指定一个
-		var specifiedFlags []string
-		if filePath != "" {
-			specifiedFlags = append(specifiedFlags, "--file")
-		}
-		if imagePath != "" {
-			specifiedFlags = append(specifiedFlags, "--image")
-		}
-		if contentFile != "" {
-			specifiedFlags = append(specifiedFlags, "--content-file")
-		}
-		if content != "" {
-			specifiedFlags = append(specifiedFlags, "--content")
-		}
-		if text != "" {
-			specifiedFlags = append(specifiedFlags, "--text")
-		}
-		if len(specifiedFlags) > 1 {
-			return fmt.Errorf("以下标志互斥，只能指定其中一个: %s", fmt.Sprintf("%v", specifiedFlags))
-		}
-
-		// 文件/图片路径预检查
-		if filePath != "" {
-			if _, err := os.Stat(filePath); err != nil {
-				return fmt.Errorf("无法访问文件: %w", err)
-			}
-		}
-		if imagePath != "" {
-			if _, err := os.Stat(imagePath); err != nil {
-				return fmt.Errorf("无法访问图片文件: %w", err)
-			}
-		}
-
-		var msgContent string
-		switch {
-		case filePath != "":
-			// Upload file via IM API, then send as file message
-			fmt.Fprintf(os.Stderr, "正在上传文件: %s\n", filepath.Base(filePath))
-			fileKey, err := client.UploadIMFile(filePath, "")
-			if err != nil {
-				return err
-			}
-			msgType = "file"
-			contentJSON, _ := json.Marshal(map[string]string{"file_key": fileKey})
-			msgContent = string(contentJSON)
-
-		case imagePath != "":
-			// Upload image via IM API, then send as image message
-			fmt.Fprintf(os.Stderr, "正在上传图片: %s\n", filepath.Base(imagePath))
-			imageKey, err := client.UploadIMImage(imagePath, "")
-			if err != nil {
-				return err
-			}
-			msgType = "image"
-			contentJSON, _ := json.Marshal(map[string]string{"image_key": imageKey})
-			msgContent = string(contentJSON)
-
-		case contentFile != "":
-			data, err := os.ReadFile(contentFile)
-			if err != nil {
-				return fmt.Errorf("读取内容文件失败: %w", err)
-			}
-			msgContent = string(data)
-
-		case content != "":
-			msgContent = content
-
-		case text != "":
-			msgType = "text"
-			// 在 marshal 前规范化 @ 标签（修复 <at id=...> / <at open_id=...> 等 AI 易错格式），
-			// 让 json.Marshal 自动转义产生的双引号，避免破坏 JSON 结构。
-			text = client.NormalizeAtMentions(text)
-			msgContent = client.CreateTextMessageContent(text)
-
-		default:
-			return fmt.Errorf("必须指定 --content、--content-file、--text、--file 或 --image")
-		}
-
-		// 自动上传本地图片（仅对 post 和 interactive 消息有效）
-		if uploadImages && (msgType == "post" || msgType == "interactive") {
-			// 确定 basePath：如果使用 --content-file，以其目录为 basePath；否则用当前目录
-			basePath := "."
-			if contentFile != "" {
-				basePath = filepath.Dir(contentFile)
-				if basePath == "" || basePath == "." {
-					basePath = "."
-				}
-			}
-			processedContent, uploadCount, err := processAndUploadLocalImages(msgContent, basePath)
-			if err != nil {
-				return err
-			}
-			if uploadCount > 0 {
-				fmt.Fprintf(os.Stderr, "已自动上传 %d 张本地图片\n", uploadCount)
-			}
-			msgContent = processedContent
+		msgType, msgContent, err := contentInput.resolve()
+		if err != nil {
+			return err
 		}
 
 		messageID, err := client.SendMessage(receiveIDType, receiveID, msgType, msgContent, token, idempotencyKey)
@@ -266,10 +164,12 @@ var sendMessageCmd = &cobra.Command{
 
 func validateSendReceiveIDType(receiveIDType string) error {
 	switch receiveIDType {
-	case "email", "open_id", "user_id", "union_id", "chat_id", "thread_id":
+	case "email", "open_id", "user_id", "union_id", "chat_id":
 		return nil
+	case "thread_id":
+		return fmt.Errorf("--receive-id-type thread_id 不受飞书 create message 接口支持；请改用 msg reply <om_xxx>")
 	default:
-		return fmt.Errorf("无效的 --receive-id-type: %s，有效值: email/open_id/user_id/union_id/chat_id/thread_id", receiveIDType)
+		return fmt.Errorf("无效的 --receive-id-type: %s，有效值: email/open_id/user_id/union_id/chat_id", receiveIDType)
 	}
 }
 
@@ -296,16 +196,11 @@ func validateIdempotencyKey(key string) error {
 
 func init() {
 	msgCmd.AddCommand(sendMessageCmd)
-	sendMessageCmd.Flags().String("receive-id-type", "", "接收者类型（email/open_id/user_id/union_id/chat_id/thread_id）")
+	sendMessageCmd.Flags().String("receive-id-type", "", "接收者类型（email/open_id/user_id/union_id/chat_id）")
 	sendMessageCmd.Flags().String("receive-id", "", "接收者标识")
-	sendMessageCmd.Flags().String("thread-id", "", "话题 ID（omt_xxx），在已有话题内追加消息；与 --receive-id-type/--receive-id 互斥")
-	sendMessageCmd.Flags().String("msg-type", "text", "消息类型（text/post/image/interactive 等）")
-	sendMessageCmd.Flags().StringP("content", "c", "", "消息内容 JSON")
-	sendMessageCmd.Flags().String("content-file", "", "消息内容 JSON 文件")
-	sendMessageCmd.Flags().StringP("text", "t", "", "简单文本消息")
-	sendMessageCmd.Flags().StringP("file", "f", "", "发送本地文件（自动上传并发送）")
-	sendMessageCmd.Flags().String("image", "", "发送本地图片（自动上传并发送）")
-	sendMessageCmd.Flags().Bool("upload-images", false, "自动上传 Markdown、post image_key 与 Card V2 img_key 中的本地图片")
+	sendMessageCmd.Flags().String("thread-id", "", "已废弃：飞书 create message 不支持 thread_id；请使用 msg reply <om_xxx>")
+	_ = sendMessageCmd.Flags().MarkDeprecated("thread-id", "飞书 create message 不支持 thread_id，请使用 msg reply <om_xxx>")
+	addMessageContentFlags(sendMessageCmd)
 	sendMessageCmd.Flags().String("idempotency-key", "", "幂等键（≤50 字符），服务端按此键去重；相同键重复发送返回首次消息，防止重发")
 	sendMessageCmd.Flags().StringP("output", "o", "", "输出格式（json）")
 	sendMessageCmd.Flags().String("user-access-token", "", "User Access Token（用户授权令牌）")

--- a/internal/client/im_upload.go
+++ b/internal/client/im_upload.go
@@ -19,7 +19,7 @@ const (
 func fileExtToIMType(filename string) string {
 	ext := strings.ToLower(filepath.Ext(filename))
 	switch ext {
-	case ".opus":
+	case ".opus", ".ogg":
 		return "opus"
 	case ".mp4":
 		return "mp4"
@@ -37,8 +37,14 @@ func fileExtToIMType(filename string) string {
 }
 
 // UploadIMFile uploads a local file via the IM API (/open-apis/im/v1/files)
-// and returns the file_key that can be used directly in msg send --msg-type file.
+// and returns the file_key. file_type is inferred from the filename.
 func UploadIMFile(filePath string, fileName string) (string, error) {
+	return UploadIMFileWithOptions(filePath, fileName, "", 0)
+}
+
+// UploadIMFileWithOptions 上传 IM 文件，并允许调用方指定 file_type 与音视频时长。
+// fileType 为空时按文件扩展名推断；durationMs <= 0 时不提交 duration。
+func UploadIMFileWithOptions(filePath string, fileName string, fileType string, durationMs int) (string, error) {
 	client, err := GetClient()
 	if err != nil {
 		return "", err
@@ -57,19 +63,32 @@ func UploadIMFile(filePath string, fileName string) (string, error) {
 	if stat.Size() > maxIMFileSize {
 		return "", fmt.Errorf("文件大小 %s 超过 IM 上传限制（30MB），请使用 file upload 命令上传到云空间", formatSize(int(stat.Size())))
 	}
+	if stat.Size() == 0 {
+		return "", fmt.Errorf("文件为空，飞书 IM 不允许上传空文件")
+	}
 
 	if fileName == "" {
 		fileName = filepath.Base(filePath)
 	}
 
-	fileType := fileExtToIMType(fileName)
+	if fileType == "" {
+		fileType = fileExtToIMType(fileName)
+	}
+	switch fileType {
+	case "opus", "mp4", "pdf", "doc", "xls", "ppt", "stream":
+	default:
+		return "", fmt.Errorf("无效的 IM file_type: %s", fileType)
+	}
 
+	bodyBuilder := larkim.NewCreateFileReqBodyBuilder().
+		FileType(fileType).
+		FileName(fileName).
+		File(f)
+	if durationMs > 0 {
+		bodyBuilder.Duration(durationMs)
+	}
 	req := larkim.NewCreateFileReqBuilder().
-		Body(larkim.NewCreateFileReqBodyBuilder().
-			FileType(fileType).
-			FileName(fileName).
-			File(f).
-			Build()).
+		Body(bodyBuilder.Build()).
 		Build()
 
 	resp, err := client.Im.File.Create(ContextWithTimeout(downloadTimeout), req)

--- a/internal/client/message.go
+++ b/internal/client/message.go
@@ -64,7 +64,7 @@ func SendMessage(receiveIDType string, receiveID string, msgType string, content
 		return "", fmt.Errorf("发送消息失败: code=%d, msg=%s", resp.Code, resp.Msg)
 	}
 
-	if resp.Data.MessageId == nil {
+	if resp.Data == nil || resp.Data.MessageId == nil || *resp.Data.MessageId == "" {
 		return "", fmt.Errorf("消息已发送但未返回消息 ID")
 	}
 
@@ -73,8 +73,9 @@ func SendMessage(receiveIDType string, receiveID string, msgType string, content
 
 // ReplyMessage replies to a message.
 // 当 replyInThread 为 true 时，以话题（thread）形式回复；
-// 若目标群聊本身就是话题模式，该参数会自动回复到消息所在话题。
-func ReplyMessage(messageID string, msgType string, content string, replyInThread bool, userAccessToken string) (string, error) {
+// 若目标消息已经属于话题，则服务端默认将回复放入同一话题。
+// uuid 非空时用于服务端回复去重；相同 uuid 在一小时内至多成功回复一条消息。
+func ReplyMessage(messageID string, msgType string, content string, replyInThread bool, userAccessToken string, uuid string) (string, error) {
 	client, err := GetClient()
 	if err != nil {
 		return "", err
@@ -85,6 +86,9 @@ func ReplyMessage(messageID string, msgType string, content string, replyInThrea
 		Content(content)
 	if replyInThread {
 		bodyBuilder.ReplyInThread(true)
+	}
+	if uuid != "" {
+		bodyBuilder.Uuid(uuid)
 	}
 
 	req := larkim.NewReplyMessageReqBuilder().
@@ -101,7 +105,7 @@ func ReplyMessage(messageID string, msgType string, content string, replyInThrea
 		return "", fmt.Errorf("回复消息失败: code=%d, msg=%s", resp.Code, resp.Msg)
 	}
 
-	if resp.Data.MessageId == nil {
+	if resp.Data == nil || resp.Data.MessageId == nil || *resp.Data.MessageId == "" {
 		return "", fmt.Errorf("回复已发送但未返回消息 ID")
 	}
 

--- a/internal/client/message_write_test.go
+++ b/internal/client/message_write_test.go
@@ -1,0 +1,161 @@
+package client
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestReplyMessageRequestIncludesThreadAndUUID(t *testing.T) {
+	const (
+		messageID = "om_parent"
+		userToken = "u-test"
+		uuid      = "reply-once"
+	)
+	var gotPath string
+	var gotAuth string
+	var gotBody map[string]interface{}
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		gotAuth = r.Header.Get("Authorization")
+		if err := json.NewDecoder(r.Body).Decode(&gotBody); err != nil {
+			t.Fatalf("解析请求体失败: %v", err)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = fmt.Fprint(w, `{"code":0,"msg":"success","data":{"message_id":"om_reply"}}`)
+	}
+	_, cleanup := stubFeishuServer(t, handler)
+	defer cleanup()
+
+	got, err := ReplyMessage(messageID, "image", `{"image_key":"img_xxx"}`, true, userToken, uuid)
+	if err != nil {
+		t.Fatalf("ReplyMessage() error = %v", err)
+	}
+	if got != "om_reply" {
+		t.Fatalf("message_id = %q, want om_reply", got)
+	}
+	if gotPath != "/open-apis/im/v1/messages/"+messageID+"/reply" {
+		t.Fatalf("path = %q", gotPath)
+	}
+	if gotAuth != "Bearer "+userToken {
+		t.Fatalf("Authorization = %q", gotAuth)
+	}
+	if gotBody["msg_type"] != "image" ||
+		gotBody["content"] != `{"image_key":"img_xxx"}` ||
+		gotBody["reply_in_thread"] != true ||
+		gotBody["uuid"] != uuid {
+		t.Fatalf("请求体不完整: %#v", gotBody)
+	}
+}
+
+func TestMessageWriteRejectsSuccessfulResponseWithoutMessageID(t *testing.T) {
+	tests := []struct {
+		name string
+		call func() (string, error)
+	}{
+		{
+			name: "send nil data",
+			call: func() (string, error) {
+				return SendMessage("chat_id", "oc_xxx", "text", `{"text":"x"}`, "u-test", "")
+			},
+		},
+		{
+			name: "reply empty message id",
+			call: func() (string, error) {
+				return ReplyMessage("om_xxx", "text", `{"text":"x"}`, false, "u-test", "")
+			},
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			handler := func(w http.ResponseWriter, _ *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				if strings.Contains(test.name, "nil") {
+					_, _ = fmt.Fprint(w, `{"code":0,"msg":"success","data":null}`)
+					return
+				}
+				_, _ = fmt.Fprint(w, `{"code":0,"msg":"success","data":{"message_id":""}}`)
+			}
+			_, cleanup := stubFeishuServer(t, handler)
+			defer cleanup()
+
+			got, err := test.call()
+			if err == nil || got != "" || !strings.Contains(err.Error(), "消息 ID") {
+				t.Fatalf("got=%q err=%v, want missing message ID error", got, err)
+			}
+		})
+	}
+}
+
+func TestReplyMessageBusinessErrorIsFailure(t *testing.T) {
+	handler := func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = fmt.Fprint(w, `{"code":99992402,"msg":"field validation failed","data":{}}`)
+	}
+	_, cleanup := stubFeishuServer(t, handler)
+	defer cleanup()
+
+	got, err := ReplyMessage("om_xxx", "text", `{"text":"x"}`, false, "u-test", "reply-once")
+	if err == nil || got != "" || !strings.Contains(err.Error(), "99992402") {
+		t.Fatalf("got=%q err=%v, want business error", got, err)
+	}
+}
+
+func TestUploadIMFileWithOptionsMultipart(t *testing.T) {
+	var gotFileType, gotFileName, gotDuration string
+	business := func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/open-apis/im/v1/files" {
+			t.Fatalf("path = %q", r.URL.Path)
+		}
+		if err := r.ParseMultipartForm(1 << 20); err != nil {
+			t.Fatalf("解析 multipart 失败: %v", err)
+		}
+		gotFileType = r.FormValue("file_type")
+		gotFileName = r.FormValue("file_name")
+		gotDuration = r.FormValue("duration")
+		file, _, err := r.FormFile("file")
+		if err != nil {
+			t.Fatalf("缺少 file part: %v", err)
+		}
+		_ = file.Close()
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = fmt.Fprint(w, `{"code":0,"msg":"success","data":{"file_key":"file_uploaded"}}`)
+	}
+	_, cleanup := stubFeishuServer(t, tenantRouteHandler(t, business))
+	defer cleanup()
+
+	path := filepath.Join(t.TempDir(), "voice.ogg")
+	if err := os.WriteFile(path, []byte("fake-opus"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	key, err := UploadIMFileWithOptions(path, "voice.ogg", "opus", 1234)
+	if err != nil {
+		t.Fatalf("UploadIMFileWithOptions() error = %v", err)
+	}
+	if key != "file_uploaded" ||
+		gotFileType != "opus" ||
+		gotFileName != "voice.ogg" ||
+		gotDuration != "1234" {
+		t.Fatalf("key=%q file_type=%q file_name=%q duration=%q", key, gotFileType, gotFileName, gotDuration)
+	}
+}
+
+func TestUploadIMFileRejectsEmptyFile(t *testing.T) {
+	_, cleanup := stubFeishuServer(t, func(w http.ResponseWriter, _ *http.Request) {
+		t.Fatal("空文件不应发起网络请求")
+		w.WriteHeader(http.StatusInternalServerError)
+	})
+	defer cleanup()
+
+	path := filepath.Join(t.TempDir(), "empty.bin")
+	if err := os.WriteFile(path, nil, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := UploadIMFile(path, ""); err == nil || !strings.Contains(err.Error(), "空文件") {
+		t.Fatalf("期望空文件错误，实际: %v", err)
+	}
+}

--- a/skills/feishu-cli-messaging/SKILL.md
+++ b/skills/feishu-cli-messaging/SKILL.md
@@ -35,9 +35,14 @@ allowed-tools: Bash(feishu-cli:*), Bash(jq:*), Bash(python3:*), Read, Write
 
 1. 发送前确认接收者类型和 ID；不要把 email、open_id、chat_id 混用。
 2. 群发、加急和删除消息有外部影响，先展示目标和数量。
-3. 使用 `--upload-images` 时，任一文件缺失、格式非法或上传失败都会阻止发送；修复后用同一幂等键重试。
-4. 外部群 232033 的排错读取 `references/workflows/chat/references/external-chat.md`。
-5. 卡片草稿与发送候选分开校验；发送前必须运行 card workflow 的
+3. `msg send` 与 `msg reply` 共用内容快捷参数；本地图片、文件、Opus 音频、MP4 视频会先上传，
+   任一文件缺失、格式非法或上传失败都会阻止提交消息。`--upload-images` 同时适用于两条命令。
+4. 进入既有话题必须使用 `msg reply <om_xxx>`；`omt_xxx` 仅用于话题查询/转发，不能作为
+   `msg send` 的接收者。普通消息群开启新话题时才加 `--reply-in-thread`。
+5. 发送与回复重试都使用同一 `--idempotency-key`；媒体上传可能重做，但服务端幂等键防止
+   可见消息重复。只有命令返回非空 `message_id` 才判定成功。
+6. 外部群 232033 的排错读取 `references/workflows/chat/references/external-chat.md`。
+7. 卡片草稿与发送候选分开校验；发送前必须运行 card workflow 的
    `lint_card.py --strict`，不得发送含占位符、示例 ID、假链接或未接通回调按钮的卡片。
-6. 用户点名卡片风格时使用 card workflow 内置的 19 个预设；使用本地头图或图标素材时，
-   lint 与 `msg send` 都传 `--upload-images`，不要固化跨租户 `img_key`。
+8. 用户点名卡片风格时使用 card workflow 内置的 19 个预设；使用本地头图或图标素材时，
+   lint 与实际的 `msg send` / `msg reply` 都传 `--upload-images`，不要固化跨租户 `img_key`。

--- a/skills/feishu-cli-messaging/references/workflows/msg/workflow.md
+++ b/skills/feishu-cli-messaging/references/workflows/msg/workflow.md
@@ -35,17 +35,23 @@
 
 ### 消息架构
 
-飞书消息 API 的 `content` 字段是一个 **JSON 字符串**（不是 JSON 对象）。CLI 提供三种输入方式：
+飞书消息 API 的 `content` 字段是一个 **JSON 字符串**（不是 JSON 对象）。`msg send` 和
+`msg reply` 共用以下输入方式：
 
 | 输入方式 | 参数 | 适用场景 |
 |---------|------|---------|
 | 快捷文本 | `--text "内容"` | 纯文本消息，最简单 |
-| 发送文件 | `--file <路径>` 或 `-f` | 本地文件自动上传并发送（限 30MB） |
-| 发送图片 | `--image <路径>` | 本地图片自动上传并发送（限 10MB） |
+| Markdown | `--markdown "..."` | 自动包装为 post |
+| 发送文件 | `--file <路径或 file_key>` 或 `-f` | 本地文件自动上传并作为附件发送（限 30MB） |
+| 发送图片 | `--image <路径或 image_key>` | 本地图片自动上传并发送（限 10MB） |
+| 发送语音 | `--audio <路径或 file_key>` | 本地 Opus/Ogg Opus 自动上传 |
+| 发送视频 | `--video <路径或 file_key> --video-cover <路径或 image_key>` | MP4 + 必填封面 |
 | 内联 JSON | `--content '{"key":"val"}'` 或 `-c` | 简单 JSON，一行搞定 |
 | JSON 文件 | `--content-file file.json` | 复杂消息（卡片、富文本等） |
 
-**互斥**：以上 5 种输入方式**只能指定一个**，同时指定会报错。
+**互斥**：`content/content-file/text/markdown/file/image/audio/video` 只能指定一个；
+`video-cover` 只能且必须与 `video` 同时使用。快捷参数会推断消息类型，若显式
+`--msg-type` 与推断结果冲突，会在上传和发送前报错。
 
 ### 接收者类型
 
@@ -110,13 +116,17 @@ feishu-cli msg send \
   --receive-id-type <type> \
   --receive-id <id> \
   [--msg-type <msg_type>] \
-  [--text "<text>" | --file <path> | --image <path> | --content '<json>' | --content-file <file.json>] \
+  [--text "<text>" | --markdown "<markdown>" | --file <path-or-key> | --image <path-or-key> | \
+   --audio <path-or-key> | --video <path-or-key> --video-cover <path-or-key> | \
+   --content '<json>' | --content-file <file.json>] \
   [--idempotency-key <key>]
 ```
 
 ### 幂等键（--idempotency-key，防重发）
 
-`--idempotency-key` 映射到发消息 API 的 `uuid` 字段，服务端按此键去重：**相同键的重复请求返回首次发送的消息**（同一 `message_id`），只会真正发出一条。适用于重试、定时任务、可能重复触发的自动化场景。
+`--idempotency-key` 在 `msg send` 和 `msg reply` 中都映射到 API 的 `uuid`。发送接口对同一
+key 去重；回复接口保证同一 key 的请求在 1 小时内至多成功回复一条。它适用于重试、定时任务
+和可能重复触发的自动化场景。
 
 ```bash
 # 相同 key 调用两次，第二次不会重复发送，返回与第一次相同的 message_id
@@ -127,6 +137,8 @@ feishu-cli msg send --receive-id-type email --receive-id user@example.com \
 - 长度上限 **50 字符**（按 Unicode 字符 / rune 计数，非字节，中文键不会被误拒），超限本地直接报错，不发请求。
 - 键由调用方自行保证唯一/可复现：同一逻辑消息用固定键（幂等），不同消息用不同键，否则会被误判为重复而丢弃。
 - 不传该 flag 时行为不变（每次都新发）。
+- 本地媒体在提交消息前上传，因此进程级重试可能再次上传并取得新 key；幂等键保证的是
+  **可见消息不重复**，不是上传请求只执行一次。
 
 ### file 类型（直发文件）
 
@@ -142,6 +154,10 @@ feishu-cli msg send \
 file_token 不是同一种 token，不能先用 `file upload` 再把返回值当作 file_key。超过 30MB 时应压缩、
 拆分、改发云盘链接，或让用户从飞书客户端发送。
 
+若 `.mp4` / `.opus` 明确通过 `--file` 发送，CLI 会按普通 `stream` 附件上传，避免飞书因
+上传类型与 `msg_type=file` 不匹配而返回 230055。要让它呈现为视频或语音，使用 `--video`
+或 `--audio`。
+
 ### image 类型（直发图片）
 
 ```bash
@@ -153,6 +169,24 @@ feishu-cli msg send \
 ```
 
 支持 JPEG、PNG、BMP、GIF、TIFF、WebP 格式。
+
+### audio / media 类型
+
+```bash
+# 语音消息：飞书仅接受 Opus
+feishu-cli msg send --receive-id-type chat_id --receive-id oc_xxx \
+  --audio /path/to/voice.opus
+
+# 视频消息：MP4 与封面缺一不可
+feishu-cli msg reply om_xxx \
+  --video /path/to/demo.mp4 \
+  --video-cover /path/to/cover.png \
+  --idempotency-key "demo-video-reply-001"
+```
+
+音频支持 `.opus` 与 Ogg Opus `.ogg`；MP3/WAV 需要先转换为 Opus，或者使用 `--file` 作为普通
+附件发送。视频快捷参数只接受 MP4。图片/文件/音视频也可直接传当前 App 可用的
+`img_xxx` / `file_xxx`，此时跳过上传。
 
 ### text 类型
 
@@ -228,7 +262,7 @@ post 支持的 tag 类型：
 
 ### 图片自动上传（--upload-images）
 
-`msg send` 支持 `--upload-images`，扫描 **post / interactive** 消息中的本地图片引用，
+`msg send` 与 `msg reply` 都支持 `--upload-images`，扫描 **post / interactive** 消息中的本地图片引用，
 上传到飞书 IM 图床并替换为当前 App 可用的 key 后再发送。
 
 | 维度 | 行为 |
@@ -326,7 +360,9 @@ feishu-cli msg send \
 ### 回复、转发、合并转发与加急
 
 ```bash
-feishu-cli msg reply om_xxx --text "收到"
+feishu-cli msg reply om_xxx --text "收到" --idempotency-key "ack-001"
+feishu-cli msg reply om_xxx --image /path/to/photo.png --idempotency-key "photo-001"
+feishu-cli msg reply om_xxx --file /path/to/report.pdf
 feishu-cli msg forward om_xxx --receive-id user@example.com --receive-id-type email
 feishu-cli msg merge-forward --receive-id oc_xxx --receive-id-type chat_id --message-ids om_xxx,om_yyy
 feishu-cli msg urgent om_xxx --user-id-type open_id --user-ids ou_xxx,ou_yyy
@@ -342,8 +378,9 @@ feishu-cli msg urgent om_xxx --user-id-type open_id --user-ids ou_xxx,ou_yyy
    - 用户明确指定类型 → 使用指定类型
    - 结构化或美观通知 → 先用 `feishu-cli-messaging` 构造 JSON，再用 `interactive` 发送
    - 用户明确要求纯文本/富文本，或内容很短 → 使用 `text` / `post`
-3. **准备内容**：纯文本直接传 `--text`；卡片 JSON 使用 `--content-file`；文件/图片使用 `--file` / `--image`
-4. **发送并检查结果**：执行命令，确认返回 message_id
+3. **准备内容**：纯文本用 `--text`；Markdown 用 `--markdown`；卡片 JSON 用 `--content-file`；
+   图片/附件/语音/视频分别用 `--image` / `--file` / `--audio` / `--video + --video-cover`
+4. **发送并检查结果**：确认命令退出码为 0 且返回非空 `message_id`；不要仅凭上传成功判定消息成功
 
 ## 权限要求
 
@@ -414,19 +451,20 @@ feishu-cli msg resource-download <message_id> <file_key> --type file --user-acce
 
 ### 发送到已有话题
 
-`msg send` 支持 `--thread-id`（等价于 `--receive-id-type thread_id --receive-id <thread_id>`）：
+飞书 create message 的 `receive_id_type` 不支持 `thread_id`。要在已有话题内追加消息，必须
+回复话题内的 `om_xxx` 消息 ID；不能把 `omt_xxx` 传给 `msg send`。
 
 ```bash
-# 在已有话题内追加一条消息
-feishu-cli msg send --thread-id omt_xxx --text "话题内继续聊"
+# 目标消息已在话题中时，默认进入同一话题
+feishu-cli msg reply om_xxx --text "话题内继续聊"
 
-# 卡片消息也支持
-feishu-cli msg send --thread-id omt_xxx \
-  --msg-type interactive \
-  --content "$(cat card.json)"
+# 图片/文件/卡片沿用同一 reply 内容模型
+feishu-cli msg reply om_xxx --image /path/to/photo.png --idempotency-key "topic-photo-001"
+feishu-cli msg reply om_xxx --msg-type interactive --content-file card.json --upload-images
 ```
 
-> `--thread-id` 与 `--receive-id-type/--receive-id` **互斥**，只能指定一组。
+旧 `msg send --thread-id omt_xxx ...` 会在上传媒体和调用飞书 API 前直接报错，并提示迁移到
+`msg reply <om_xxx>`。
 
 ### 回复时开启话题
 
@@ -436,12 +474,13 @@ feishu-cli msg send --thread-id omt_xxx \
 # 在非话题群聊中，以话题形式回复某条消息（会开启一个新话题）
 feishu-cli msg reply om_xxx --text "这里开个话题" --reply-in-thread
 
-# 若群聊已是话题模式，--reply-in-thread 会自动回复到消息所在话题
+# 目标消息已经属于话题时，通常不需要 --reply-in-thread
 ```
 
 ### 话题回复列表
 
-获取话题回复属于读取消息，请使用 **feishu-cli-messaging** 技能。发送话题内消息仍使用本技能的 `msg send --thread-id`。
+获取话题回复属于读取消息，请使用 **feishu-cli-messaging** 技能。`omt_xxx` 可用于
+`msg thread-messages` 等读取/转发能力；话题内发送使用 `msg reply <om_xxx>`。
 
 ## 参考文档
 


### PR DESCRIPTION
## What changed

- unify `msg send` and `msg reply` content handling for text, Markdown, post/card JSON, images, files, Opus audio, and MP4 video
- add reply-side local media upload, `--upload-images`, JSON output, and UUID idempotency
- reject the unsupported create-message `thread_id` target before upload and direct callers to `msg reply <om_xxx>`
- harden upload/message success checks and avoid MP4/Opus attachment type mismatch
- update README and `feishu-cli-messaging` guidance

## Root cause

`msg send --thread-id` mapped `omt_xxx` to `receive_id_type=thread_id`, but Feishu's create-message contract only accepts user identifiers and `chat_id`. Existing topic replies must use the reply-message endpoint with an `om_xxx` message ID. Reply previously lacked the media upload and UUID capabilities already present on send.

## Validation

- `go build -o feishu-cli .`
- actual compiled-binary HTTP E2E for image upload + reply request body
- real Feishu E2E in the dedicated AIAM-E2E topic test chat: send/reply idempotency, standalone image, rich-text `--upload-images`, Opus audio, MP4 video, and MP4-as-file attachment
- `gofmt -l cmd internal`
- `go test ./...`
- `go test -race ./cmd ./internal/client`
- `go vet ./...`
- `make check-skills`
- privacy scan and `git diff --check`
