### PR TITLE
docs(readme): 修复 README 中失效的 Star History 图表

### DIFF
--- a/README.md
+++ b/README.md
@@ -1672,15 +1672,15 @@ go vet ./...
 
 ## Star History
 
-<a href="https://www.star-history.com/#riba2534/feishu-cli&Date">
- <picture>
-   <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/svg?repos=riba2534/feishu-cli&type=Date&theme=dark" />
-   <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/svg?repos=riba2534/feishu-cli&type=Date" />
-   <img alt="Star History Chart" src="https://api.star-history.com/svg?repos=riba2534/feishu-cli&type=Date" />
- </picture>
+<a href="https://star-history.dera.page/#riba2534/feishu-cli&Date">
+  <picture>
+    <source media="(prefers-color-scheme: dark)" srcset="https://star-history.dera.page/svg?repos=riba2534/feishu-cli&type=Date&theme=dark" />
+    <source media="(prefers-color-scheme: light)" srcset="https://star-history.dera.page/svg?repos=riba2534/feishu-cli&type=Date" />
+    <img alt="Star History Chart" src="https://star-history.dera.page/svg?repos=riba2534/feishu-cli&type=Date" />
+  </picture>
 </a>
 
-> 图表由 star-history.com 生成，若上方未加载出来（该服务偶发超时），可直接[查看交互式 Star 增长曲线](https://www.star-history.com/#riba2534/feishu-cli&Date)。
+> 图表由 star-history.dera.page 生成，若上方未加载出来（该服务偶发超时），可直接[查看交互式 Star 增长曲线](https://star-history.dera.page/#riba2534/feishu-cli&Date)。
 
 ## License
 


### PR DESCRIPTION
README 顶部的 Star History 图表当前因数据源限制已无法正常加载。
本 PR 将图表切换到可用的替代数据源，恢复增长曲线的正常展示，
其余内容不变。