### PR TITLE
fix(messaging): preserve keys matching non-files

### DIFF
--- a/cmd/msg_content.go
+++ b/cmd/msg_content.go
@@ -168,11 +168,11 @@ func (input messageContentInput) inferredMessageType() string {
 }
 
 func isIMImageKey(value string) bool {
-	return strings.HasPrefix(value, "img_") && !localPathExists(value, ".")
+	return strings.HasPrefix(value, "img_") && !localRegularFileExists(value, ".")
 }
 
 func isIMFileKey(value string) bool {
-	return strings.HasPrefix(value, "file_") && !localPathExists(value, ".")
+	return strings.HasPrefix(value, "file_") && !localRegularFileExists(value, ".")
 }
 
 func rejectRemoteMediaURL(flagName, value string) error {

--- a/cmd/send_message.go
+++ b/cmd/send_message.go
@@ -217,13 +217,13 @@ var supportedIMImageExtensions = map[string]struct{}{
 }
 
 // isLocalPath 检测字符串是否为本地文件路径
-func localPathExists(path, basePath string) bool {
+func localRegularFileExists(path, basePath string) bool {
 	resolvedPath, err := resolveLocalPath(path, basePath)
 	if err != nil {
 		return false
 	}
-	_, err = os.Stat(resolvedPath)
-	return err == nil
+	info, err := os.Stat(resolvedPath)
+	return err == nil && info.Mode().IsRegular()
 }
 
 func isLocalPath(s, basePath string) bool {
@@ -236,7 +236,7 @@ func isLocalPath(s, basePath string) bool {
 	}
 	// 本地已有文件优先于资源 key 前缀，避免 img_logo.png / file_report.png
 	// 这类相对文件名被误判为已上传的飞书 key。
-	if localPathExists(s, basePath) {
+	if localRegularFileExists(s, basePath) {
 		return true
 	}
 	if strings.HasPrefix(s, "img_") || strings.HasPrefix(s, "file_") {

--- a/cmd/send_message_test.go
+++ b/cmd/send_message_test.go
@@ -76,6 +76,12 @@ func TestIsLocalPathPrefersExistingPrefixedFile(t *testing.T) {
 	if isLocalPath("img_missing.png", tempDir) {
 		t.Fatal("不存在的 img_ 前缀值应继续识别为飞书资源 key")
 	}
+	if err := os.Mkdir(filepath.Join(tempDir, "img_existing_directory"), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if isLocalPath("img_existing_directory", tempDir) {
+		t.Fatal("img_ 前缀目录不是本地媒体文件，应继续识别为飞书资源 key")
+	}
 }
 
 // -------------------------------------------------------------------


### PR DESCRIPTION
## 变更

- 仅普通文件可以优先于 `img_` / `file_` 资源 key 前缀
- 目录、FIFO 等非普通文件不再抢占同名飞书资源 key
- 增加同名前缀目录的回归测试

## 根因

PR #174 使用 `os.Stat` 成功作为“本地媒体存在”的条件，目录等非普通文件也会满足，
导致极端情况下真实资源 key 被误判为本地媒体。

## 验证

- `go test ./...`
- `go test -race ./cmd`
- `go vet ./...`
- `make check-skills`
- 真实编译产物在同名目录场景下不触发上传或本地文件错误

跟进 PR #174 的 Codex P3 Review。
