### PR TITLE
fix(messaging): prefer local media paths over keys

### DIFF
--- a/cmd/msg_content.go
+++ b/cmd/msg_content.go
@@ -168,11 +168,11 @@ func (input messageContentInput) inferredMessageType() string {
 }
 
 func isIMImageKey(value string) bool {
-	return strings.HasPrefix(value, "img_")
+	return strings.HasPrefix(value, "img_") && !localPathExists(value, ".")
 }
 
 func isIMFileKey(value string) bool {
-	return strings.HasPrefix(value, "file_")
+	return strings.HasPrefix(value, "file_") && !localPathExists(value, ".")
 }
 
 func rejectRemoteMediaURL(flagName, value string) error {

--- a/cmd/msg_content_test.go
+++ b/cmd/msg_content_test.go
@@ -147,6 +147,124 @@ func TestMessageContentResolveLocalMedia(t *testing.T) {
 	}
 }
 
+func TestMessageContentResolvePrefixedLocalMediaPaths(t *testing.T) {
+	tempDir := t.TempDir()
+	oldWorkingDir, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chdir(tempDir); err != nil {
+		t.Fatal(err)
+	}
+	defer func() {
+		if err := os.Chdir(oldWorkingDir); err != nil {
+			t.Errorf("恢复工作目录失败: %v", err)
+		}
+	}()
+
+	files := map[string][]byte{
+		"img_logo.png":    []byte("\x89PNG\r\n\x1a\n"),
+		"file_report.pdf": []byte("%PDF-test"),
+		"file_voice.opus": []byte("fake-opus"),
+		"file_video.mp4":  []byte("fake-mp4"),
+		"img_cover.png":   []byte("\x89PNG\r\n\x1a\n"),
+	}
+	for name, data := range files {
+		if err := os.WriteFile(name, data, 0o600); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	oldImageUpload := uploadIMImage
+	oldFileUpload := uploadIMFileWithOptions
+	defer func() {
+		uploadIMImage = oldImageUpload
+		uploadIMFileWithOptions = oldFileUpload
+	}()
+
+	var uploadedImages []string
+	uploadIMImage = func(path, imageType string) (string, error) {
+		uploadedImages = append(uploadedImages, filepath.Base(path))
+		return "img_uploaded_" + filepath.Base(path), nil
+	}
+	type fileUpload struct {
+		name     string
+		fileType string
+	}
+	var uploadedFiles []fileUpload
+	uploadIMFileWithOptions = func(path, name, fileType string, duration int) (string, error) {
+		baseName := filepath.Base(path)
+		uploadedFiles = append(uploadedFiles, fileUpload{name: baseName, fileType: fileType})
+		return "file_uploaded_" + baseName, nil
+	}
+
+	tests := []struct {
+		name        string
+		args        []string
+		wantMsgType string
+		wantContent []string
+	}{
+		{
+			name:        "image",
+			args:        []string{"--image", "img_logo.png"},
+			wantMsgType: "image",
+			wantContent: []string{`"image_key":"img_uploaded_img_logo.png"`},
+		},
+		{
+			name:        "file",
+			args:        []string{"--file", "file_report.pdf"},
+			wantMsgType: "file",
+			wantContent: []string{`"file_key":"file_uploaded_file_report.pdf"`},
+		},
+		{
+			name:        "audio",
+			args:        []string{"--audio", "file_voice.opus"},
+			wantMsgType: "audio",
+			wantContent: []string{`"file_key":"file_uploaded_file_voice.opus"`},
+		},
+		{
+			name:        "video",
+			args:        []string{"--video", "file_video.mp4", "--video-cover", "img_cover.png"},
+			wantMsgType: "media",
+			wantContent: []string{
+				`"file_key":"file_uploaded_file_video.mp4"`,
+				`"image_key":"img_uploaded_img_cover.png"`,
+			},
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			_, input := newMessageContentTestCommand(t, test.args...)
+			if err := input.validate(); err != nil {
+				t.Fatal(err)
+			}
+			msgType, content, err := input.resolve()
+			if err != nil {
+				t.Fatal(err)
+			}
+			if msgType != test.wantMsgType {
+				t.Fatalf("msgType = %q, want %q", msgType, test.wantMsgType)
+			}
+			for _, want := range test.wantContent {
+				if !strings.Contains(content, want) {
+					t.Fatalf("content = %s, want contains %s", content, want)
+				}
+			}
+		})
+	}
+
+	if got, want := strings.Join(uploadedImages, ","), "img_logo.png,img_cover.png"; got != want {
+		t.Fatalf("上传图片 = %q, want %q", got, want)
+	}
+	gotFileUploads := []string{}
+	for _, upload := range uploadedFiles {
+		gotFileUploads = append(gotFileUploads, upload.name+":"+upload.fileType)
+	}
+	if got, want := strings.Join(gotFileUploads, ","), "file_report.pdf:,file_voice.opus:opus,file_video.mp4:mp4"; got != want {
+		t.Fatalf("上传文件 = %q, want %q", got, want)
+	}
+}
+
 func TestValidateReplyMessageID(t *testing.T) {
 	if err := validateReplyMessageID("om_xxx"); err != nil {
 		t.Fatalf("om_xxx 应合法: %v", err)

--- a/cmd/send_message.go
+++ b/cmd/send_message.go
@@ -217,13 +217,29 @@ var supportedIMImageExtensions = map[string]struct{}{
 }
 
 // isLocalPath 检测字符串是否为本地文件路径
-func isLocalPath(s string) bool {
+func localPathExists(path, basePath string) bool {
+	resolvedPath, err := resolveLocalPath(path, basePath)
+	if err != nil {
+		return false
+	}
+	_, err = os.Stat(resolvedPath)
+	return err == nil
+}
+
+func isLocalPath(s, basePath string) bool {
 	if s == "" {
 		return false
 	}
-	// 如果是 URL 或已上传的 image_key（img_ 开头），不是本地路径
-	if strings.HasPrefix(s, "http://") || strings.HasPrefix(s, "https://") ||
-		strings.HasPrefix(s, "img_") || strings.HasPrefix(s, "file_") {
+	// URL 永远不是本地路径。
+	if strings.HasPrefix(s, "http://") || strings.HasPrefix(s, "https://") {
+		return false
+	}
+	// 本地已有文件优先于资源 key 前缀，避免 img_logo.png / file_report.png
+	// 这类相对文件名被误判为已上传的飞书 key。
+	if localPathExists(s, basePath) {
+		return true
+	}
+	if strings.HasPrefix(s, "img_") || strings.HasPrefix(s, "file_") {
 		return false
 	}
 	// 只接受显式绝对/相对路径，或受支持的图片扩展名。
@@ -330,7 +346,7 @@ func processAndUploadLocalImages(content string, basePath string) (string, int, 
 		fullMatch := match[0] // 完整匹配如 ![alt](local/path.png)
 		imagePath := match[2] // 图片路径
 
-		if !isLocalPath(imagePath) {
+		if !isLocalPath(imagePath, basePath) {
 			continue
 		}
 
@@ -377,7 +393,7 @@ func processJSONLocalImages(data interface{}, basePath string) (bool, interface{
 		for key, val := range v {
 			// post 富文本使用 image_key；Card JSON 2.0 的 img 与 img_combination 使用 img_key。
 			if tag == "img" && (key == "image_key" || key == "img_key") {
-				if localPath, ok := val.(string); ok && isLocalPath(localPath) {
+				if localPath, ok := val.(string); ok && isLocalPath(localPath, basePath) {
 					imageKey, err := uploadLocalImageForIM(localPath, basePath)
 					if err != nil {
 						return false, v, 0, err
@@ -457,7 +473,7 @@ func processImageListLocalImages(data interface{}, basePath string) (bool, inter
 			continue
 		}
 		localPath, ok := image["img_key"].(string)
-		if !ok || !isLocalPath(localPath) {
+		if !ok || !isLocalPath(localPath, basePath) {
 			result[index] = item
 			continue
 		}

--- a/cmd/send_message_test.go
+++ b/cmd/send_message_test.go
@@ -56,11 +56,25 @@ func TestIsLocalPath(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			result := isLocalPath(tt.path)
+			result := isLocalPath(tt.path, ".")
 			if result != tt.expected {
 				t.Errorf("isLocalPath(%q) = %v, 期望 %v", tt.path, result, tt.expected)
 			}
 		})
+	}
+}
+
+func TestIsLocalPathPrefersExistingPrefixedFile(t *testing.T) {
+	tempDir := t.TempDir()
+	path := filepath.Join(tempDir, "img_logo.png")
+	if err := os.WriteFile(path, []byte("\x89PNG\r\n\x1a\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if !isLocalPath("img_logo.png", tempDir) {
+		t.Fatal("存在的 img_ 前缀相对文件应优先识别为本地路径")
+	}
+	if isLocalPath("img_missing.png", tempDir) {
+		t.Fatal("不存在的 img_ 前缀值应继续识别为飞书资源 key")
 	}
 }
 

--- a/skills/feishu-cli-messaging/references/workflows/msg/workflow.md
+++ b/skills/feishu-cli-messaging/references/workflows/msg/workflow.md
@@ -188,6 +188,10 @@ feishu-cli msg reply om_xxx \
 附件发送。视频快捷参数只接受 MP4。图片/文件/音视频也可直接传当前 App 可用的
 `img_xxx` / `file_xxx`，此时跳过上传。
 
+本地路径优先于资源 key 前缀：如果当前相对路径基准下确实存在 `img_logo.png`、
+`file_report.pdf` 等文件，即使文件名以 `img_` / `file_` 开头，CLI 仍会先上传本地文件；
+只有不存在同名本地路径时，才按飞书资源 key 解释。
+
 ### text 类型
 
 ```bash


### PR DESCRIPTION
## 变更

- 本地媒体路径存在时优先于 `img_` / `file_` 资源 key 前缀
- 同步修复独立媒体参数和 `--upload-images` 的路径判定
- 覆盖图片、文件、Opus、MP4、视频封面和内联图片回归测试
- 更新 feishu-cli-messaging Skill 的歧义处理说明

## 根因

媒体输入此前仅按字符串前缀识别飞书资源 key，导致当前目录中的
`img_logo.png`、`file_report.pdf` 等真实文件跳过上传，并把文件名作为无效 key 提交。

## 验证

- `go test ./...`
- `go test -race ./cmd`
- `go vet ./...`
- `make check-skills`
- `gofmt -l cmd internal`
- `git diff --check`
- 使用真实编译产物在专用飞书话题测试群验证裸相对路径图片和文件，读回类型分别为 `image`、`file`
