### PR TITLE
feat(profile): 多 Bot 身份支持（--profile / --bot-app-* 全局 flag）

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -66,14 +66,24 @@ go vet ./...                      # 静态检查
 
 ### 配置方式
 
-**优先级**：环境变量 > 配置文件 > 默认值
+配置与 Token 使用两条正交解析链：
+
+- **目录 / User Token**：`--profile` > `FEISHU_PROFILE` > `active-profile` 指针 > 旧布局
+- **App 凭证**：`--bot-app-id` / `--bot-app-secret` > `FEISHU_APP_ID` / `FEISHU_APP_SECRET` > 选中目录的 `config.yaml`
 
 ```bash
-# 环境变量（推荐）
+# 多 Bot：先看清单，再单次指定（不要长期 export FEISHU_APP_ID）
+feishu-cli profile list --json
+feishu-cli --profile alert msg send ...
+
+# 单次覆盖 App 凭证（不写盘；User Token 仍来自当前 profile）
+feishu-cli --bot-app-id cli_xxx --bot-app-secret xxx auth status -o json
+
+# 单应用环境变量（会盖住所选 profile 的 App 凭证，不切换 token.json）
 export FEISHU_APP_ID=cli_xxx
 export FEISHU_APP_SECRET=xxx
 
-# 配置文件 (~/.feishu-cli/config.yaml)，通过 feishu-cli config init 初始化
+# 配置文件 (~/.feishu-cli/config.yaml 或 profiles/<name>/config.yaml)
 ```
 
 ## 核心功能

--- a/README.md
+++ b/README.md
@@ -160,7 +160,7 @@ feishu-cli doc import large-doc.md --title "大文档" \
 | **实时事件** | WebSocket 长连接订阅应用事件（EventKey 列表/schema/consume/status/stop），**卡片按钮/表单回调（card.action.trigger）**、**审批 v4 事件（自动注册服务端订阅）**、Bot 菜单事件 |
 | **Raw API** | `api GET/POST/PUT/DELETE/PATCH <path>` 裸调任意未封装的 OpenAPI 接口，自动鉴权与错误码处理，支持 dry-run、自定义超时、jq 过滤与 json/pretty/table/ndjson/csv 多格式输出 |
 | **OpenAPI Schema** | 本地查询内置 OpenAPI service/resource/method、路径、参数和 scope，无需 token |
-| **Profile 多配置** | 多 App / 多账号配置 add/list/use/current/rename/remove/migrate，支持 `FEISHU_PROFILE` 临时切换 |
+| **Profile 多配置** | 多 App / 多账号配置 add/list/use/current/rename/remove/migrate；`profile list --json` 列出可操作 Bot；全局 `--profile` / `FEISHU_PROFILE` 单次切换目录与 User Token（`FEISHU_APP_ID/SECRET` 仍可覆盖 App 凭证） |
 | **健康检查** | `doctor` 一次检查配置、User Token、端点、代理和本地依赖 |
 
 </details>
@@ -1012,8 +1012,12 @@ feishu-cli event stop --all
 feishu-cli schema list --service im
 feishu-cli schema im.messages.delete --format json
 feishu-cli doctor --json
+feishu-cli profile list --json
+feishu-cli profile current --json
 feishu-cli profile migrate
 feishu-cli profile add work --app-id cli_xxx --app-secret secret_xxx --use
+feishu-cli --profile work auth status -o json
+feishu-cli --bot-app-id cli_xxx --bot-app-secret xxx profile list --json  # 单次覆盖 App 凭证，不切换 token.json
 feishu-cli profile use -
 
 # 通用 OpenAPI 透传（v1.29+）⭐ 覆盖 2500+ 未封装端点

--- a/cmd/auth_status.go
+++ b/cmd/auth_status.go
@@ -19,6 +19,7 @@ var authStatusCmd = &cobra.Command{
   - Access Token（脱敏）和有效期
   - Refresh Token 状态和有效期
   - 授权范围
+  - 当前 profile / 生效 app_id
 
 示例:
   feishu-cli auth status
@@ -35,20 +36,25 @@ var authStatusCmd = &cobra.Command{
 		token, err := auth.LoadToken()
 		if err != nil {
 			if output == "json" {
-				return printJSON(map[string]any{"logged_in": false, "error": err.Error()})
+				out := map[string]any{"logged_in": false, "error": err.Error()}
+				attachProfileContext(out)
+				return printJSON(out)
 			}
 			return fmt.Errorf("读取 token 失败: %w", err)
 		}
 
 		if token == nil {
 			if output == "json" {
-				return printJSON(map[string]any{
+				out := map[string]any{
 					"logged_in": false,
 					"identity":  "bot",
 					"note":      "未登录用户身份，仅可使用应用身份（App Token）能力",
-				})
+				}
+				attachProfileContext(out)
+				return printJSON(out)
 			}
 			fmt.Println("授权状态: 未登录")
+			printProfileContextHuman()
 			fmt.Println("  使用 feishu-cli auth login 进行授权")
 			return nil
 		}
@@ -114,23 +120,24 @@ var authStatusCmd = &cobra.Command{
 				result["verify_error"] = verifyErr
 			}
 		}
-
-		// JSON 输出模式
+		// JSON 输出模式（人类可读走 printProfileContextHuman，避免重复构建 inventory）
 		if output == "json" {
+			attachProfileContext(result)
 			return printJSON(result)
 		}
 
 		// 人类可读输出
 		fmt.Printf("授权状态: 已登录（%s）\n", status)
+		printProfileContextHuman()
 		fmt.Printf("  Access Token:   %s\n", auth.MaskToken(token.AccessToken))
 
 		if token.IsAccessTokenValid() {
 			remaining := time.Until(token.ExpiresAt)
-			fmt.Printf("  有效期至:        %s（剩余 %s）\n",
+			fmt.Printf("  有效期至:       %s（剩余 %s）\n",
 				token.ExpiresAt.Format("2006-01-02 15:04:05"),
 				formatDuration(remaining))
 		} else {
-			fmt.Printf("  有效期至:        %s（已过期）\n", token.ExpiresAt.Format("2006-01-02 15:04:05"))
+			fmt.Printf("  有效期至:       %s（已过期）\n", token.ExpiresAt.Format("2006-01-02 15:04:05"))
 		}
 
 		if refreshPresent {
@@ -149,20 +156,20 @@ var authStatusCmd = &cobra.Command{
 		}
 
 		if token.Scope != "" {
-			fmt.Printf("  授权范围:        %s\n", token.Scope)
+			fmt.Printf("  授权范围:       %s\n", token.Scope)
 		}
 		if cache, ok := result["cached_user"].(map[string]any); ok {
-			fmt.Printf("  当前用户:        %s (%s)\n", cache["name"], cache["open_id"])
+			fmt.Printf("  当前用户:       %s (%s)\n", cache["name"], cache["open_id"])
 		}
-		fmt.Printf("  健康度:          %s\n", health)
+		fmt.Printf("  健康度:         %s\n", health)
 		if note != "" {
-			fmt.Printf("  提示:            %s\n", note)
+			fmt.Printf("  提示:           %s\n", note)
 		}
 		if verify {
 			if verified, _ := result["verified"].(bool); verified {
-				fmt.Println("  在线校验:        通过")
+				fmt.Println("  在线校验:       通过")
 			} else if verifyErr, _ := result["verify_error"].(string); verifyErr != "" {
-				fmt.Printf("  在线校验:        失败（%s）\n", verifyErr)
+				fmt.Printf("  在线校验:       失败（%s）\n", verifyErr)
 			}
 		}
 

--- a/cmd/credential_warning_test.go
+++ b/cmd/credential_warning_test.go
@@ -1,0 +1,196 @@
+package cmd
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/riba2534/feishu-cli/internal/config"
+	"github.com/riba2534/feishu-cli/internal/profile"
+)
+
+func writeLegacyConfig(t *testing.T, home, appID, appSecret string) {
+	t.Helper()
+	root := filepath.Join(home, ".feishu-cli")
+	if err := os.MkdirAll(root, 0700); err != nil {
+		t.Fatal(err)
+	}
+	var body strings.Builder
+	if appID != "" {
+		body.WriteString("app_id: " + appID + "\n")
+	}
+	if appSecret != "" {
+		body.WriteString("app_secret: " + appSecret + "\n")
+	}
+	if err := os.WriteFile(filepath.Join(root, "config.yaml"), []byte(body.String()), 0600); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// 单应用是文档推荐用法，不该每条命令刷一行警告。
+func TestAppCredentialWarningSilentOnSingleApp(t *testing.T) {
+	t.Run("旧布局无配置文件，仅环境变量", func(t *testing.T) {
+		withCmdHome(t)
+		t.Setenv("FEISHU_APP_ID", "cli_env")
+		t.Setenv("FEISHU_APP_SECRET", "sec_env")
+		if got := appCredentialWarning(); got != "" {
+			t.Errorf("单应用 env 不该告警，得到: %s", got)
+		}
+	})
+
+	t.Run("环境变量与旧布局配置同一个应用", func(t *testing.T) {
+		home := withCmdHome(t)
+		writeLegacyConfig(t, home, "cli_same", "sec_file")
+		t.Setenv("FEISHU_APP_ID", "cli_same")
+		t.Setenv("FEISHU_APP_SECRET", "sec_env")
+		if got := appCredentialWarning(); got != "" {
+			t.Errorf("同一应用不该告警，得到: %s", got)
+		}
+	})
+
+	t.Run("只 export app_id 且与配置文件同值，secret 走文件", func(t *testing.T) {
+		home := withCmdHome(t)
+		writeLegacyConfig(t, home, "cli_same", "sec_file")
+		t.Setenv("FEISHU_APP_ID", "cli_same")
+		if got := appCredentialWarning(); got != "" {
+			t.Errorf("app_id 同值时 secret 走文件是安全的，得到: %s", got)
+		}
+	})
+
+	t.Run("--bot-app-id 与所选 profile 同值", func(t *testing.T) {
+		withCmdHome(t)
+		if err := profile.Create("work", profile.CreateOpts{AppID: "cli_work", AppSecret: "sec_work", SwitchTo: true}); err != nil {
+			t.Fatal(err)
+		}
+		config.SetBotFlagCredentials("cli_work", "")
+		if got := appCredentialWarning(); got != "" {
+			t.Errorf("flag 与 profile 同一应用不该告警，得到: %s", got)
+		}
+	})
+
+	t.Run("完全没有覆盖", func(t *testing.T) {
+		withCmdHome(t)
+		if err := profile.Create("work", profile.CreateOpts{AppID: "cli_work", AppSecret: "sec_work", SwitchTo: true}); err != nil {
+			t.Fatal(err)
+		}
+		if got := appCredentialWarning(); got != "" {
+			t.Errorf("无覆盖不该告警，得到: %s", got)
+		}
+	})
+}
+
+// 覆盖来的 app_id 与所选目录不是同一个应用时，User Token 归属必须说清楚。
+func TestAppCredentialWarningOnMismatch(t *testing.T) {
+	t.Run("环境变量覆盖 profile 的 app_id", func(t *testing.T) {
+		withCmdHome(t)
+		if err := profile.Create("work", profile.CreateOpts{AppID: "cli_work", AppSecret: "sec_work", SwitchTo: true}); err != nil {
+			t.Fatal(err)
+		}
+		t.Setenv("FEISHU_APP_ID", "cli_other")
+		t.Setenv("FEISHU_APP_SECRET", "sec_other")
+		got := appCredentialWarning()
+		if !strings.Contains(got, "不是同一个应用") || !strings.Contains(got, `profile "work"`) {
+			t.Errorf("缺少错配与 token 归属说明: %q", got)
+		}
+		if strings.Contains(got, "sec_other") || strings.Contains(got, "sec_work") {
+			t.Errorf("app_secret 泄漏进告警: %q", got)
+		}
+	})
+
+	t.Run("环境变量覆盖旧布局的 app_id", func(t *testing.T) {
+		home := withCmdHome(t)
+		writeLegacyConfig(t, home, "cli_legacy", "sec_file")
+		t.Setenv("FEISHU_APP_ID", "cli_other")
+		t.Setenv("FEISHU_APP_SECRET", "sec_other")
+		got := appCredentialWarning()
+		if !strings.Contains(got, "不是同一个应用") || !strings.Contains(got, "旧布局") {
+			t.Errorf("旧布局错配文案不对: %q", got)
+		}
+	})
+
+	t.Run("--bot-app-id 指向另一个应用", func(t *testing.T) {
+		withCmdHome(t)
+		if err := profile.Create("work", profile.CreateOpts{AppID: "cli_work", AppSecret: "sec_work", SwitchTo: true}); err != nil {
+			t.Fatal(err)
+		}
+		config.SetBotFlagCredentials("cli_flag", "sec_flag")
+		if got := appCredentialWarning(); !strings.Contains(got, "--bot-app-id") || !strings.Contains(got, "cli_flag") {
+			t.Errorf("flag 错配文案不对: %q", got)
+		}
+	})
+}
+
+// app_id 与 app_secret 分处不同层时提示拼接风险。
+func TestAppCredentialWarningOnSplitSources(t *testing.T) {
+	t.Run("只传 --bot-app-secret，app_id 走 profile", func(t *testing.T) {
+		withCmdHome(t)
+		if err := profile.Create("work", profile.CreateOpts{AppID: "cli_work", AppSecret: "sec_work", SwitchTo: true}); err != nil {
+			t.Fatal(err)
+		}
+		config.SetBotFlagCredentials("", "sec_flag")
+		got := appCredentialWarning()
+		if !strings.Contains(got, "app_secret 来自") {
+			t.Errorf("缺少拼接风险提示: %q", got)
+		}
+		if strings.Contains(got, "sec_flag") {
+			t.Errorf("app_secret 泄漏进告警: %q", got)
+		}
+	})
+
+	t.Run("只 export app_secret 且没有任何 app_id", func(t *testing.T) {
+		withCmdHome(t)
+		t.Setenv("FEISHU_APP_SECRET", "sec_env")
+		if got := appCredentialWarning(); got != "" {
+			t.Errorf("缺 app_id 由 Validate 报错即可，不重复告警: %q", got)
+		}
+	})
+}
+
+// `--profile X profile use Y` 时，告警必须讲切换后的 Y，不能一行 X 一行 Y。
+func TestAppCredentialWarningForTargetsGivenProfile(t *testing.T) {
+	withCmdHome(t)
+	if err := profile.Create("alert", profile.CreateOpts{AppID: "cli_alert", AppSecret: "s1"}); err != nil {
+		t.Fatal(err)
+	}
+	if err := profile.Create("notify", profile.CreateOpts{AppID: "cli_notify", AppSecret: "s2", SwitchTo: true}); err != nil {
+		t.Fatal(err)
+	}
+	if err := profile.SetCommandOverride("alert"); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("FEISHU_APP_ID", "cli_third")
+	t.Setenv("FEISHU_APP_SECRET", "sec")
+
+	dir, err := profile.ProfileDir("notify")
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := appCredentialWarningForProfile("notify", dir)
+	if !strings.Contains(got, `profile "notify"`) || !strings.Contains(got, "cli_notify") {
+		t.Errorf("显式入口应针对目标 profile: %q", got)
+	}
+	if strings.Contains(got, "alert") {
+		t.Errorf("显式入口不该混入 --profile 指向的 profile: %q", got)
+	}
+
+	// 不带参数的入口仍跟随 --profile，供普通命令使用
+	if got := appCredentialWarning(); !strings.Contains(got, `profile "alert"`) {
+		t.Errorf("默认入口应跟随 --profile: %q", got)
+	}
+}
+
+func TestConfigInitFallbackScope(t *testing.T) {
+	if !configInitOptional(authStatusCmd) || !configInitOptional(authLogoutCmd) {
+		t.Error("auth status/logout 应在配置损坏时降级继续")
+	}
+	if configInitOptional(authLoginCmd) {
+		t.Error("auth login 需要 App 凭证，不能降级")
+	}
+	if !isProfileUseCmd(profileUseCmd) {
+		t.Error("profile use 应由自己在切换后打印凭证告警")
+	}
+	if isProfileUseCmd(profileCurrentCmd) || isProfileUseCmd(authStatusCmd) {
+		t.Error("isProfileUseCmd 误判了其他命令")
+	}
+}

--- a/cmd/doctor.go
+++ b/cmd/doctor.go
@@ -17,6 +17,7 @@ import (
 
 	"github.com/riba2534/feishu-cli/internal/auth"
 	"github.com/riba2534/feishu-cli/internal/config"
+	"github.com/riba2534/feishu-cli/internal/profile"
 	"github.com/spf13/cobra"
 )
 
@@ -433,6 +434,7 @@ func outputJSON(results []checkResult) error {
 		"ok":     allOK,
 		"checks": results,
 	}
+	attachProfileContext(out)
 	enc := json.NewEncoder(os.Stdout)
 	enc.SetIndent("", "  ")
 	if err := enc.Encode(out); err != nil {
@@ -445,6 +447,21 @@ func outputJSON(results []checkResult) error {
 }
 
 func outputPretty(results []checkResult) error {
+	name, source, err := profile.ResolveActive()
+	switch {
+	case err != nil:
+		fmt.Printf("profile=? source=? （解析失败: %v）\n", err)
+	default:
+		if name == "" {
+			name = "(legacy)"
+		}
+		fmt.Printf("profile=%s source=%s\n", name, source)
+	}
+	if config.BotFlagAppID() != "" {
+		fmt.Println("提示: --bot-app-id 已设置，doctor 看到的是命令行覆盖后的应用身份")
+	} else if profile.EnvOverrides().AppID {
+		fmt.Println("提示: FEISHU_APP_ID 已设置，doctor 看到的是环境变量覆盖后的应用身份")
+	}
 	allOK := true
 	for _, r := range results {
 		var icon string

--- a/cmd/profile.go
+++ b/cmd/profile.go
@@ -26,19 +26,27 @@ var profileCmd = &cobra.Command{
   - 第一次执行 'profile add' 不会自动迁移旧文件——用 'profile migrate'
     把现有 config.yaml + token.json 拷到 profiles/default/。
 
-环境变量：
-  FEISHU_PROFILE=<name>   临时强制使用指定 profile（不修改指针文件）
+指定 Bot（不改指针，Agent 推荐）:
+  feishu-cli --profile <name> <命令>
+  FEISHU_PROFILE=<name> feishu-cli <命令>
+
+两条解析链彼此独立:
+  目录 / User Token: --profile > FEISHU_PROFILE > active-profile 指针 > 旧布局
+  App 凭证: --bot-app-id/--bot-app-secret > FEISHU_APP_ID/FEISHU_APP_SECRET > 选中目录的 config.yaml
+
+先看能操作哪些 Bot:
+  feishu-cli profile list --json
 
 示例:
   feishu-cli profile add work --app-id cli_xxx --app-secret secret_xxx --use
-  feishu-cli profile list
+  feishu-cli profile list --json
   feishu-cli profile use personal
   feishu-cli profile use -                # 切回上一个 profile
   feishu-cli profile rename old new
   feishu-cli profile remove temp --force
-  feishu-cli profile current
+  feishu-cli profile current --json
   feishu-cli profile migrate              # 旧布局 → profiles/default/
-  FEISHU_PROFILE=work feishu-cli msg send ...`,
+  feishu-cli --profile work msg send ...`,
 }
 
 func init() {

--- a/cmd/profile_blackbox_test.go
+++ b/cmd/profile_blackbox_test.go
@@ -1,0 +1,621 @@
+package cmd
+
+import (
+	"encoding/json"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/riba2534/feishu-cli/internal/profile"
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+)
+
+// runCLI 走真实 rootCmd 执行一条命令，同时捕获 stdout 与 stderr。
+//
+// 必须捕获 stderr：身份 warning 全部写在那里，只看 stdout 的 harness 会让
+// 「两条 warning 自相矛盾」这类问题在全绿测试下存活。
+func runCLI(t *testing.T, args ...string) (stdout, stderr string, err error) {
+	t.Helper()
+
+	// rootCmd 是包级单例：全局 flag 变量和各子命令的 flag（如 profileListJSON）
+	// 都会跨用例残留，必须把整棵命令树复位，否则上一条 --json 会让下一条也输出 JSON。
+	profileFlag, botAppIDFlag, botAppSecretFlag, cfgFile = "", "", "", ""
+	resetCommandTreeFlags(rootCmd)
+	rootCmd.SetArgs(args)
+	t.Cleanup(func() {
+		rootCmd.SetArgs(nil)
+		profileFlag, botAppIDFlag, botAppSecretFlag, cfgFile = "", "", "", ""
+		_ = profile.SetCommandOverride("")
+	})
+
+	// printJSON 与 warning 分别直写 os.Stdout / os.Stderr，SetOut 捕获不到
+	origOut, origErr := os.Stdout, os.Stderr
+	outR, outW, perr := os.Pipe()
+	if perr != nil {
+		t.Fatal(perr)
+	}
+	errR, errW, perr := os.Pipe()
+	if perr != nil {
+		t.Fatal(perr)
+	}
+	os.Stdout, os.Stderr = outW, errW
+	// defer 恢复：即使被测路径 panic 也不污染后续用例
+	defer func() {
+		os.Stdout, os.Stderr = origOut, origErr
+	}()
+
+	err = rootCmd.Execute()
+	_ = outW.Close()
+	_ = errW.Close()
+	ob, _ := io.ReadAll(outR)
+	eb, _ := io.ReadAll(errR)
+	return string(ob), string(eb), err
+}
+
+// resetCommandTreeFlags 把整棵命令树的 flag 复位到默认值并清除 Changed 标记。
+func resetCommandTreeFlags(cmd *cobra.Command) {
+	reset := func(f *pflag.Flag) {
+		if f.Changed {
+			_ = f.Value.Set(f.DefValue)
+			f.Changed = false
+		}
+	}
+	cmd.Flags().VisitAll(reset)
+	cmd.PersistentFlags().VisitAll(reset)
+	for _, sub := range cmd.Commands() {
+		resetCommandTreeFlags(sub)
+	}
+}
+
+func decodeInventory(t *testing.T, out string) profileInventory {
+	t.Helper()
+	var inv profileInventory
+	if err := json.Unmarshal([]byte(out), &inv); err != nil {
+		t.Fatalf("解析 inventory 失败: %v\n原始输出: %s", err, out)
+	}
+	return inv
+}
+
+// 三个全局 flag 必须经由 PersistentPreRunE 真正生效，而不只是注册成功。
+func TestCLIGlobalFlagsPropagate(t *testing.T) {
+	withCmdHome(t)
+	if err := profile.Create("alpha", profile.CreateOpts{AppID: "cli_alpha", AppSecret: "sa"}); err != nil {
+		t.Fatal(err)
+	}
+	if err := profile.Create("beta", profile.CreateOpts{AppID: "cli_beta", AppSecret: "sb", SwitchTo: true}); err != nil {
+		t.Fatal(err)
+	}
+
+	out, _, err := runCLI(t, "profile", "list", "--json")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if inv := decodeInventory(t, out); inv.Active != "beta" || inv.ActiveSource != profile.SourcePointer {
+		t.Errorf("默认应走指针: active=%s source=%s", inv.Active, inv.ActiveSource)
+	}
+
+	out, _, err = runCLI(t, "--profile", "alpha", "profile", "list", "--json")
+	if err != nil {
+		t.Fatal(err)
+	}
+	inv := decodeInventory(t, out)
+	if inv.Active != "alpha" || inv.ActiveSource != profile.SourceFlag {
+		t.Errorf("--profile 未经命令入口生效: active=%s source=%s", inv.Active, inv.ActiveSource)
+	}
+	if inv.Effective.AppID != "cli_alpha" {
+		t.Errorf("effective 未跟随 --profile: %s", inv.Effective.AppID)
+	}
+
+	out, _, err = runCLI(t, "--bot-app-id", "cli_oneshot", "profile", "list", "--json")
+	if err != nil {
+		t.Fatal(err)
+	}
+	inv = decodeInventory(t, out)
+	if inv.Effective.AppID != "cli_oneshot" || !inv.FlagOverrides.AppID {
+		t.Errorf("--bot-app-id 未经命令入口生效: %+v", inv.Effective)
+	}
+	if inv.TokenFrom != "beta" {
+		t.Errorf("App 凭证覆盖不应改变 token 归属: %s", inv.TokenFrom)
+	}
+
+	// --bot-app-secret 单独传：app_id 仍走 profile，has_secret 由 flag 提供
+	out, _, err = runCLI(t, "--bot-app-secret", "sec_oneshot", "profile", "list", "--json")
+	if err != nil {
+		t.Fatal(err)
+	}
+	inv = decodeInventory(t, out)
+	if !inv.FlagOverrides.AppSecret || inv.FlagOverrides.AppID {
+		t.Errorf("--bot-app-secret 未经命令入口生效: %+v", inv.FlagOverrides)
+	}
+	if inv.Effective.AppID != "cli_beta" || !inv.Effective.HasSecret {
+		t.Errorf("只传 secret 时 app_id 应仍来自 profile: %+v", inv.Effective)
+	}
+	if strings.Contains(out, "sec_oneshot") {
+		t.Error("app_secret 明文泄漏进 JSON")
+	}
+}
+
+// 一个损坏的 inactive profile 不能让整张清单打不开。
+func TestCLIBrokenInactiveProfileDoesNotBreakList(t *testing.T) {
+	withCmdHome(t)
+	if err := profile.Create("good", profile.CreateOpts{AppID: "cli_good", AppSecret: "s", SwitchTo: true}); err != nil {
+		t.Fatal(err)
+	}
+	if err := profile.Create("broken", profile.CreateOpts{AppID: "cli_b", AppSecret: "s"}); err != nil {
+		t.Fatal(err)
+	}
+	dir, err := profile.ProfileDir("broken")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "config.yaml"), []byte("app_id: x\n  bad: [unclosed\n"), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	out, _, err := runCLI(t, "profile", "list", "--json")
+	if err != nil {
+		t.Fatalf("损坏的 inactive profile 不应让命令失败: %v", err)
+	}
+	inv := decodeInventory(t, out)
+	if len(inv.Profiles) != 2 {
+		t.Fatalf("两条都应保留: %+v", inv.Profiles)
+	}
+	var brokenSnap profileSnapshot
+	for _, p := range inv.Profiles {
+		if p.Name == "broken" {
+			brokenSnap = p
+		}
+	}
+	if brokenSnap.ConfigError == "" {
+		t.Error("损坏条目必须带 config_error 说明，不能静默吞掉")
+	}
+	if brokenSnap.problems() == "" {
+		t.Error("problems() 应汇总出该条目的错误")
+	}
+	if inv.Effective.AppID != "cli_good" {
+		t.Errorf("active profile 不受影响: %s", inv.Effective.AppID)
+	}
+}
+
+// legacy 与 profiles 共存、无指针时，生效的那套必须出现在 effective 里。
+func TestCLILegacyCoexistsWithProfiles(t *testing.T) {
+	home := withCmdHome(t)
+	if err := profile.Create("spare", profile.CreateOpts{AppID: "cli_spare", AppSecret: "s"}); err != nil {
+		t.Fatal(err)
+	}
+	root := filepath.Join(home, ".feishu-cli")
+	if err := os.WriteFile(filepath.Join(root, "config.yaml"), []byte("app_id: cli_legacy\napp_secret: s\n"), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	out, _, err := runCLI(t, "profile", "list", "--json")
+	if err != nil {
+		t.Fatal(err)
+	}
+	inv := decodeInventory(t, out)
+	if inv.ActiveSource != profile.SourceLegacy {
+		t.Fatalf("应优先旧布局: source=%s", inv.ActiveSource)
+	}
+	if inv.Effective.AppID != "cli_legacy" {
+		t.Errorf("effective 应是旧布局那套: %s", inv.Effective.AppID)
+	}
+	if len(inv.Profiles) != 1 || inv.Profiles[0].AppID != "cli_spare" {
+		t.Errorf("profiles[] 仍应列出磁盘上的 profile: %+v", inv.Profiles)
+	}
+}
+
+// active 字段必须始终存在（基线是 bool，omitempty 会让 inactive 条目丢字段）。
+func TestCLIInventoryJSONShapeStable(t *testing.T) {
+	withCmdHome(t)
+	if err := profile.Create("one", profile.CreateOpts{AppID: "cli_one", AppSecret: "s", SwitchTo: true}); err != nil {
+		t.Fatal(err)
+	}
+	if err := profile.Create("two", profile.CreateOpts{AppID: "cli_two", AppSecret: "s"}); err != nil {
+		t.Fatal(err)
+	}
+
+	out, _, err := runCLI(t, "profile", "list", "--json")
+	if err != nil {
+		t.Fatal(err)
+	}
+	var raw struct {
+		Profiles []map[string]any `json:"profiles"`
+	}
+	if err := json.Unmarshal([]byte(out), &raw); err != nil {
+		t.Fatal(err)
+	}
+	for _, p := range raw.Profiles {
+		for _, key := range []string{"name", "active", "has_config", "has_token"} {
+			if _, ok := p[key]; !ok {
+				t.Errorf("profile %v 缺少契约字段 %q", p["name"], key)
+			}
+		}
+	}
+	for _, key := range []string{`"user_token_override"`, `"has_config_user_token"`} {
+		if !strings.Contains(out, key) {
+			t.Errorf("缺少契约字段 %s", key)
+		}
+	}
+}
+
+// 显式 User Token 存在时，不能把 profile 目录说成实际来源。
+func TestCLIUserTokenSourceReflectsEnv(t *testing.T) {
+	withCmdHome(t)
+	if err := profile.Create("work", profile.CreateOpts{AppID: "cli_work", AppSecret: "s", SwitchTo: true}); err != nil {
+		t.Fatal(err)
+	}
+
+	out, _, err := runCLI(t, "profile", "list", "--json")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := decodeInventory(t, out).UserTokenOverride; got != "" {
+		t.Errorf("没有显式设置时不应报告任何 override，得到 %q", got)
+	}
+
+	t.Setenv("FEISHU_USER_ACCESS_TOKEN", "u-env-token")
+	t.Setenv("FEISHU_APP_ID", "cli_other")
+	t.Setenv("FEISHU_APP_SECRET", "sec_other")
+	out, _, err = runCLI(t, "profile", "list", "--json")
+	if err != nil {
+		t.Fatal(err)
+	}
+	inv := decodeInventory(t, out)
+	if inv.UserTokenOverride != "FEISHU_USER_ACCESS_TOKEN" {
+		t.Errorf("user_token_override = %q, want FEISHU_USER_ACCESS_TOKEN", inv.UserTokenOverride)
+	}
+	if !strings.Contains(inv.Hint, "FEISHU_USER_ACCESS_TOKEN") {
+		t.Errorf("hint 应点名覆盖来源: %q", inv.Hint)
+	}
+	// 措辞必须限定在「使用 User Token 的命令」，不能断言本次命令的实际身份
+	if strings.Contains(inv.Hint, "本次 User Token 来自") {
+		t.Errorf("不得断言本次命令的实际 token 来源: %q", inv.Hint)
+	}
+}
+
+// config.yaml 坏掉时 auth status 必须还能跑——它正是用来排查这种情况的。
+func TestCLIAuthStatusSurvivesMalformedConfig(t *testing.T) {
+	home := withCmdHome(t)
+	root := filepath.Join(home, ".feishu-cli")
+	if err := os.MkdirAll(root, 0700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(root, "config.yaml"), []byte("app_id: x\n  bad: [unclosed\n"), 0600); err != nil {
+		t.Fatal(err)
+	}
+	token := `{"access_token":"u-local","expires_at":"2099-01-01T00:00:00Z"}`
+	if err := os.WriteFile(filepath.Join(root, "token.json"), []byte(token), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	out, _, err := runCLI(t, "auth", "status", "-o", "json")
+	if err != nil {
+		t.Fatalf("配置损坏不应堵死 auth status: %v", err)
+	}
+	var got map[string]any
+	if err := json.Unmarshal([]byte(out), &got); err != nil {
+		t.Fatalf("输出不是合法 JSON: %v\n%s", err, out)
+	}
+	if got["logged_in"] != true {
+		t.Errorf("本地 token 有效，应报告已登录: %v", got["logged_in"])
+	}
+	if _, ok := got["profile_source"]; !ok {
+		t.Error("降级路径仍须保留身份线索 profile_source")
+	}
+
+	// 对照：业务命令必须继续 fail-fast，不能被降级路径带跑偏
+	if _, _, err := runCLI(t, "chat", "list"); err == nil {
+		t.Error("业务命令遇到损坏配置应直接报错")
+	}
+}
+
+// 显式空 flag 不构成覆盖：resolver 会跳过空值继续走 env/file。
+func TestCLIUserTokenEmptyFlagIsNotOverride(t *testing.T) {
+	withCmdHome(t)
+	if err := profile.Create("work", profile.CreateOpts{AppID: "cli_work", AppSecret: "s", SwitchTo: true}); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("FEISHU_USER_ACCESS_TOKEN", "u-env")
+
+	// api 命令带 local 的 --user-access-token；--dry-run 不发请求
+	if _, _, err := runCLI(t, "api", "GET", "/open-apis/im/v1/chats", "--user-access-token", "", "--dry-run"); err != nil {
+		t.Fatal(err)
+	}
+	if got := userTokenOverride(); got != "FEISHU_USER_ACCESS_TOKEN" {
+		t.Errorf("空 flag 不该被当成覆盖来源，应仍是环境变量，得到 %q", got)
+	}
+
+	// 非空 flag 才构成覆盖
+	if _, _, err := runCLI(t, "api", "GET", "/open-apis/im/v1/chats", "--user-access-token", "u-flag", "--dry-run"); err != nil {
+		t.Fatal(err)
+	}
+	if got := userTokenOverride(); got != "--user-access-token" {
+		t.Errorf("非空 flag 应构成覆盖，得到 %q", got)
+	}
+}
+
+// config.yaml 里的静态 user_access_token 是解析链最后一级，必须能被观察到且不泄漏明文。
+func TestCLIConfigUserTokenIsReportedWithoutLeaking(t *testing.T) {
+	home := withCmdHome(t)
+	root := filepath.Join(home, ".feishu-cli")
+	if err := os.MkdirAll(root, 0700); err != nil {
+		t.Fatal(err)
+	}
+	body := "app_id: cli_legacy\napp_secret: s\nuser_access_token: u-static-secret\n"
+	if err := os.WriteFile(filepath.Join(root, "config.yaml"), []byte(body), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	out, _, err := runCLI(t, "profile", "list", "--json")
+	if err != nil {
+		t.Fatal(err)
+	}
+	inv := decodeInventory(t, out)
+	if !inv.HasConfigUserToken {
+		t.Error("config.yaml 有静态 user_access_token，应报告 has_config_user_token=true")
+	}
+	if strings.Contains(out, "u-static-secret") {
+		t.Error("静态 user_access_token 明文泄漏进 JSON")
+	}
+}
+
+// 当前生效那套的损坏原因必须能从 stdout 观察到，不能只留在 stderr。
+func TestCLIEffectiveErrorReachesStdout(t *testing.T) {
+	home := withCmdHome(t)
+	root := filepath.Join(home, ".feishu-cli")
+	if err := os.MkdirAll(root, 0700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(root, "config.yaml"), []byte("app_id: x\n  bad: [\n"), 0600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(root, "token.json"), []byte("{not json"), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	out, _, err := runCLI(t, "profile", "list", "--json")
+	if err != nil {
+		t.Fatal(err)
+	}
+	inv := decodeInventory(t, out)
+	if inv.EffectiveError == "" {
+		t.Fatal("生效那套坏了，effective_error 不能为空")
+	}
+	if inv.Effective.ConfigError == "" || inv.Effective.TokenError == "" {
+		t.Errorf("config 与 token 的错误应分别记录: %+v", inv.Effective)
+	}
+}
+
+// --config 只替换 config 那一层，token/cache 的错误必须保留。
+func TestCLIConfigFlagKeepsTokenErrors(t *testing.T) {
+	home := withCmdHome(t)
+	root := filepath.Join(home, ".feishu-cli")
+	if err := os.MkdirAll(root, 0700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(root, "config.yaml"), []byte("app_id: x\n  bad: [\n"), 0600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(root, "token.json"), []byte("{not json"), 0600); err != nil {
+		t.Fatal(err)
+	}
+	alt := filepath.Join(t.TempDir(), "alt.yaml")
+	if err := os.WriteFile(alt, []byte("app_id: cli_alt\napp_secret: sa\n"), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	out, _, err := runCLI(t, "--config", alt, "profile", "list", "--json")
+	if err != nil {
+		t.Fatal(err)
+	}
+	inv := decodeInventory(t, out)
+	if inv.Effective.ConfigError != "" {
+		t.Errorf("--config 提供了有效配置，config 层错误应被替换掉: %q", inv.Effective.ConfigError)
+	}
+	if inv.Effective.AppID != "cli_alt" {
+		t.Errorf("effective 应用 --config 的 app_id: %q", inv.Effective.AppID)
+	}
+	if inv.Effective.TokenError == "" {
+		t.Error("--config 不替换 token.json，它的解析错误必须保留")
+	}
+}
+
+// 人类可读输出也要验证，这轮修的正是表格与提示行。
+func TestCLIHumanOutputShowsLegacyAndBrokenEntries(t *testing.T) {
+	home := withCmdHome(t)
+	if err := profile.Create("spare", profile.CreateOpts{AppID: "cli_spare", AppSecret: "s"}); err != nil {
+		t.Fatal(err)
+	}
+	root := filepath.Join(home, ".feishu-cli")
+	if err := os.WriteFile(filepath.Join(root, "config.yaml"), []byte("app_id: cli_legacy\napp_secret: s\n"), 0600); err != nil {
+		t.Fatal(err)
+	}
+	dir, err := profile.ProfileDir("spare")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "token.json"), []byte("{not json"), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	out, _, err := runCLI(t, "profile", "list")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(out, "(legacy)") || !strings.Contains(out, "cli_legacy") {
+		t.Errorf("生效的旧布局必须出现在表格里:\n%s", out)
+	}
+	if !strings.Contains(out, "* ") {
+		t.Errorf("生效行必须有 * 标记:\n%s", out)
+	}
+	if !strings.Contains(out, "spare") {
+		t.Errorf("磁盘上的 profile 仍应列出:\n%s", out)
+	}
+	if !strings.Contains(out, "token.json 解析失败") {
+		t.Errorf("损坏条目必须被点名:\n%s", out)
+	}
+}
+
+// 身份 warning 写在 stderr。这组断言正是前几轮「测试全绿但文案自相矛盾」的补漏。
+func TestCLIWarningsAreConsistentOnStderr(t *testing.T) {
+	home := withCmdHome(t)
+	if err := profile.Create("beta", profile.CreateOpts{AppID: "cli_beta", AppSecret: "sb", SwitchTo: true}); err != nil {
+		t.Fatal(err)
+	}
+	alt := filepath.Join(t.TempDir(), "alt.yaml")
+	if err := os.WriteFile(alt, []byte("app_id: cli_alt\napp_secret: sa\n"), 0600); err != nil {
+		t.Fatal(err)
+	}
+	_ = home
+
+	t.Setenv("FEISHU_APP_ID", "cli_env")
+	t.Setenv("FEISHU_APP_SECRET", "se")
+	t.Setenv("FEISHU_USER_ACCESS_TOKEN", "u-env")
+
+	_, stderr, err := runCLI(t, "--config", alt, "profile", "list", "--json")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// 旧 --config warning 不得声称 token 实际读自 profile——那与显式 token 优先的说明冲突
+	if strings.Contains(stderr, "token 仍读自当前 profile") {
+		t.Errorf("--config warning 与显式 User Token 说明自相矛盾:\n%s", stderr)
+	}
+	// 不得断言本次命令的实际身份（本项目按命令分四类 token helper，root 层无权断言）
+	for _, forbidden := range []string{"本次 User Token 来自", "本次实际"} {
+		if strings.Contains(stderr, forbidden) {
+			t.Errorf("stderr 不得断言本次命令实际身份（含 %q）:\n%s", forbidden, stderr)
+		}
+	}
+	// token.json 仍可能被 refreshIfStaleLocalToken 读取，不能说"不读"
+	if strings.Contains(stderr, "不读 profile") || strings.Contains(stderr, "不读 旧布局") {
+		t.Errorf("token.json 仍可能被读取用于自动刷新，措辞不应是「不读」:\n%s", stderr)
+	}
+	if !strings.Contains(stderr, "FEISHU_USER_ACCESS_TOKEN") {
+		t.Errorf("应说明存在 User Token override:\n%s", stderr)
+	}
+}
+
+// 单应用推荐用法必须完全静默——这是收窄告警的初衷。
+func TestCLINoWarningOnSingleAppSetup(t *testing.T) {
+	home := withCmdHome(t)
+	root := filepath.Join(home, ".feishu-cli")
+	if err := os.MkdirAll(root, 0700); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("FEISHU_APP_ID", "cli_only")
+	t.Setenv("FEISHU_APP_SECRET", "s")
+
+	_, stderr, err := runCLI(t, "profile", "list", "--json")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(stderr, "⚠") {
+		t.Errorf("单应用 env 配置不该产生任何告警:\n%s", stderr)
+	}
+}
+
+// profile use 的告警必须指向切换后的目标，且不被本次 --profile / --config 带偏。
+func TestCLIProfileUseWarningTargetsNewProfile(t *testing.T) {
+	withCmdHome(t)
+	if err := profile.Create("alpha", profile.CreateOpts{AppID: "cli_alpha", AppSecret: "sa", SwitchTo: true}); err != nil {
+		t.Fatal(err)
+	}
+	if err := profile.Create("beta", profile.CreateOpts{AppID: "cli_beta", AppSecret: "sb"}); err != nil {
+		t.Fatal(err)
+	}
+	alt := filepath.Join(t.TempDir(), "alt.yaml")
+	if err := os.WriteFile(alt, []byte("app_id: cli_alt\napp_secret: sa\n"), 0600); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("FEISHU_APP_ID", "cli_env")
+	t.Setenv("FEISHU_APP_SECRET", "se")
+
+	_, stderr, err := runCLI(t, "--profile", "alpha", "--config", alt, "profile", "use", "beta")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(stderr, `profile "beta"`) {
+		t.Errorf("告警应指向切换后的 beta:\n%s", stderr)
+	}
+	if !strings.Contains(stderr, "cli_beta") {
+		t.Errorf("应以 beta 自己的 config.yaml 为基准，不被 --config 劫持:\n%s", stderr)
+	}
+	if strings.Contains(stderr, "cli_alt") {
+		t.Errorf("profile use 的目标检查不应读 --config 的文件:\n%s", stderr)
+	}
+	if strings.Contains(stderr, `profile "alpha"`) {
+		t.Errorf("不应混入 --profile 指向的 alpha:\n%s", stderr)
+	}
+}
+
+// --config 指向不存在的文件：诊断命令必须说出来，业务命令必须失败。
+func TestCLIMissingConfigFileIsReported(t *testing.T) {
+	withCmdHome(t)
+	if err := profile.Create("work", profile.CreateOpts{AppID: "cli_work", AppSecret: "s", SwitchTo: true}); err != nil {
+		t.Fatal(err)
+	}
+	missing := filepath.Join(t.TempDir(), "nope.yaml")
+
+	out, _, err := runCLI(t, "--config", missing, "profile", "list", "--json")
+	if err != nil {
+		t.Fatal(err)
+	}
+	inv := decodeInventory(t, out)
+	if inv.EffectiveError == "" || !strings.Contains(inv.EffectiveError, "不存在") {
+		t.Errorf("显式 --config 文件缺失必须报告: %q", inv.EffectiveError)
+	}
+
+	if _, _, err := runCLI(t, "--config", missing, "chat", "list"); err == nil {
+		t.Error("业务命令遇到不存在的 --config 应直接失败")
+	}
+}
+
+// profile current 的人类分支同样要暴露当前这套的问题。
+func TestCLIProfileCurrentHumanShowsError(t *testing.T) {
+	withCmdHome(t)
+	if err := profile.Create("only", profile.CreateOpts{AppID: "cli_only", AppSecret: "s", SwitchTo: true}); err != nil {
+		t.Fatal(err)
+	}
+	dir, err := profile.ProfileDir("only")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "config.yaml"), []byte("app_id: x\n  bad: [\n"), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	out, _, err := runCLI(t, "profile", "current")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(out, "解析失败") {
+		t.Errorf("profile current 人类输出必须提示配置损坏:\n%s", out)
+	}
+}
+
+// --config 生效时人类表格的 * 行是磁盘 YAML，必须补一行点明真正生效的 app_id。
+func TestCLIListShowsEffectiveAppIDUnderConfigFlag(t *testing.T) {
+	withCmdHome(t)
+	if err := profile.Create("alpha", profile.CreateOpts{AppID: "cli_alpha", AppSecret: "sa", SwitchTo: true}); err != nil {
+		t.Fatal(err)
+	}
+	alt := filepath.Join(t.TempDir(), "alt.yaml")
+	if err := os.WriteFile(alt, []byte("app_id: cli_explicit\napp_secret: sa\n"), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	out, _, err := runCLI(t, "--config", alt, "profile", "list")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(out, "cli_explicit") {
+		t.Errorf("必须点明本次生效的 app_id，否则 * 行会被误读:\n%s", out)
+	}
+	if !strings.Contains(out, "--config") {
+		t.Errorf("应说明生效凭证来自 --config:\n%s", out)
+	}
+}

--- a/cmd/profile_inspect.go
+++ b/cmd/profile_inspect.go
@@ -1,0 +1,470 @@
+package cmd
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/riba2534/feishu-cli/internal/auth"
+	"github.com/riba2534/feishu-cli/internal/config"
+	"github.com/riba2534/feishu-cli/internal/profile"
+	"github.com/spf13/cobra"
+)
+
+// profileSnapshot 是一套 Bot 的离线身份卡（不输出 secret / 裸 token）。
+type profileSnapshot struct {
+	Name      string `json:"name,omitempty"`
+	Source    string `json:"source"`
+	Path      string `json:"path"`
+	AppID     string `json:"app_id,omitempty"`
+	BaseURL   string `json:"base_url,omitempty"`
+	HasConfig bool   `json:"has_config"`
+	HasSecret bool   `json:"has_secret"`
+	HasToken  bool   `json:"has_token"`
+	// HasConfigUserToken 表示该目录 config.yaml 里配了静态 user_access_token（不输出明文）。
+	HasConfigUserToken bool   `json:"has_config_user_token,omitempty"`
+	TokenStatus        string `json:"token_status,omitempty"`
+	UserName           string `json:"user_name,omitempty"`
+	UserOpenID         string `json:"user_open_id,omitempty"`
+	Active             bool   `json:"active"`
+	SelectWith         string `json:"select_with,omitempty"`
+	// 按来源分开记录读取失败原因：--config 只替换 config.yaml，
+	// token.json / user_profile.json 仍来自该目录，它们的错误必须保留。
+	ConfigError string `json:"config_error,omitempty"`
+	TokenError  string `json:"token_error,omitempty"`
+	CacheError  string `json:"cache_error,omitempty"`
+}
+
+// profileInventory 是 Agent 的 Bot 清单契约。
+type profileInventory struct {
+	Mode               string `json:"mode"`
+	Active             string `json:"active"`
+	ActiveSource       string `json:"active_source"`
+	TokenFrom          string `json:"token_from_profile"`
+	UserTokenOverride  string `json:"user_token_override"`
+	HasConfigUserToken bool   `json:"has_config_user_token"`
+	// EffectiveError 是当前生效那套的读取问题；inactive profile 的问题只留在 profiles[] 里。
+	EffectiveError string                   `json:"effective_error,omitempty"`
+	EnvOverrides   profile.EnvOverrideFlags `json:"env_overrides"`
+	FlagOverrides  profile.EnvOverrideFlags `json:"flag_overrides"`
+	Effective      profileSnapshot          `json:"effective"`
+	Profiles       []profileSnapshot        `json:"profiles"`
+	Hint           string                   `json:"hint,omitempty"`
+}
+
+// fileExists 判断路径是否存在，用于与基线一致的 has_config / has_token 语义。
+func fileExists(path string) bool {
+	_, err := os.Stat(path)
+	return err == nil
+}
+
+// snapshotFromDir 读一套 Bot 的离线身份卡。单个文件坏掉只记录到 snap.Error，
+// 不返回 error——一个损坏的 inactive profile 不该让整张清单打不开（基线的
+// profile.Describe 只做文件存在性检查，同样不会因内容非法而失败）。
+func snapshotFromDir(name, source, dir string, active bool) profileSnapshot {
+	snap := profileSnapshot{
+		Name:   name,
+		Source: source,
+		Path:   dir,
+		Active: active,
+	}
+	if name != "" {
+		snap.SelectWith = "--profile " + name
+	}
+	// has_config 与基线语义一致：文件存在即为 true，与内容是否合法无关
+	snap.HasConfig = fileExists(filepath.Join(dir, profile.ConfigFileName))
+	fields, err := profile.ReadConfigFields(dir)
+	if err != nil {
+		snap.ConfigError = fmt.Sprintf("config.yaml 解析失败: %v", err)
+	} else {
+		snap.AppID = fields.AppID
+		snap.BaseURL = profile.EffectiveBaseURL(fields.BaseURL)
+		snap.HasSecret = fields.AppSecret != ""
+		snap.HasConfigUserToken = fields.UserAccessToken != ""
+	}
+
+	tokenPath := filepath.Join(dir, profile.TokenFileName)
+	snap.HasToken = fileExists(tokenPath)
+	token, err := auth.LoadTokenFrom(tokenPath)
+	if err != nil {
+		snap.TokenError = fmt.Sprintf("token.json 解析失败: %v", err)
+	} else if token != nil {
+		snap.TokenStatus = token.TokenStatus()
+	}
+
+	cache, err := auth.LoadUserCacheFrom(filepath.Join(dir, profile.UserCacheFileName))
+	if err != nil {
+		snap.CacheError = fmt.Sprintf("user_profile.json 解析失败: %v", err)
+	} else if cache != nil {
+		snap.UserName = cache.Name
+		snap.UserOpenID = cache.OpenID
+	}
+
+	return snap
+}
+
+// activeConfigFields 读当前真正生效的配置字段：--config 指定时以它为准，否则读所选
+// 目录的 config.yaml——与 config.Init 的取文件规则保持一致，避免 auth status 显示的
+// app_id 和 doctor / 实际请求用的不是同一个。
+func activeConfigFields(dir string) (profile.ConfigFields, error) {
+	if cfgFile != "" {
+		return profile.ReadConfigFieldsFile(cfgFile)
+	}
+	return profile.ReadConfigFields(dir)
+}
+
+// fileCredSource 描述「文件」这一层的实际来源，--config 时要点名是它。
+func fileCredSource() credSource {
+	if cfgFile != "" {
+		return credSource("--config 指定的配置文件")
+	}
+	return credFromFile
+}
+
+func flagOverrideFlags() profile.EnvOverrideFlags {
+	return profile.EnvOverrideFlags{
+		AppID:     config.BotFlagAppID() != "",
+		AppSecret: config.BotFlagAppSecretSet(),
+		Profile:   profile.CommandOverride() != "",
+	}
+}
+
+func applyEnvToEffective(snap profileSnapshot) profileSnapshot {
+	if id := config.BotFlagAppID(); id != "" {
+		snap.AppID = id
+	} else if profile.EnvOverrides().AppID {
+		snap.AppID = profile.EnvAppID()
+	}
+	if config.BotFlagAppSecretSet() || profile.EnvOverrides().AppSecret {
+		snap.HasSecret = true
+	}
+	if envURL := profile.EnvBaseURL(); envURL != "" {
+		snap.BaseURL = strings.TrimRight(envURL, "/")
+	}
+	return snap
+}
+
+func buildProfileInventory() (profileInventory, error) {
+	active, source, err := profile.ResolveActive()
+	if err != nil {
+		return profileInventory{}, err
+	}
+	names, err := profile.List()
+	if err != nil {
+		return profileInventory{}, err
+	}
+
+	inv := profileInventory{
+		Active:            active,
+		ActiveSource:      source,
+		TokenFrom:         tokenFromProfile(active),
+		UserTokenOverride: userTokenOverride(),
+		EnvOverrides:      profile.EnvOverrides(),
+		FlagOverrides:     flagOverrideFlags(),
+		Profiles:          []profileSnapshot{},
+	}
+	if len(names) > 0 {
+		inv.Mode = "profile"
+	} else {
+		inv.Mode = "legacy"
+	}
+
+	for _, name := range names {
+		dir, err := profile.ProfileDir(name)
+		if err != nil {
+			return profileInventory{}, err
+		}
+		inv.Profiles = append(inv.Profiles, snapshotFromDir(name, "profile", dir, name == active))
+	}
+
+	activeDir, err := profile.ActiveDir()
+	if err != nil {
+		return profileInventory{}, err
+	}
+	effSource := source
+	if active != "" {
+		effSource = "profile"
+	} else if source == profile.SourceNone {
+		effSource = "legacy"
+	}
+	effective := snapshotFromDir(active, effSource, activeDir, true)
+	// profiles[] 各读各自目录，但 effective 必须反映 --config 覆盖后的那份。
+	// --config 显式给了有效凭证时，所选目录 YAML 是否损坏与本次命令无关，
+	// 连它的 Error 一起清掉，否则「配置坏了但已用 --config 绕开」会被误诊成故障。
+	if cfgFile != "" {
+		// 只替换 config 这一层：token.json / user_profile.json 仍来自所选目录，
+		// 它们的解析错误依然成立，不能被 --config 一并抹掉。
+		effective.ConfigError = ""
+		effective.HasConfig = fileExists(cfgFile)
+		if !effective.HasConfig {
+			// 用户点名的文件不存在：config.Init 会直接失败，诊断输出必须同步这个事实
+			effective.ConfigError = fmt.Sprintf("--config 指定的 %s 不存在", cfgFile)
+			effective.AppID, effective.HasSecret, effective.HasConfigUserToken = "", false, false
+		}
+		fields, ferr := profile.ReadConfigFieldsFile(cfgFile)
+		if ferr != nil {
+			effective.ConfigError = fmt.Sprintf("--config %s 解析失败: %v", cfgFile, ferr)
+			effective.AppID, effective.HasSecret, effective.HasConfigUserToken = "", false, false
+		} else {
+			effective.AppID = fields.AppID
+			effective.HasSecret = fields.AppSecret != ""
+			effective.BaseURL = profile.EffectiveBaseURL(fields.BaseURL)
+			effective.HasConfigUserToken = fields.UserAccessToken != ""
+		}
+	}
+	inv.Effective = applyEnvToEffective(effective)
+	inv.HasConfigUserToken = inv.Effective.HasConfigUserToken
+	inv.EffectiveError = inv.Effective.problems()
+	inv.Hint = inventoryHint(inv)
+	return inv, nil
+}
+
+// problems 汇总该条目的全部读取错误，供人类输出与 profile_error 字段复用。
+func (s profileSnapshot) problems() string {
+	var parts []string
+	for _, e := range []string{s.ConfigError, s.TokenError, s.CacheError} {
+		if e != "" {
+			parts = append(parts, e)
+		}
+	}
+	return strings.Join(parts, "; ")
+}
+
+// displayProfileName 把空 profile 名渲染成旧布局标记。
+func displayProfileName(name string) string {
+	if name == "" {
+		return "(legacy)"
+	}
+	return name
+}
+
+func printProfileContextHuman() {
+	inv, err := buildProfileInventory()
+	if err != nil {
+		// config.yaml 坏掉时更要说清当前在哪个 profile——这正是排查最需要的信息
+		if name, source, rerr := profile.ResolveActive(); rerr == nil {
+			fmt.Printf("  Profile:        %s（source=%s）\n", displayProfileName(name), source)
+		}
+		return
+	}
+	fmt.Printf("  Profile:        %s（source=%s）\n", displayProfileName(inv.Active), inv.ActiveSource)
+	if inv.Effective.AppID != "" {
+		fmt.Printf("  App ID:         %s\n", inv.Effective.AppID)
+	}
+	if inv.EffectiveError != "" {
+		fmt.Printf("  ⚠️ 配置问题:      %s\n", inv.EffectiveError)
+	}
+	if inv.Hint != "" {
+		fmt.Printf("  提示:           %s\n", inv.Hint)
+	}
+}
+
+func attachProfileContext(result map[string]any) {
+	inv, err := buildProfileInventory()
+	if err != nil {
+		result["profile_error"] = err.Error()
+		// 清单构建失败也要保留身份线索，否则 JSON 消费方连当前 profile 都拿不到
+		if name, source, rerr := profile.ResolveActive(); rerr == nil {
+			result["profile"] = name
+			result["profile_source"] = source
+			result["token_from_profile"] = tokenFromProfile(name)
+		}
+		return
+	}
+	result["profile"] = inv.Active
+	result["profile_source"] = inv.ActiveSource
+	if inv.EffectiveError != "" {
+		result["profile_error"] = inv.EffectiveError
+	}
+	result["token_from_profile"] = inv.TokenFrom
+	if inv.Effective.AppID != "" {
+		result["app_id"] = inv.Effective.AppID
+	}
+	result["env_overrides"] = inv.EnvOverrides
+	result["flag_overrides"] = inv.FlagOverrides
+	if inv.Hint != "" {
+		result["hint"] = inv.Hint
+	}
+}
+
+func inventoryHint(inv profileInventory) string {
+	var parts []string
+	if inv.FlagOverrides.AppID || inv.FlagOverrides.AppSecret {
+		parts = append(parts, "本命令使用 --bot-app-id/--bot-app-secret 覆盖对应 App 凭证，不写盘。")
+		if inv.FlagOverrides.AppID != inv.FlagOverrides.AppSecret {
+			parts = append(parts, "只传了其中一个 flag，另一半仍走环境变量或配置文件。")
+		}
+	} else if inv.EnvOverrides.AppID || inv.EnvOverrides.AppSecret {
+		if len(inv.Profiles) > 0 {
+			parts = append(parts, "FEISHU_APP_ID/FEISHU_APP_SECRET 中非空项会覆盖所选 profile 的 App 凭证；要使用 profile YAML 中的凭证，请先 unset 对应环境变量。")
+		} else {
+			parts = append(parts, "App 凭证来自 FEISHU_APP_ID/FEISHU_APP_SECRET。")
+		}
+	}
+	if inv.FlagOverrides.AppID || inv.FlagOverrides.AppSecret || inv.EnvOverrides.AppID || inv.EnvOverrides.AppSecret {
+		parts = append(parts, userTokenPhrase(inv.Active)+"；App 凭证与 User Token 来源不会自动绑定。")
+	}
+	if inv.Mode == "legacy" && len(inv.Profiles) == 0 {
+		parts = append(parts, "尚未创建 profile。当前只用环境变量/旧布局的一套 Bot。要管理多个: feishu-cli profile add <name> --app-id ... --app-secret ...")
+	}
+	return strings.Join(parts, " ")
+}
+
+func tokenFromProfile(active string) string {
+	if active == "" {
+		return "(legacy)"
+	}
+	return active
+}
+
+// credSource 描述某个 App 凭证字段最终来自哪一层。
+type credSource string
+
+const (
+	credFromFlag credSource = "--bot-app-id/--bot-app-secret"
+	credFromEnv  credSource = "FEISHU_APP_ID/FEISHU_APP_SECRET"
+	credFromFile credSource = "config.yaml"
+)
+
+// profileLabel 把 profile 名渲染成可读位置，空名表示旧布局。
+func profileLabel(active string) string {
+	if active == "" {
+		return "旧布局 ~/.feishu-cli"
+	}
+	return fmt.Sprintf("profile %q", active)
+}
+
+// appCredentialWarning 只在 App 凭证「真错配」时返回告警文案，其余情况返回空串。
+//
+// 会告警的两种情况：
+//  1. 覆盖来的 app_id 与所选目录 config.yaml 里的 app_id 不是同一个应用——User Token 仍读
+//     该目录的 token.json，App 身份与 User 身份分属两个应用。
+//  2. app_id 与 app_secret 落在不同层且无法确认同属一个应用（例如只传了 --bot-app-secret，
+//     app_id 仍走 config.yaml）——两半凭证拼在一起会换不到 tenant_access_token。
+//
+// 单应用 export FEISHU_APP_ID/FEISHU_APP_SECRET（没有 profile，或与所选 profile 是同一个
+// 应用）是文档推荐用法，不产生任何输出——否则每条命令都要刷一行无效警告。
+func appCredentialWarning() string {
+	active, _, err := profile.ResolveActive()
+	if err != nil {
+		return ""
+	}
+	dir, err := profile.ActiveDir()
+	if err != nil {
+		return ""
+	}
+	fields, err := activeConfigFields(dir)
+	if err != nil {
+		return ""
+	}
+	return credentialWarningFrom(active, fields, fileCredSource(), configOrigin(profileLabel(active)))
+}
+
+// userTokenFlagValue 保存本次命令 --user-access-token 的实际取值（各命令的 local flag）。
+// 用值而不是 Changed：显式传空串时 resolver 会跳过它继续走 env/file。
+var userTokenFlagValue string
+
+// setUserTokenFlagPresence 在 PersistentPreRunE 中记录 --user-access-token 的取值。
+func setUserTokenFlagPresence(cmd *cobra.Command) {
+	userTokenFlagValue = ""
+	if cmd == nil {
+		return
+	}
+	if f := cmd.Flags().Lookup("user-access-token"); f != nil {
+		// 不 TrimSpace：auth.ResolveUserAccessToken 判的是原始 != ""，
+		// 这里做额外清洗会让报告与 resolver 的实际行为对不上
+		userTokenFlagValue = f.Value.String()
+	}
+}
+
+// userTokenOverride 报告是否存在压过 profile token.json 的显式 User Token 设置。
+//
+// 它只陈述「设置了什么」，绝不断言本次命令实际用了哪个 token：本项目按命令分四类
+// token helper（cmd/utils.go），`--as bot`、默认 Bot 身份的写命令、只认 flag 的
+// vc bot meeting-join、固定读本地文件的 auth status 各有各的解析路径，root 层
+// 无权替它们下结论。返回空串表示没有任何显式覆盖。
+func userTokenOverride() string {
+	if userTokenFlagValue != "" {
+		return "--user-access-token"
+	}
+	if os.Getenv("FEISHU_USER_ACCESS_TOKEN") != "" {
+		return "FEISHU_USER_ACCESS_TOKEN"
+	}
+	return ""
+}
+
+// userTokenPhrase 描述 User Token 的候选来源，措辞限定在「使用 User Token 的命令」，
+// 不断言本次命令是否走 User 身份。
+func userTokenPhrase(active string) string {
+	if origin := userTokenOverride(); origin != "" {
+		return fmt.Sprintf("%s 已设置，使用 User Token 的命令会优先用它，而不是回退到 %s 的 token.json（该文件仍可能被读取用于自动刷新）", origin, profileLabel(active))
+	}
+	return fmt.Sprintf("使用 User Token 的命令会读 %s 的 token.json", profileLabel(active))
+}
+
+// appCredentialWarningForProfile 强制以目标 profile 自己的 config.yaml 为基准。
+// profile use 必须走这个入口：它讲的是「写完指针后的持久状态」，既不能被本次
+// --profile 带偏，也不能被本次 --config 这种一次性覆盖劫持。
+func appCredentialWarningForProfile(name, dir string) string {
+	fields, err := profile.ReadConfigFields(dir)
+	if err != nil {
+		return ""
+	}
+	return credentialWarningFrom(name, fields, credFromFile, profileLabel(name)+" 的 config.yaml")
+}
+
+// credentialWarningFrom 按给定的「文件层」凭证判定错配。fromFile 是该层的来源标签，
+// origin 是它在文案里的可读位置。
+func credentialWarningFrom(active string, fields profile.ConfigFields, fromFile credSource, origin string) string {
+	flags := flagOverrideFlags()
+	env := profile.EnvOverrides()
+	if !flags.AppID && !flags.AppSecret && !env.AppID && !env.AppSecret {
+		return ""
+	}
+
+	idSource, effectiveID := fromFile, fields.AppID
+	switch {
+	case flags.AppID:
+		idSource, effectiveID = credFromFlag, config.BotFlagAppID()
+	case env.AppID:
+		idSource, effectiveID = credFromEnv, profile.EnvAppID()
+	}
+	secretSource, hasSecret := fromFile, fields.AppSecret != ""
+	switch {
+	case flags.AppSecret:
+		secretSource, hasSecret = credFromFlag, true
+	case env.AppSecret:
+		secretSource, hasSecret = credFromEnv, true
+	}
+
+	// app_secret 落在配置文件且该文件的 app_id 就是最终 app_id 时，两半必属同一应用
+	sameApp := idSource == secretSource ||
+		(secretSource == fromFile && fields.AppID != "" && fields.AppID == effectiveID)
+
+	switch {
+	case idSource != fromFile && fields.AppID != "" && effectiveID != fields.AppID:
+		return fmt.Sprintf(
+			"⚠️  App 凭证被 %s 覆盖为 %s，与 %s（%s）不是同一个应用；%s。",
+			idSource, effectiveID, origin, fields.AppID, userTokenPhrase(active))
+	case effectiveID != "" && hasSecret && !sameApp:
+		return fmt.Sprintf(
+			"⚠️  app_id 来自 %s、app_secret 来自 %s；两半凭证若不属于同一应用会换不到 tenant_access_token。",
+			idSource, secretSource)
+	}
+	return ""
+}
+
+// configOrigin 描述凭证文件的位置，供告警文案使用。
+func configOrigin(where string) string {
+	if cfgFile != "" {
+		return fmt.Sprintf("--config 指定的 %s", cfgFile)
+	}
+	return where + " 的 config.yaml"
+}
+
+func warnAppCredentialTokenSource() {
+	if msg := appCredentialWarning(); msg != "" {
+		fmt.Fprintln(os.Stderr, msg)
+	}
+}

--- a/cmd/profile_list.go
+++ b/cmd/profile_list.go
@@ -1,11 +1,11 @@
 package cmd
 
 import (
-	"encoding/json"
 	"fmt"
-	"text/tabwriter"
+	"io"
 
 	"github.com/riba2534/feishu-cli/internal/profile"
+
 	"github.com/spf13/cobra"
 )
 
@@ -13,63 +13,140 @@ var profileListJSON bool
 
 var profileListCmd = &cobra.Command{
 	Use:   "list",
-	Short: "列出所有 profile",
-	Long: `列出 ~/.feishu-cli/profiles/ 下所有 profile，并标注当前激活的 profile。
+	Short: "列出可操作的 Bot / profile",
+	Long: `列出本机所有飞书 Bot（profile），以及当前真正会生效的那一套。
+
+即使还没执行过 profile add，也会输出环境变量 / 旧布局里正在用的那一套，
+避免 Agent 误以为「一个 Bot 都没有」。
+
+JSON（--json）是 Agent 契约：看 profiles[] 识别磁盘上的 Bot，
+看 effective 确认叠加 FEISHU_APP_ID 后实际会打到哪个 App。
 
 示例:
   feishu-cli profile list
-  feishu-cli profile list --json`,
+  feishu-cli profile list --json
+  feishu-cli --profile alert profile list --json`,
 	Aliases: []string{"ls"},
 	RunE: func(cmd *cobra.Command, args []string) error {
-		infos, err := profile.Describe()
+		inv, err := buildProfileInventory()
 		if err != nil {
 			return err
 		}
-		active, err := profile.ActiveName()
-		if err != nil {
-			return err
-		}
-
 		if profileListJSON {
-			out := map[string]any{
-				"active":   active,
-				"profiles": infos,
-			}
-			return json.NewEncoder(cmd.OutOrStdout()).Encode(out)
+			return printJSON(inv)
 		}
-
-		if len(infos) == 0 {
-			fmt.Fprintln(cmd.OutOrStdout(), "尚未创建任何 profile。")
-			fmt.Fprintln(cmd.OutOrStdout(), "提示: feishu-cli profile add <name>            # 新建")
-			fmt.Fprintln(cmd.OutOrStdout(), "      feishu-cli profile migrate                # 旧布局 → default profile")
-			return nil
-		}
-
-		w := tabwriter.NewWriter(cmd.OutOrStdout(), 0, 0, 2, ' ', 0)
-		fmt.Fprintln(w, "ACTIVE\tNAME\tCONFIG\tTOKEN\tPATH")
-		for _, info := range infos {
-			marker := " "
-			if info.Active {
-				marker = "*"
-			}
-			fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\n",
-				marker, info.Name, yesNo(info.HasConfig), yesNo(info.HasToken), info.Path)
-		}
-		if err := w.Flush(); err != nil {
-			return err
-		}
-		if active == "" {
-			fmt.Fprintln(cmd.OutOrStdout(), "\n当前无激活 profile（active-profile 指针缺失），首次使用会回退到字典序第一个。")
-		}
-		return nil
+		return printProfileInventory(cmd, inv)
 	},
 }
 
-func yesNo(b bool) string {
-	if b {
-		return "yes"
+func printProfileInventory(cmd *cobra.Command, inv profileInventory) error {
+	out := cmd.OutOrStdout()
+	if inv.Active != "" {
+		fmt.Fprintf(out, "当前: %s（source=%s, mode=%s）\n", inv.Active, inv.ActiveSource, inv.Mode)
+	} else {
+		fmt.Fprintf(out, "当前: 旧布局/环境变量（source=%s, mode=%s）\n", inv.ActiveSource, inv.Mode)
 	}
-	return "no"
+
+	// active 为空表示生效的是旧布局，它不在 profiles[] 里。哪怕磁盘上另有 profile，
+	// 也必须把这行摆进表格——否则「列出真正会生效的那一套」就成了空话。
+	rows := inv.Profiles
+	if inv.Active == "" {
+		row := inv.Effective
+		row.Name = displayProfileName(row.Name)
+		row.Active = true
+		rows = append([]profileSnapshot{row}, rows...)
+	}
+
+	table := make([][]string, 0, len(rows))
+	for _, info := range rows {
+		marker := " "
+		if info.Active {
+			marker = "*"
+		}
+		appID := info.AppID
+		if appID == "" {
+			appID = "-"
+		}
+		token := info.TokenStatus
+		if token == "" {
+			token = "-"
+		}
+		user := info.UserName
+		if user == "" {
+			user = "-"
+		}
+		sel := info.SelectWith
+		if sel == "" {
+			sel = "-"
+		}
+		table = append(table, []string{marker, info.Name, appID, token, user, sel})
+	}
+	// 用户名可能是中文，按显示宽度对齐（tabwriter 按字节算会顶歪 SELECT 列）
+	if err := renderColumns(out, []string{"ACTIVE", "NAME", "APP_ID", "TOKEN", "USER", "SELECT"}, table); err != nil {
+		return err
+	}
+
+	// 表格里的 * 行是磁盘上的 YAML；被覆盖时必须点明本次真正生效的 app_id，
+	// 否则用户会把 * 行当成本次实际用的凭证。
+	switch {
+	case inv.FlagOverrides.AppID && inv.Effective.AppID != "":
+		fmt.Fprintf(out, "\n生效 app_id: %s（被 --bot-app-id 覆盖）\n", inv.Effective.AppID)
+	case inv.EnvOverrides.AppID && inv.Effective.AppID != "":
+		fmt.Fprintf(out, "\n生效 app_id: %s（被 FEISHU_APP_ID 覆盖）\n", inv.Effective.AppID)
+	case cfgFile != "":
+		if inv.Effective.AppID != "" {
+			fmt.Fprintf(out, "\n生效 app_id: %s（来自 --config %s）\n", inv.Effective.AppID, cfgFile)
+		} else {
+			fmt.Fprintf(out, "\n生效配置: --config %s\n", cfgFile)
+		}
+	}
+	if inv.EffectiveError != "" {
+		fmt.Fprintf(out, "⚠️  当前生效的这套有问题: %s\n", inv.EffectiveError)
+	}
+	// 容错不等于静默：坏掉的条目必须点名，否则用户只会看到一行 "-"
+	var broken []profileSnapshot
+	for _, info := range rows {
+		if info.problems() != "" {
+			broken = append(broken, info)
+		}
+	}
+	if len(broken) > 0 {
+		fmt.Fprintln(out)
+		for _, info := range broken {
+			fmt.Fprintf(out, "⚠️  %s: %s\n", displayProfileName(info.Name), info.problems())
+		}
+	}
+	if inv.Hint != "" {
+		fmt.Fprintf(out, "\n提示: %s\n", inv.Hint)
+	}
+	printPointerNote(out, inv)
+	return nil
+}
+
+// printPointerNote 解释指针状态。指针失效与指针缺失是两回事，
+// 且回退结果此时已经确定，不该再说"或字典序第一个"。
+func printPointerNote(out io.Writer, inv profileInventory) {
+	if inv.Mode != "profile" {
+		return
+	}
+	ptr, err := profile.ReadActive()
+	if err != nil {
+		return
+	}
+	switch inv.ActiveSource {
+	case profile.SourceLegacy:
+		if ptr != "" {
+			fmt.Fprintf(out, "\nactive-profile 指针指向 %q，该 profile 已不存在，已回退到旧布局 ~/.feishu-cli。\n", ptr)
+			return
+		}
+		fmt.Fprintln(out, "\n没有 active-profile 指针，旧布局仍在，已回退到旧布局 ~/.feishu-cli。")
+	case profile.SourceFallback:
+		if ptr != "" {
+			fmt.Fprintf(out, "\nactive-profile 指针指向 %q，该 profile 已不存在，已回退到字典序第一个（%s）。\n", ptr, inv.Active)
+			return
+		}
+		fmt.Fprintf(out, "\n没有 active-profile 指针，已回退到字典序第一个（%s）。\n", inv.Active)
+	}
 }
 
 func init() {

--- a/cmd/profile_list_test.go
+++ b/cmd/profile_list_test.go
@@ -1,0 +1,216 @@
+package cmd
+
+import (
+	"bytes"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/riba2534/feishu-cli/internal/config"
+	"github.com/riba2534/feishu-cli/internal/profile"
+	"github.com/spf13/cobra"
+)
+
+func withCmdHome(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	restore := profile.SetHomeFunc(func() (string, error) { return dir, nil })
+	oldCfgFile := cfgFile
+	t.Cleanup(func() {
+		restore()
+		_ = profile.SetCommandOverride("")
+		config.SetBotFlagCredentials("", "")
+		cfgFile = oldCfgFile
+	})
+	_ = profile.SetCommandOverride("")
+	config.SetBotFlagCredentials("", "")
+	cfgFile = ""
+	t.Setenv("FEISHU_PROFILE", "")
+	t.Setenv("FEISHU_APP_ID", "")
+	t.Setenv("FEISHU_APP_SECRET", "")
+	return dir
+}
+
+func TestBuildInventoryLegacyEnv(t *testing.T) {
+	withCmdHome(t)
+	t.Setenv("FEISHU_APP_ID", "cli_env_only")
+	t.Setenv("FEISHU_APP_SECRET", "sec")
+	inv, err := buildProfileInventory()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if inv.Mode != "legacy" {
+		t.Errorf("mode=%s", inv.Mode)
+	}
+	if inv.Effective.AppID != "cli_env_only" {
+		t.Errorf("effective app_id=%s", inv.Effective.AppID)
+	}
+	if !inv.EnvOverrides.AppID {
+		t.Errorf("expected env override")
+	}
+	if inv.Hint == "" {
+		t.Errorf("expected hint for no profiles")
+	}
+}
+
+func TestBuildInventoryTwoProfilesAndFlag(t *testing.T) {
+	withCmdHome(t)
+	if err := profile.Create("alert", profile.CreateOpts{AppID: "cli_aaa", AppSecret: "s1"}); err != nil {
+		t.Fatal(err)
+	}
+	if err := profile.Create("notify", profile.CreateOpts{AppID: "cli_bbb", AppSecret: "s2", SwitchTo: true}); err != nil {
+		t.Fatal(err)
+	}
+	inv, err := buildProfileInventory()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if inv.Active != "notify" || len(inv.Profiles) != 2 {
+		t.Fatalf("active=%s n=%d", inv.Active, len(inv.Profiles))
+	}
+	if inv.Effective.AppID != "cli_bbb" {
+		t.Errorf("effective=%s", inv.Effective.AppID)
+	}
+	if err := profile.SetCommandOverride("alert"); err != nil {
+		t.Fatal(err)
+	}
+	inv, err = buildProfileInventory()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if inv.Active != "alert" || inv.ActiveSource != profile.SourceFlag {
+		t.Errorf("flag override active=%s source=%s", inv.Active, inv.ActiveSource)
+	}
+	if !inv.FlagOverrides.Profile {
+		t.Error("expected flag_overrides.profile=true")
+	}
+	if inv.TokenFrom != "alert" {
+		t.Errorf("token_from_profile=%q, want alert", inv.TokenFrom)
+	}
+	if inv.Effective.AppID != "cli_aaa" {
+		t.Errorf("flag effective=%s", inv.Effective.AppID)
+	}
+	t.Setenv("FEISHU_APP_ID", "cli_env")
+	inv, err = buildProfileInventory()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if inv.Effective.AppID != "cli_env" {
+		t.Errorf("env should win effective=%s", inv.Effective.AppID)
+	}
+	if !strings.Contains(inv.Hint, "覆盖所选 profile") || !strings.Contains(inv.Hint, "token.json") {
+		t.Errorf("missing env/token-source hint: %q", inv.Hint)
+	}
+	raw, _ := json.Marshal(inv)
+	if bytes.Contains(raw, []byte("s1")) || bytes.Contains(raw, []byte("s2")) {
+		t.Errorf("secret leaked in JSON: %s", raw)
+	}
+}
+
+func TestBuildInventoryBotFlagContext(t *testing.T) {
+	withCmdHome(t)
+	if err := profile.Create("work", profile.CreateOpts{AppID: "cli_work", AppSecret: "sec_work", SwitchTo: true}); err != nil {
+		t.Fatal(err)
+	}
+	config.SetBotFlagCredentials("cli_flag", "sec_flag")
+	inv, err := buildProfileInventory()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if inv.Effective.AppID != "cli_flag" || !inv.FlagOverrides.AppID || !inv.FlagOverrides.AppSecret {
+		t.Fatalf("unexpected flag inventory: %+v", inv)
+	}
+	if inv.TokenFrom != "work" || !strings.Contains(inv.Hint, "token.json") {
+		t.Fatalf("missing token source context: %+v", inv)
+	}
+	ctx := map[string]any{}
+	attachProfileContext(ctx)
+	if ctx["token_from_profile"] != "work" || ctx["hint"] == "" {
+		t.Fatalf("attached context missing token source/hint: %+v", ctx)
+	}
+}
+
+func TestGlobalBotCredentialFlagsDoNotCollide(t *testing.T) {
+	if rootCmd.PersistentFlags().Lookup("bot-app-id") == nil || rootCmd.PersistentFlags().Lookup("bot-app-secret") == nil {
+		t.Fatal("missing global --bot-app-id/--bot-app-secret")
+	}
+	if rootCmd.PersistentFlags().Lookup("app-id") != nil || rootCmd.PersistentFlags().Lookup("app-secret") != nil {
+		t.Fatal("root must not register global --app-id/--app-secret")
+	}
+	if profileAddCmd.Flags().Lookup("app-id") == nil || profileAddCmd.Flags().Lookup("app-secret") == nil {
+		t.Fatal("profile add must retain local --app-id/--app-secret")
+	}
+	if appsUpdateCmd.Flags().Lookup("app-id") == nil {
+		t.Fatal("apps update must retain local Miaoda --app-id")
+	}
+}
+
+func TestBotCredentialOverridesDoNotPersistIntoProfileAdd(t *testing.T) {
+	withCmdHome(t)
+	oldID, oldSecret, oldJSON := profileAddAppID, profileAddAppSecret, profileAddJSON
+	oldOut := profileAddCmd.OutOrStdout()
+	t.Cleanup(func() {
+		profileAddAppID, profileAddAppSecret, profileAddJSON = oldID, oldSecret, oldJSON
+		profileAddCmd.SetOut(oldOut)
+	})
+	profileAddAppID, profileAddAppSecret, profileAddJSON = "", "", false
+	profileAddCmd.SetOut(&bytes.Buffer{})
+	config.SetBotFlagCredentials("cli_transient", "sec_transient")
+
+	if err := profileAddCmd.RunE(profileAddCmd, []string{"foo"}); err != nil {
+		t.Fatal(err)
+	}
+	dir, err := profile.ProfileDir("foo")
+	if err != nil {
+		t.Fatal(err)
+	}
+	fields, err := profile.ReadConfigFields(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if fields.AppID != "" || fields.AppSecret != "" {
+		t.Fatalf("one-shot Bot credentials leaked into profile config: app_id=%q has_secret=%t", fields.AppID, fields.AppSecret != "")
+	}
+}
+
+func TestAuthStatusAndLogoutLoadSelectedConfig(t *testing.T) {
+	for name, cmd := range map[string]*cobra.Command{
+		"auth status": authStatusCmd,
+		"auth logout": authLogoutCmd,
+	} {
+		if shouldSkipConfigInit(cmd) {
+			t.Errorf("%s must run config.Init for refresh/revoke credentials", name)
+		}
+	}
+}
+
+func TestProfileListJSONNoEmptyTrap(t *testing.T) {
+	home := withCmdHome(t)
+	root := filepath.Join(home, ".feishu-cli")
+	if err := os.MkdirAll(root, 0700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(root, "config.yaml"), []byte("app_id: cli_legacy\napp_secret: sec\n"), 0600); err != nil {
+		t.Fatal(err)
+	}
+	inv, err := buildProfileInventory()
+	if err != nil {
+		t.Fatal(err)
+	}
+	raw, err := json.Marshal(inv)
+	if err != nil {
+		t.Fatal(err)
+	}
+	out := string(raw)
+	if strings.Contains(out, "尚未创建任何 profile") {
+		t.Fatalf("empty trap: %s", out)
+	}
+	if inv.Effective.AppID != "cli_legacy" {
+		t.Fatalf("missing effective app_id: %s", out)
+	}
+	if len(inv.Profiles) != 0 {
+		t.Fatalf("legacy should have empty profiles: %s", out)
+	}
+}

--- a/cmd/profile_snapshot_test.go
+++ b/cmd/profile_snapshot_test.go
@@ -1,0 +1,126 @@
+package cmd
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/riba2534/feishu-cli/internal/profile"
+)
+
+// snapshotFromDir 承接了原 profile.Describe 的职责（active 标记 + 文件存在性），
+// 并额外给出 app_id / token 状态 / 登录用户。
+func TestSnapshotFromDirReportsFiles(t *testing.T) {
+	withCmdHome(t)
+	if err := profile.Create("work", profile.CreateOpts{AppID: "cli_work", AppSecret: "sec", SwitchTo: true}); err != nil {
+		t.Fatal(err)
+	}
+	if err := profile.Create("personal", profile.CreateOpts{AppID: "cli_personal", AppSecret: "sec2"}); err != nil {
+		t.Fatal(err)
+	}
+	dir, err := profile.ProfileDir("work")
+	if err != nil {
+		t.Fatal(err)
+	}
+	token := `{"access_token":"u-x","expires_at":"2099-01-01T00:00:00Z"}`
+	if err := os.WriteFile(filepath.Join(dir, "token.json"), []byte(token), 0600); err != nil {
+		t.Fatal(err)
+	}
+	cache := `{"open_id":"ou_x","name":"张三","cached_at":"2026-01-01T00:00:00Z"}`
+	if err := os.WriteFile(filepath.Join(dir, "user_profile.json"), []byte(cache), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	inv, err := buildProfileInventory()
+	if err != nil {
+		t.Fatal(err)
+	}
+	byName := map[string]profileSnapshot{}
+	for _, snap := range inv.Profiles {
+		byName[snap.Name] = snap
+	}
+	if len(byName) != 2 {
+		t.Fatalf("profiles = %d, want 2", len(byName))
+	}
+
+	work := byName["work"]
+	if !work.Active {
+		t.Error("work 应标记为 active")
+	}
+	if !work.HasConfig || !work.HasSecret || !work.HasToken {
+		t.Errorf("work 文件状态不对: %+v", work)
+	}
+	if work.TokenStatus == "" || work.UserName != "张三" || work.UserOpenID != "ou_x" {
+		t.Errorf("work token/用户信息不对: %+v", work)
+	}
+	if work.SelectWith != "--profile work" {
+		t.Errorf("select_with = %q", work.SelectWith)
+	}
+
+	personal := byName["personal"]
+	if personal.Active {
+		t.Error("personal 不应标记为 active")
+	}
+	if !personal.HasConfig || personal.HasToken {
+		t.Errorf("personal 未登录，不该有 token: %+v", personal)
+	}
+	if personal.TokenStatus != "" || personal.UserName != "" {
+		t.Errorf("personal 不该有 token 状态/用户名: %+v", personal)
+	}
+}
+
+// --config 替换的是「选中目录的 config.yaml」这一层，effective 必须跟着走，
+// 否则 auth status 报的 app_id 会和 doctor / 真实请求用的对不上。
+func TestInventoryEffectiveFollowsConfigFlag(t *testing.T) {
+	withCmdHome(t)
+	if err := profile.Create("work", profile.CreateOpts{AppID: "cli_work", AppSecret: "sw", SwitchTo: true}); err != nil {
+		t.Fatal(err)
+	}
+	alt := filepath.Join(t.TempDir(), "alt.yaml")
+	if err := os.WriteFile(alt, []byte("app_id: cli_alt\napp_secret: sa\n"), 0600); err != nil {
+		t.Fatal(err)
+	}
+	cfgFile = alt
+
+	inv, err := buildProfileInventory()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if inv.Effective.AppID != "cli_alt" {
+		t.Errorf("effective.app_id = %q, want cli_alt（--config 指定的那份）", inv.Effective.AppID)
+	}
+	if !inv.Effective.HasSecret {
+		t.Error("--config 里有 app_secret，effective.has_secret 应为 true")
+	}
+	if len(inv.Profiles) != 1 || inv.Profiles[0].AppID != "cli_work" {
+		t.Errorf("profiles[] 应保持磁盘原值，不受 --config 影响: %+v", inv.Profiles)
+	}
+	// token 归属不受 --config 影响
+	if inv.TokenFrom != "work" {
+		t.Errorf("token_from_profile = %q, want work", inv.TokenFrom)
+	}
+}
+
+// --config 下的告警要点名实际读的那个文件，而不是笼统说 config.yaml。
+func TestAppCredentialWarningNamesConfigFlagFile(t *testing.T) {
+	withCmdHome(t)
+	if err := profile.Create("work", profile.CreateOpts{AppID: "cli_work", AppSecret: "sw", SwitchTo: true}); err != nil {
+		t.Fatal(err)
+	}
+	alt := filepath.Join(t.TempDir(), "alt.yaml")
+	if err := os.WriteFile(alt, []byte("app_id: cli_alt\napp_secret: sa\n"), 0600); err != nil {
+		t.Fatal(err)
+	}
+	cfgFile = alt
+	t.Setenv("FEISHU_APP_ID", "cli_env")
+	t.Setenv("FEISHU_APP_SECRET", "se")
+
+	got := appCredentialWarning()
+	if !strings.Contains(got, "--config") || !strings.Contains(got, "cli_alt") {
+		t.Errorf("告警应点名 --config 文件及其 app_id: %q", got)
+	}
+	if strings.Contains(got, "cli_work") {
+		t.Errorf("--config 生效时不该拿 profile 目录的 app_id 作基准: %q", got)
+	}
+}

--- a/cmd/profile_use.go
+++ b/cmd/profile_use.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"encoding/json"
 	"fmt"
+	"os"
 
 	"github.com/riba2534/feishu-cli/internal/profile"
 	"github.com/spf13/cobra"
@@ -37,6 +38,12 @@ var profileUseCmd = &cobra.Command{
 			return err
 		}
 
+		// 显式针对切换后的 profile 判定，不受本次 --profile 影响；只有真错配才出声
+		if msg := appCredentialWarningForProfile(newActive, dir); msg != "" {
+			fmt.Fprintln(os.Stderr, msg)
+			fmt.Fprintf(os.Stderr, "    profile use 只切换目录和 User Token；要改用 profile %q 自带的 App 凭证，请先 unset FEISHU_APP_ID/FEISHU_APP_SECRET 或去掉 --bot-app-* flag。\n", newActive)
+		}
+
 		if profileUseJSON {
 			out := map[string]any{
 				"ok":       true,
@@ -60,23 +67,39 @@ var profileUseCmd = &cobra.Command{
 	},
 }
 
+var profileCurrentJSON bool
+
 var profileCurrentCmd = &cobra.Command{
 	Use:   "current",
-	Short: "显示当前激活的 profile",
+	Short: "显示当前真正生效的 Bot / profile",
+	Long: `显示叠加 --profile / FEISHU_PROFILE / App 凭证覆盖后，当前命令会使用的完整身份上下文。
+
+JSON 输出与 profile list --json 同形的完整 inventory，包含 effective、active_source、
+token_from_profile、env_overrides、flag_overrides 和 hint，便于 Agent 确认身份。`,
 	RunE: func(cmd *cobra.Command, args []string) error {
-		name, err := profile.ActiveName()
+		inv, err := buildProfileInventory()
 		if err != nil {
 			return err
 		}
+		if profileCurrentJSON {
+			return printJSON(inv)
+		}
+		eff := inv.Effective
+		name := eff.Name
 		if name == "" {
-			fmt.Fprintln(cmd.OutOrStdout(), "(未启用 profile 系统，使用旧布局 ~/.feishu-cli/)")
-			return nil
+			name = "(legacy)"
 		}
-		dir, err := profile.ProfileDir(name)
-		if err != nil {
-			return err
+		fmt.Fprintf(cmd.OutOrStdout(), "%s\t%s\n", name, eff.Path)
+		if eff.AppID != "" {
+			fmt.Fprintf(cmd.OutOrStdout(), "app_id:\t%s\n", eff.AppID)
 		}
-		fmt.Fprintf(cmd.OutOrStdout(), "%s\t%s\n", name, dir)
+		fmt.Fprintf(cmd.OutOrStdout(), "source:\t%s\n", inv.ActiveSource)
+		if inv.EffectiveError != "" {
+			fmt.Fprintf(cmd.OutOrStdout(), "⚠️ 问题:\t%s\n", inv.EffectiveError)
+		}
+		if inv.Hint != "" {
+			fmt.Fprintf(cmd.OutOrStdout(), "提示:\t%s\n", inv.Hint)
+		}
 		return nil
 	},
 }
@@ -126,6 +149,7 @@ var profileMigrateCmd = &cobra.Command{
 
 func init() {
 	profileUseCmd.Flags().BoolVar(&profileUseJSON, "json", false, "JSON 输出")
+	profileCurrentCmd.Flags().BoolVar(&profileCurrentJSON, "json", false, "JSON 输出（完整 inventory，适合 Agent）")
 	profileCmd.AddCommand(profileUseCmd)
 	profileCmd.AddCommand(profileCurrentCmd)
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -5,14 +5,18 @@ import (
 	"os"
 
 	"github.com/riba2534/feishu-cli/internal/config"
+	"github.com/riba2534/feishu-cli/internal/profile"
 	"github.com/spf13/cobra"
 )
 
 var (
-	cfgFile   string
-	debug     bool
-	version   = "dev"
-	buildTime = "unknown"
+	cfgFile          string
+	profileFlag      string
+	botAppIDFlag     string
+	botAppSecretFlag string
+	debug            bool
+	version          = "dev"
+	buildTime        = "unknown"
 )
 
 // SetVersionInfo sets version information from main package
@@ -67,14 +71,18 @@ var rootCmd = &cobra.Command{
 注意：bitable 命令已切换到 base/v3 API，flag 使用 --base-token。
 
 配置方式:
-  1. 环境变量（推荐）:
+  1. 单次覆盖（不写盘）:
+     --bot-app-id cli_xxx --bot-app-secret xxx
+
+  2. 环境变量:
      export FEISHU_APP_ID="cli_xxx"
      export FEISHU_APP_SECRET="xxx"
 
-  2. 配置文件:
+  3. 配置文件:
      ~/.feishu-cli/config.yaml
 
-  配置优先级: 环境变量 > 配置文件 > 默认值
+  目录 / User Token: --profile > FEISHU_PROFILE > active-profile 指针 > 旧布局
+  App 凭证: --bot-app-id/--bot-app-secret > FEISHU_APP_ID/FEISHU_APP_SECRET > 选中目录的 config.yaml
 
 快速开始:
   # 创建文档
@@ -94,33 +102,33 @@ var rootCmd = &cobra.Command{
 
 更多信息请访问: https://github.com/riba2534/feishu-cli`,
 	PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
+		// --profile 必须在 skip / config.Init 之前生效，doctor/auth status/profile 才能看到覆盖。
+		if err := profile.SetCommandOverride(profileFlag); err != nil {
+			return err
+		}
+		config.SetBotFlagCredentials(botAppIDFlag, botAppSecretFlag)
+		setUserTokenFlagPresence(cmd)
+		// profile use 切换后局面才是用户关心的那个，由它自己在切换完成后打印
+		if !isProfileUseCmd(cmd) {
+			warnAppCredentialTokenSource()
+		}
 		// --config 仅影响 config.yaml 加载，token 仍按 profile 解析；显式提醒避免错配
 		if cfgFile != "" {
-			fmt.Fprintln(os.Stderr, "⚠️  使用 --config 时，token 仍读自当前 profile（~/.feishu-cli/[profiles/<active>/]token.json）。")
-			fmt.Fprintln(os.Stderr, "    如需完整隔离，请改用 FEISHU_PROFILE=<name>。")
+			fmt.Fprintln(os.Stderr, "⚠️  --config 只替换 config.yaml，不改变 token.json 的候选目录（~/.feishu-cli/[profiles/<active>/]）。")
+			fmt.Fprintln(os.Stderr, "    如需完整隔离，请改用 --profile <name> 或 FEISHU_PROFILE=<name>。")
 		}
-		// Skip config initialization for group commands (those with subcommands but no own RunE,
-		// or with the guard-injected RunE) and utility commands that don't need config
-		if cmd.HasSubCommands() && (cmd.RunE == nil && cmd.Run == nil || cmd.Annotations[groupGuardAnnotation] == "1") {
+		if shouldSkipConfigInit(cmd) {
+			config.ApplyBotFlagCredentials()
 			return nil
-		}
-		switch cmd.Name() {
-		case "init", "help", "completion", "version", "doctor", "schema":
-			return nil
-		}
-		// auth status/logout / schema list / profile 全子命令 不需要配置（纯本地操作或配置自身）
-		if cmd.Parent() != nil {
-			switch cmd.Parent().Name() {
-			case "schema", "profile":
-				return nil
-			case "auth":
-				if cmd.Name() == "status" || cmd.Name() == "logout" {
-					return nil
-				}
-			}
 		}
 
 		if err := config.Init(cfgFile); err != nil {
+			// auth status/logout 是排查入口：config.yaml 坏掉时更需要它们跑得起来
+			if configInitOptional(cmd) {
+				fmt.Fprintf(os.Stderr, "⚠️  读取配置失败（%v）；%s 继续以本地 token 运行，在线刷新/吊销可能不可用。\n", err, cmd.CommandPath())
+				config.ApplyBotFlagCredentials()
+				return nil
+			}
 			return err
 		}
 
@@ -132,6 +140,33 @@ var rootCmd = &cobra.Command{
 
 		return nil
 	},
+}
+
+// isProfileUseCmd 判断是否 `profile use`（别名 switch/checkout 不改变 cmd.Name()）。
+func isProfileUseCmd(cmd *cobra.Command) bool {
+	return cmd.Parent() != nil && cmd.Parent().Name() == "profile" && cmd.Name() == "use"
+}
+
+// configInitOptional 报告命令能否在配置加载失败时降级继续。
+// auth status/logout 纯读本地 token 也有价值，不该被一个坏掉的 config.yaml 堵死。
+func configInitOptional(cmd *cobra.Command) bool {
+	if cmd.Parent() == nil || cmd.Parent().Name() != "auth" {
+		return false
+	}
+	return cmd.Name() == "status" || cmd.Name() == "logout"
+}
+
+// shouldSkipConfigInit 只跳过纯本地元数据/配置管理命令。
+// auth status --verify 与 auth logout 需要当前 profile 的 App 凭证做刷新/吊销，必须返回 false。
+func shouldSkipConfigInit(cmd *cobra.Command) bool {
+	if cmd.HasSubCommands() && (cmd.RunE == nil && cmd.Run == nil || cmd.Annotations[groupGuardAnnotation] == "1") {
+		return true
+	}
+	switch cmd.Name() {
+	case "init", "help", "completion", "version", "doctor", "schema":
+		return true
+	}
+	return cmd.Parent() != nil && (cmd.Parent().Name() == "schema" || cmd.Parent().Name() == "profile")
 }
 
 // Execute adds all child commands to the root command and sets flags appropriately.
@@ -152,6 +187,9 @@ func Execute() {
 
 func init() {
 	rootCmd.PersistentFlags().StringVar(&cfgFile, "config", "", "配置文件路径（默认: ~/.feishu-cli/config.yaml）")
+	rootCmd.PersistentFlags().StringVar(&profileFlag, "profile", "", "使用指定 profile（优先于 FEISHU_PROFILE，不修改指针）")
+	rootCmd.PersistentFlags().StringVar(&botAppIDFlag, "bot-app-id", "", "本次命令使用的 Bot app_id（优先于环境变量和配置文件，不写盘）")
+	rootCmd.PersistentFlags().StringVar(&botAppSecretFlag, "bot-app-secret", "", "本次命令使用的 Bot app_secret（优先于环境变量和配置文件，不写盘；会进入 shell 历史与 ps 输出，共享机器慎用）")
 	rootCmd.PersistentFlags().BoolVar(&debug, "debug", false, "启用调试模式")
 	// R1 review fix: RunE 返回 error 时不再打印整页 usage 淹没真错误（11/13 PR 未单独设此 flag → root 统一处理）
 	rootCmd.SilenceUsage = true

--- a/cmd/textwidth.go
+++ b/cmd/textwidth.go
@@ -1,0 +1,56 @@
+package cmd
+
+import (
+	"fmt"
+	"io"
+	"strings"
+
+	"github.com/rivo/uniseg"
+)
+
+// displayWidth 返回字符串在等宽终端里占的列数。
+//
+// 用 uniseg 按 grapheme cluster 计算：ZWJ 表情（👨‍💻）、variation selector、组合音标
+// 都必须整簇算一列宽度，按 rune 累加会把 👨‍💻 算成 2+1+2=5 而实际只占 2 列。
+// uniseg 已在依赖图中（go-runewidth 的依赖），不引入新的体积。
+func displayWidth(s string) int {
+	return uniseg.StringWidth(s)
+}
+
+// padCell 把单元格补到 width 显示列；超宽时原样返回，由后续列自行错开。
+func padCell(s string, width int) string {
+	if pad := width - displayWidth(s); pad > 0 {
+		return s + strings.Repeat(" ", pad)
+	}
+	return s
+}
+
+// renderColumns 按显示宽度对齐输出表格：列间固定 2 空格，末列不补尾随空格。
+func renderColumns(w io.Writer, header []string, rows [][]string) error {
+	widths := make([]int, len(header))
+	for i, h := range header {
+		widths[i] = displayWidth(h)
+	}
+	for _, row := range rows {
+		for i, cell := range row {
+			if i < len(widths) && displayWidth(cell) > widths[i] {
+				widths[i] = displayWidth(cell)
+			}
+		}
+	}
+	for _, row := range append([][]string{header}, rows...) {
+		var b strings.Builder
+		for i, cell := range row {
+			if i == len(row)-1 {
+				b.WriteString(cell)
+				break
+			}
+			b.WriteString(padCell(cell, widths[i]))
+			b.WriteString("  ")
+		}
+		if _, err := fmt.Fprintln(w, b.String()); err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/cmd/textwidth_test.go
+++ b/cmd/textwidth_test.go
@@ -1,0 +1,75 @@
+package cmd
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"github.com/rivo/uniseg"
+)
+
+func TestDisplayWidth(t *testing.T) {
+	// 期望值来自终端实际渲染列数，独立于实现，不复用被测函数计算
+	cases := []struct {
+		in   string
+		want int
+	}{
+		{"", 0},
+		{"alert", 5},
+		{"--profile alert", 15},
+		{"测试用户", 8},
+		{"a测b", 4},
+		{"（全角）", 8},
+		{"张三🎉", 6},
+		{"👨\u200d💻", 2},  // ZWJ 表情整簇占 2 列，不是 2+1+2
+		{"é", 1},         // 组合音标：e + U+0301
+		{"❤\ufe0f", 2},   // variation selector 让心形变成全宽表情
+		{"a\u0301bc", 3}, // 组合音标不额外占列
+	}
+	for _, c := range cases {
+		if got := displayWidth(c.in); got != c.want {
+			t.Errorf("displayWidth(%q) = %d, want %d", c.in, got, c.want)
+		}
+	}
+}
+
+// tabwriter 按字节对齐，中文用户名会把后面的列顶歪；renderColumns 必须按显示宽度对齐。
+func TestRenderColumnsAlignsCJK(t *testing.T) {
+	var buf bytes.Buffer
+	header := []string{"NAME", "USER", "SELECT"}
+	rows := [][]string{
+		{"alert", "测试用户", "--profile alert"},
+		{"notify", "-", "--profile notify"},
+		{"a", "Ada", "--profile a"},
+		{"zwj", "👨\u200d💻", "--profile zwj"},
+	}
+	if err := renderColumns(&buf, header, rows); err != nil {
+		t.Fatal(err)
+	}
+	lines := strings.Split(strings.TrimRight(buf.String(), "\n"), "\n")
+	if len(lines) != len(rows)+1 {
+		t.Fatalf("行数 = %d, want %d", len(lines), len(rows)+1)
+	}
+
+	// 列宽由最宽单元格决定：NAME=6("notify")、USER=8("测试用户")，列间 2 空格,
+	// 因此末列必须从第 6+2+8+2=18 列开始。硬编码此值，不用 displayWidth 自证。
+	const wantCol = 18
+	for i, line := range lines {
+		marker := "SELECT"
+		if i > 0 {
+			marker = "--profile"
+		}
+		idx := strings.Index(line, marker)
+		if idx < 0 {
+			t.Fatalf("第 %d 行缺少末列: %q", i, line)
+		}
+		if col := uniseg.StringWidth(line[:idx]); col != wantCol {
+			t.Errorf("第 %d 行末列起始于第 %d 显示列，want %d\n%s", i, col, wantCol, buf.String())
+		}
+	}
+	for _, line := range lines {
+		if strings.HasSuffix(line, " ") {
+			t.Errorf("末列不应补尾随空格: %q", line)
+		}
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.21
 require (
 	github.com/itchyny/gojq v0.12.17
 	github.com/larksuite/oapi-sdk-go/v3 v3.5.3
+	github.com/rivo/uniseg v0.4.7
 	github.com/spf13/cobra v1.8.0
 	github.com/spf13/pflag v1.0.5
 	github.com/spf13/viper v1.18.2

--- a/go.sum
+++ b/go.sum
@@ -38,6 +38,8 @@ github.com/pelletier/go-toml/v2 v2.1.0/go.mod h1:tJU2Z3ZkXwnxa4DPO899bsyIoywizdU
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 h1:Jamvg5psRIccs7FGNTlIRMkT8wgtp5eCXdBlqhYGL6U=
 github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/rivo/uniseg v0.4.7 h1:WUdvkW8uEhrYfLC4ZzdpI2ztxP1I582+49Oc5Mq64VQ=
+github.com/rivo/uniseg v0.4.7/go.mod h1:FN3SvrM+Zdj16jyLfmOkMNblXMcoc8DfTHruCPUcx88=
 github.com/rogpeppe/go-internal v1.9.0 h1:73kH8U+JUqXU8lRuOHeVHaa/SZPifC7BkcraZVejAe8=
 github.com/rogpeppe/go-internal v1.9.0/go.mod h1:WtVeX8xhTBvf0smdhujwtBcq4Qrzq/fJaraNFVN+nFs=
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=

--- a/internal/auth/token.go
+++ b/internal/auth/token.go
@@ -38,13 +38,20 @@ func TokenPath() (string, error) {
 	return tokenPathFunc()
 }
 
-// LoadToken 从文件加载 token，文件不存在返回 nil, nil
+// LoadToken 从当前激活 profile 的 token.json 加载，文件不存在返回 nil, nil。
 func LoadToken() (*TokenStore, error) {
 	path, err := TokenPath()
 	if err != nil {
 		return nil, err
 	}
+	return LoadTokenFrom(path)
+}
 
+// LoadTokenFrom 从指定路径加载 token.json，文件不存在返回 nil, nil。
+func LoadTokenFrom(path string) (*TokenStore, error) {
+	if path == "" {
+		return nil, nil
+	}
 	data, err := os.ReadFile(path)
 	if err != nil {
 		if os.IsNotExist(err) {

--- a/internal/auth/token_from_test.go
+++ b/internal/auth/token_from_test.go
@@ -1,0 +1,25 @@
+package auth
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestLoadTokenFrom(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "token.json")
+	got, err := LoadTokenFrom(path)
+	if err != nil || got != nil {
+		t.Fatalf("missing file: got=%v err=%v", got, err)
+	}
+	if err := os.WriteFile(path, []byte(`{"access_token":"u-from-path","expires_at":"2099-01-01T00:00:00Z"}`), 0600); err != nil {
+		t.Fatal(err)
+	}
+	got, err = LoadTokenFrom(path)
+	if err != nil {
+		t.Fatalf("LoadTokenFrom: %v", err)
+	}
+	if got == nil || got.AccessToken != "u-from-path" {
+		t.Errorf("token = %+v", got)
+	}
+}

--- a/internal/auth/user_cache.go
+++ b/internal/auth/user_cache.go
@@ -47,7 +47,14 @@ func LoadCurrentUserCache() (*CurrentUserCache, error) {
 	if err != nil {
 		return nil, err
 	}
+	return LoadUserCacheFrom(path)
+}
 
+// LoadUserCacheFrom 从指定路径加载 user_profile.json，文件不存在返回 nil, nil。
+func LoadUserCacheFrom(path string) (*CurrentUserCache, error) {
+	if path == "" {
+		return nil, nil
+	}
 	data, err := os.ReadFile(path)
 	if err != nil {
 		if os.IsNotExist(err) {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -36,8 +36,54 @@ type ImportConfig struct {
 
 var cfg *Config
 
+// 命令行 --bot-app-id / --bot-app-secret，优先于环境变量和配置文件，不写盘。
+var botFlagAppID, botFlagAppSecret string
+
+// SetBotFlagCredentials 记录本进程 --bot-app-id / --bot-app-secret（trim 后）。
+// 空字符串表示该 flag 未传，不覆盖。
+func SetBotFlagCredentials(appID, appSecret string) {
+	botFlagAppID = strings.TrimSpace(appID)
+	botFlagAppSecret = strings.TrimSpace(appSecret)
+}
+
+// BotFlagAppID 返回 --bot-app-id，未传则为空。
+func BotFlagAppID() string { return botFlagAppID }
+
+// BotFlagAppSecretSet 报告是否传了 --bot-app-secret（不返回明文）。
+func BotFlagAppSecretSet() bool { return botFlagAppSecret != "" }
+
+func applyBotFlagCredentials() {
+	if botFlagAppID != "" {
+		if cfg != nil {
+			cfg.AppID = botFlagAppID
+		}
+		viper.Set("app_id", botFlagAppID)
+	}
+	if botFlagAppSecret != "" {
+		if cfg != nil {
+			cfg.AppSecret = botFlagAppSecret
+		}
+		viper.Set("app_secret", botFlagAppSecret)
+	}
+}
+
+// ApplyBotFlagCredentials 在 Init 被跳过时仍把 flag 写进进程配置，供 doctor/list 看到覆盖。
+func ApplyBotFlagCredentials() {
+	if botFlagAppID == "" && botFlagAppSecret == "" {
+		return
+	}
+	if cfg == nil {
+		cfg = &Config{
+			BaseURL: "https://open.feishu.cn",
+			Export:  ExportConfig{AssetsDir: "./assets"},
+			Import:  ImportConfig{UploadImages: true},
+		}
+	}
+	applyBotFlagCredentials()
+}
+
 // Init initializes the configuration from file and environment
-// 配置优先级: 环境变量 > 配置文件 > 默认值
+// 应用凭证优先级: --bot-app-id/--bot-app-secret > 环境变量 > 选中目录的配置文件 > 默认值
 //
 // 配置文件路径解析顺序：
 //  1. --config <path> 显式指定
@@ -96,6 +142,9 @@ func Init(cfgFile string) error {
 	// 统一去除 BaseURL 尾部斜杠，避免拼接 API 路径时产生双斜杠
 	cfg.BaseURL = strings.TrimRight(cfg.BaseURL, "/")
 
+	// 5. 命令行凭证覆盖环境变量和文件，不写盘
+	applyBotFlagCredentials()
+
 	return nil
 }
 
@@ -124,10 +173,10 @@ func Validate() error {
 	}
 	cfgPath := activeConfigPathForError()
 	if cfg.AppID == "" {
-		return fmt.Errorf("缺少 app_id，请通过以下方式之一设置:\n  1. 环境变量: export FEISHU_APP_ID=xxx\n  2. 配置文件: %s", cfgPath)
+		return fmt.Errorf("缺少 app_id，请通过以下方式之一设置:\n  1. 命令行: --bot-app-id cli_xxx --bot-app-secret xxx\n  2. 环境变量: export FEISHU_APP_ID=xxx\n  3. 配置文件: %s", cfgPath)
 	}
 	if cfg.AppSecret == "" {
-		return fmt.Errorf("缺少 app_secret，请通过以下方式之一设置:\n  1. 环境变量: export FEISHU_APP_SECRET=xxx\n  2. 配置文件: %s", cfgPath)
+		return fmt.Errorf("缺少 app_secret，请通过以下方式之一设置:\n  1. 命令行: --bot-app-id cli_xxx --bot-app-secret xxx\n  2. 环境变量: export FEISHU_APP_SECRET=xxx\n  3. 配置文件: %s", cfgPath)
 	}
 	return nil
 }
@@ -164,7 +213,7 @@ func CreateDefaultConfig() error {
 	content := `# 飞书 CLI 配置文件
 # 从飞书开放平台获取应用凭证: https://open.feishu.cn/app
 #
-# 配置优先级: 环境变量 > 配置文件 > 默认值
+# 应用凭证优先级: --bot-app-id/--bot-app-secret > 环境变量 > 配置文件 > 默认值
 #
 # 环境变量方式:
 #   export FEISHU_APP_ID=your_app_id

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -11,6 +11,8 @@ import (
 // resetConfig 重置全局配置状态，用于测试隔离
 func resetConfig() {
 	cfg = nil
+	botFlagAppID = ""
+	botFlagAppSecret = ""
 	viper.Reset()
 }
 

--- a/internal/config/flag_credentials_test.go
+++ b/internal/config/flag_credentials_test.go
@@ -1,0 +1,54 @@
+package config
+
+import (
+	"os"
+	"testing"
+)
+
+func TestFlagCredentialsBeatEnv(t *testing.T) {
+	resetConfig()
+	t.Setenv("HOME", t.TempDir())
+	os.Setenv("FEISHU_APP_ID", "cli_env")
+	os.Setenv("FEISHU_APP_SECRET", "sec_env")
+	t.Cleanup(func() {
+		os.Unsetenv("FEISHU_APP_ID")
+		os.Unsetenv("FEISHU_APP_SECRET")
+		resetConfig()
+	})
+
+	SetBotFlagCredentials("cli_flag", "sec_flag")
+	if err := Init(""); err != nil {
+		t.Fatal(err)
+	}
+	c := Get()
+	if c.AppID != "cli_flag" {
+		t.Errorf("AppID = %q, want cli_flag", c.AppID)
+	}
+	if c.AppSecret != "sec_flag" {
+		t.Errorf("AppSecret = %q, want sec_flag", c.AppSecret)
+	}
+}
+
+func TestFlagCredentialsPartial(t *testing.T) {
+	resetConfig()
+	t.Setenv("HOME", t.TempDir())
+	os.Setenv("FEISHU_APP_ID", "cli_env")
+	os.Setenv("FEISHU_APP_SECRET", "sec_env")
+	t.Cleanup(func() {
+		os.Unsetenv("FEISHU_APP_ID")
+		os.Unsetenv("FEISHU_APP_SECRET")
+		resetConfig()
+	})
+
+	SetBotFlagCredentials("cli_flag", "")
+	if err := Init(""); err != nil {
+		t.Fatal(err)
+	}
+	c := Get()
+	if c.AppID != "cli_flag" {
+		t.Errorf("AppID = %q, want cli_flag", c.AppID)
+	}
+	if c.AppSecret != "sec_env" {
+		t.Errorf("AppSecret = %q, want env secret when flag omitted", c.AppSecret)
+	}
+}

--- a/internal/profile/inspect.go
+++ b/internal/profile/inspect.go
@@ -1,0 +1,93 @@
+package profile
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/spf13/viper"
+)
+
+// ConfigFields 是单个 config.yaml 里和身份相关的字段。
+// AppSecret 只用于判断是否已配置，调用方不得打印明文。
+type ConfigFields struct {
+	AppID     string
+	AppSecret string
+	BaseURL   string
+	// UserAccessToken 仅用于判断配置里是否存在静态 user_access_token，
+	// 它是 auth.ResolveUserAccessToken 链的最后一级。调用方不得打印明文。
+	UserAccessToken string
+}
+
+// EnvOverrideFlags 报告哪些凭证被环境变量覆盖。
+type EnvOverrideFlags struct {
+	AppID     bool `json:"app_id"`
+	AppSecret bool `json:"app_secret"`
+	Profile   bool `json:"profile"`
+}
+
+// EnvOverrides 检测会压过配置文件的环境变量（非空即视为覆盖）。
+func EnvOverrides() EnvOverrideFlags {
+	return EnvOverrideFlags{
+		AppID:     strings.TrimSpace(os.Getenv("FEISHU_APP_ID")) != "",
+		AppSecret: strings.TrimSpace(os.Getenv("FEISHU_APP_SECRET")) != "",
+		Profile:   strings.TrimSpace(os.Getenv(EnvVar)) != "",
+	}
+}
+
+// EnvAppID 返回 FEISHU_APP_ID（trim 后），未设置则为空。
+func EnvAppID() string {
+	return strings.TrimSpace(os.Getenv("FEISHU_APP_ID"))
+}
+
+// EnvBaseURL 返回 FEISHU_BASE_URL（trim 后），未设置则为空。
+func EnvBaseURL() string {
+	return strings.TrimSpace(os.Getenv("FEISHU_BASE_URL"))
+}
+
+// ReadConfigFields 读取 dir/config.yaml 的 app_id / app_secret / base_url。
+// 文件不存在时返回零值，不报错。使用独立 viper 实例，不污染全局配置。
+func ReadConfigFields(dir string) (ConfigFields, error) {
+	if dir == "" {
+		return ConfigFields{}, nil
+	}
+	return ReadConfigFieldsFile(filepath.Join(dir, configFileName))
+}
+
+// ReadConfigFieldsFile 按显式路径读取配置字段，供 --config 覆盖场景使用。
+// 文件不存在时返回零值，不报错。
+func ReadConfigFieldsFile(path string) (ConfigFields, error) {
+	if path == "" {
+		return ConfigFields{}, nil
+	}
+	if _, err := os.Stat(path); err != nil {
+		if os.IsNotExist(err) {
+			return ConfigFields{}, nil
+		}
+		return ConfigFields{}, err
+	}
+
+	v := viper.New()
+	v.SetConfigFile(path)
+	v.SetConfigType("yaml")
+	if err := v.ReadInConfig(); err != nil {
+		return ConfigFields{}, err
+	}
+	return ConfigFields{
+		AppID:           strings.TrimSpace(v.GetString("app_id")),
+		AppSecret:       strings.TrimSpace(v.GetString("app_secret")),
+		BaseURL:         strings.TrimRight(strings.TrimSpace(v.GetString("base_url")), "/"),
+		UserAccessToken: strings.TrimSpace(v.GetString("user_access_token")),
+	}, nil
+}
+
+// EffectiveBaseURL 叠加环境变量后的最终 base_url。
+func EffectiveBaseURL(fileBaseURL string) string {
+	if env := EnvBaseURL(); env != "" {
+		return strings.TrimRight(env, "/")
+	}
+	if fileBaseURL != "" {
+		return fileBaseURL
+	}
+	return "https://open.feishu.cn"
+}

--- a/internal/profile/inspect_test.go
+++ b/internal/profile/inspect_test.go
@@ -1,0 +1,53 @@
+package profile
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestReadConfigFields(t *testing.T) {
+	dir := t.TempDir()
+	got, err := ReadConfigFields(dir)
+	if err != nil {
+		t.Fatalf("missing file: %v", err)
+	}
+	if got.AppID != "" || got.AppSecret != "" {
+		t.Errorf("empty dir should yield zero fields, got %+v", got)
+	}
+
+	content := "app_id: cli_from_file\napp_secret: secret_xxx\nbase_url: https://open.larksuite.com/\n"
+	if err := os.WriteFile(filepath.Join(dir, "config.yaml"), []byte(content), 0600); err != nil {
+		t.Fatal(err)
+	}
+	got, err = ReadConfigFields(dir)
+	if err != nil {
+		t.Fatalf("ReadConfigFields: %v", err)
+	}
+	if got.AppID != "cli_from_file" {
+		t.Errorf("AppID = %q", got.AppID)
+	}
+	if got.AppSecret != "secret_xxx" {
+		t.Errorf("AppSecret should be present")
+	}
+	if got.BaseURL != "https://open.larksuite.com" {
+		t.Errorf("BaseURL = %q (want trimmed slash)", got.BaseURL)
+	}
+}
+
+func TestEnvOverrides(t *testing.T) {
+	t.Setenv("FEISHU_APP_ID", "cli_x")
+	t.Setenv("FEISHU_APP_SECRET", "sec")
+	t.Setenv(EnvVar, "work")
+	got := EnvOverrides()
+	if !got.AppID || !got.AppSecret || !got.Profile {
+		t.Errorf("EnvOverrides = %+v, want all true", got)
+	}
+	t.Setenv("FEISHU_APP_ID", "")
+	t.Setenv("FEISHU_APP_SECRET", "")
+	t.Setenv(EnvVar, "")
+	got = EnvOverrides()
+	if got.AppID || got.AppSecret || got.Profile {
+		t.Errorf("EnvOverrides = %+v, want all false", got)
+	}
+}

--- a/internal/profile/override_lock_test.go
+++ b/internal/profile/override_lock_test.go
@@ -1,0 +1,25 @@
+package profile
+
+import (
+	"testing"
+	"time"
+)
+
+// CommandOverride 不得复用 writeMu：Create/Remove/Use 等写函数持锁期间若需要读覆盖值，
+// 复用这把不可重入的锁会直接自锁死。
+func TestCommandOverrideDoesNotShareWriteMutex(t *testing.T) {
+	writeMu.Lock()
+	defer writeMu.Unlock()
+
+	done := make(chan struct{})
+	go func() {
+		_ = CommandOverride()
+		close(done)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(3 * time.Second):
+		t.Fatal("持有 writeMu 时读 CommandOverride 卡死：两者必须使用独立 mutex")
+	}
+}

--- a/internal/profile/override_test.go
+++ b/internal/profile/override_test.go
@@ -1,0 +1,52 @@
+package profile
+
+import "testing"
+
+func TestCommandOverrideBeatsEnv(t *testing.T) {
+	withTempHome(t)
+	t.Cleanup(func() { _ = SetCommandOverride("") })
+	if err := Create("work", CreateOpts{SwitchTo: true}); err != nil {
+		t.Fatalf("Create work: %v", err)
+	}
+	if err := Create("personal", CreateOpts{}); err != nil {
+		t.Fatalf("Create personal: %v", err)
+	}
+	t.Setenv(EnvVar, "personal")
+	if err := SetCommandOverride("work"); err != nil {
+		t.Fatalf("SetCommandOverride: %v", err)
+	}
+	name, source, err := ResolveActive()
+	if err != nil {
+		t.Fatalf("ResolveActive: %v", err)
+	}
+	if name != "work" || source != SourceFlag {
+		t.Errorf("ResolveActive = %q/%q, want work/%s", name, source, SourceFlag)
+	}
+	if err := SetCommandOverride("ghost"); err == nil {
+		t.Fatalf("SetCommandOverride(ghost) should error")
+	}
+}
+
+func TestCommandOverrideClear(t *testing.T) {
+	withTempHome(t)
+	t.Cleanup(func() { _ = SetCommandOverride("") })
+	if err := Create("work", CreateOpts{SwitchTo: true}); err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	if err := Create("personal", CreateOpts{}); err != nil {
+		t.Fatalf("Create personal: %v", err)
+	}
+	if err := SetCommandOverride("personal"); err != nil {
+		t.Fatal(err)
+	}
+	if err := SetCommandOverride(""); err != nil {
+		t.Fatal(err)
+	}
+	name, source, err := ResolveActive()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if name != "work" || source != SourcePointer {
+		t.Errorf("after clear ResolveActive = %q/%q, want work/%s", name, source, SourcePointer)
+	}
+}

--- a/internal/profile/resolve_source_test.go
+++ b/internal/profile/resolve_source_test.go
@@ -1,0 +1,152 @@
+package profile
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func writeLegacyFile(t *testing.T, home, name string) {
+	t.Helper()
+	root := filepath.Join(home, ".feishu-cli")
+	if err := os.MkdirAll(root, 0700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(root, name), []byte("app_id: cli_legacy\n"), 0600); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// active_source 是写进 Skill 文档的 Agent 契约字段，六个取值都必须被钉死。
+func TestResolveActiveSources(t *testing.T) {
+	t.Run("none：空目录", func(t *testing.T) {
+		withTempHome(t)
+		name, source, err := ResolveActive()
+		if err != nil || name != "" || source != SourceNone {
+			t.Errorf("= %q/%q/%v, want \"\"/%s/nil", name, source, err, SourceNone)
+		}
+	})
+
+	t.Run("legacy：无 profiles 但有旧布局文件", func(t *testing.T) {
+		home := withTempHome(t)
+		writeLegacyFile(t, home, "config.yaml")
+		name, source, err := ResolveActive()
+		if err != nil || name != "" || source != SourceLegacy {
+			t.Errorf("= %q/%q/%v, want \"\"/%s/nil", name, source, err, SourceLegacy)
+		}
+	})
+
+	t.Run("legacy：有 profiles、无指针、旧布局仍在（保护 zero-touch 升级）", func(t *testing.T) {
+		home := withTempHome(t)
+		if err := Create("work", CreateOpts{AppID: "cli_work"}); err != nil {
+			t.Fatal(err)
+		}
+		writeLegacyFile(t, home, "token.json")
+		name, source, err := ResolveActive()
+		if err != nil || name != "" || source != SourceLegacy {
+			t.Errorf("= %q/%q/%v, want \"\"/%s/nil", name, source, err, SourceLegacy)
+		}
+	})
+
+	t.Run("fallback：无指针、无旧布局，回退字典序第一个", func(t *testing.T) {
+		withTempHome(t)
+		if err := Create("zeta", CreateOpts{}); err != nil {
+			t.Fatal(err)
+		}
+		if err := Create("alpha", CreateOpts{}); err != nil {
+			t.Fatal(err)
+		}
+		name, source, err := ResolveActive()
+		if err != nil || name != "alpha" || source != SourceFallback {
+			t.Errorf("= %q/%q/%v, want alpha/%s/nil", name, source, err, SourceFallback)
+		}
+	})
+
+	t.Run("fallback：指针指向已删除的 profile", func(t *testing.T) {
+		withTempHome(t)
+		if err := Create("gone", CreateOpts{SwitchTo: true}); err != nil {
+			t.Fatal(err)
+		}
+		if err := Create("kept", CreateOpts{}); err != nil {
+			t.Fatal(err)
+		}
+		dir, err := ProfileDir("gone")
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err := os.RemoveAll(dir); err != nil {
+			t.Fatal(err)
+		}
+		name, source, err := ResolveActive()
+		if err != nil || name != "kept" || source != SourceFallback {
+			t.Errorf("= %q/%q/%v, want kept/%s/nil", name, source, err, SourceFallback)
+		}
+	})
+
+	t.Run("legacy：指针失效但旧布局还在（与指针缺失同语义）", func(t *testing.T) {
+		home := withTempHome(t)
+		if err := Create("gone", CreateOpts{SwitchTo: true}); err != nil {
+			t.Fatal(err)
+		}
+		if err := Create("kept", CreateOpts{}); err != nil {
+			t.Fatal(err)
+		}
+		dir, err := ProfileDir("gone")
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err := os.RemoveAll(dir); err != nil {
+			t.Fatal(err)
+		}
+		writeLegacyFile(t, home, "config.yaml")
+		name, source, err := ResolveActive()
+		if err != nil || name != "" || source != SourceLegacy {
+			t.Errorf("= %q/%q/%v, want \"\"/%s/nil（不能把老用户静默切到别的 Bot）", name, source, err, SourceLegacy)
+		}
+	})
+
+	t.Run("pointer：active-profile 指针", func(t *testing.T) {
+		withTempHome(t)
+		if err := Create("work", CreateOpts{SwitchTo: true}); err != nil {
+			t.Fatal(err)
+		}
+		name, source, err := ResolveActive()
+		if err != nil || name != "work" || source != SourcePointer {
+			t.Errorf("= %q/%q/%v, want work/%s/nil", name, source, err, SourcePointer)
+		}
+	})
+
+	t.Run("env：FEISHU_PROFILE", func(t *testing.T) {
+		withTempHome(t)
+		if err := Create("work", CreateOpts{SwitchTo: true}); err != nil {
+			t.Fatal(err)
+		}
+		if err := Create("personal", CreateOpts{}); err != nil {
+			t.Fatal(err)
+		}
+		t.Setenv(EnvVar, "personal")
+		name, source, err := ResolveActive()
+		if err != nil || name != "personal" || source != SourceEnv {
+			t.Errorf("= %q/%q/%v, want personal/%s/nil", name, source, err, SourceEnv)
+		}
+	})
+
+	t.Run("flag 压过 env", func(t *testing.T) {
+		withTempHome(t)
+		t.Cleanup(func() { _ = SetCommandOverride("") })
+		if err := Create("work", CreateOpts{SwitchTo: true}); err != nil {
+			t.Fatal(err)
+		}
+		if err := Create("personal", CreateOpts{}); err != nil {
+			t.Fatal(err)
+		}
+		t.Setenv(EnvVar, "personal")
+		if err := SetCommandOverride("work"); err != nil {
+			t.Fatal(err)
+		}
+		name, source, err := ResolveActive()
+		if err != nil || name != "work" || source != SourceFlag {
+			t.Errorf("= %q/%q/%v, want work/%s/nil", name, source, err, SourceFlag)
+		}
+	})
+}

--- a/internal/profile/store.go
+++ b/internal/profile/store.go
@@ -15,10 +15,11 @@
 //	      config.yaml
 //	      ...
 //
-// 解析优先级（由 ActiveDir 返回）：
-//  1. 环境变量 FEISHU_PROFILE=<name>（强制覆盖，profile 必须存在）
-//  2. ~/.feishu-cli/active-profile 指针指向的 profile
-//  3. 无 profile 系统时，返回旧布局 ~/.feishu-cli/
+// 解析优先级（由 ActiveDir / ActiveSource 返回）：
+//  1. 进程内 --profile flag（SetCommandOverride，不写指针）
+//  2. 环境变量 FEISHU_PROFILE=<name>（强制覆盖，profile 必须存在）
+//  3. ~/.feishu-cli/active-profile 指针指向的 profile
+//  4. 无 profile 系统时，返回旧布局 ~/.feishu-cli/
 //
 // 设计要点：
 //   - 向后兼容：旧用户的 ~/.feishu-cli/config.yaml + token.json 仍然能读，
@@ -69,6 +70,23 @@ var nameRegex = regexp.MustCompile(`^[A-Za-z0-9_-]{1,64}$`)
 // 进程内锁，用于 active-profile / previous-profile 指针文件的串行化。
 // 仅 sync.Mutex 保护进程内并发；跨进程并发场景应用层避免。
 var writeMu sync.Mutex
+
+// commandOverride 是本进程 --profile flag 的覆盖值，优先于 FEISHU_PROFILE。
+// 空字符串表示未设置。由 SetCommandOverride 写入。
+//
+// 用独立 mutex：writeMu 保护文件写入，而 Create/Remove/Use 等写函数持锁期间可能需要
+// 读覆盖值，复用同一把不可重入的锁会自锁死。
+var (
+	overrideMu      sync.Mutex
+	commandOverride string
+)
+
+// 导出文件名常量，供上层按任意 profile 目录拼路径，避免各处硬编码字符串。
+const (
+	ConfigFileName    = configFileName
+	TokenFileName     = tokenFileName
+	UserCacheFileName = userCacheName
+)
 
 // ErrNotConfigured 当未配置 profile 系统时返回（无 profiles/ 目录）。
 var ErrNotConfigured = errors.New("profile 系统未初始化")
@@ -264,67 +282,126 @@ func ReadPrevious() (string, error) {
 	return readPointer(previousPointerName)
 }
 
-// ActiveName 返回当前激活的 profile 名（解析优先级见包注释）。
-// 若未启用 profile 系统返回空字符串和 nil error，调用方应回退到旧布局。
-func ActiveName() (string, error) {
+// SetCommandOverride 设置本进程 --profile 覆盖（优先于 FEISHU_PROFILE，不写指针）。
+// name 为空则清除覆盖。非空时 profile 必须已存在。
+func SetCommandOverride(name string) error {
+	name = strings.TrimSpace(name)
+	if name == "" {
+		overrideMu.Lock()
+		commandOverride = ""
+		overrideMu.Unlock()
+		return nil
+	}
+	if err := ValidateName(name); err != nil {
+		return fmt.Errorf("--profile %w", err)
+	}
+	ok, err := Exists(name)
+	if err != nil {
+		return err
+	}
+	if !ok {
+		return fmt.Errorf("%w: --profile 指向的 profile %q 不存在", ErrNotFound, name)
+	}
+	overrideMu.Lock()
+	commandOverride = name
+	overrideMu.Unlock()
+	return nil
+}
+
+// CommandOverride 返回本进程 --profile 覆盖值，未设置时为空。
+func CommandOverride() string {
+	overrideMu.Lock()
+	defer overrideMu.Unlock()
+	return commandOverride
+}
+
+// ActiveSource 取值：flag / env / pointer / fallback / legacy / none。
+const (
+	SourceFlag     = "flag"
+	SourceEnv      = "env"
+	SourcePointer  = "pointer"
+	SourceFallback = "fallback"
+	SourceLegacy   = "legacy"
+	SourceNone     = "none"
+)
+
+// ResolveActive 返回当前 profile 名及其来源。名称为空表示走旧布局。
+func ResolveActive() (name, source string, err error) {
+	if override := CommandOverride(); override != "" {
+		return override, SourceFlag, nil
+	}
 	if env := strings.TrimSpace(os.Getenv(EnvVar)); env != "" {
 		if err := ValidateName(env); err != nil {
-			return "", fmt.Errorf("%s 环境变量值非法: %w", EnvVar, err)
+			return "", "", fmt.Errorf("%s 环境变量值非法: %w", EnvVar, err)
 		}
 		ok, err := Exists(env)
 		if err != nil {
-			return "", err
+			return "", "", err
 		}
 		if !ok {
-			return "", fmt.Errorf("%w: %s 指向的 profile %q 不存在", ErrNotFound, EnvVar, env)
+			return "", "", fmt.Errorf("%w: %s 指向的 profile %q 不存在", ErrNotFound, EnvVar, env)
 		}
-		return env, nil
+		return env, SourceEnv, nil
 	}
 	hasProfiles, err := HasProfiles()
 	if err != nil {
-		return "", err
+		return "", "", err
 	}
 	if !hasProfiles {
-		return "", nil
+		if hasLegacyLayout() {
+			return "", SourceLegacy, nil
+		}
+		return "", SourceNone, nil
 	}
-	name, err := ReadActive()
+	name, err = ReadActive()
 	if err != nil {
-		return "", err
+		return "", "", err
 	}
 	if name == "" {
 		// 有 profile 但没指针。codex review P2 finding：legacy 文件存在时优先 legacy，
 		// 避免 profile add 后未 use 就被悄悄切走（zero-touch upgrade 破坏）。
 		if hasLegacyLayout() {
-			return "", nil // caller (ActiveDir) 会用 RootDir() 走旧布局
+			return "", SourceLegacy, nil
 		}
 		all, err := List()
 		if err != nil {
-			return "", err
+			return "", "", err
 		}
 		if len(all) == 0 {
-			return "", nil
+			return "", SourceNone, nil
 		}
-		return all[0], nil
+		return all[0], SourceFallback, nil
 	}
 	if err := ValidateName(name); err != nil {
-		return "", fmt.Errorf("active-profile 指针非法: %w", err)
+		return "", "", fmt.Errorf("active-profile 指针非法: %w", err)
 	}
 	ok, err := Exists(name)
 	if err != nil {
-		return "", err
+		return "", "", err
 	}
 	if !ok {
-		// 指针指向不存在的 profile，回退到第一个
+		// 指针指向已不存在的 profile。与「指针缺失」同一语义：旧布局还在时先用旧布局，
+		// 不要把仍在用 ~/.feishu-cli/ 的老用户静默切到另一套 Bot。
+		if hasLegacyLayout() {
+			return "", SourceLegacy, nil
+		}
 		all, err := List()
 		if err != nil {
-			return "", err
+			return "", "", err
 		}
 		if len(all) == 0 {
-			return "", nil
+			return "", SourceNone, nil
 		}
-		return all[0], nil
+		return all[0], SourceFallback, nil
 	}
-	return name, nil
+	return name, SourcePointer, nil
+}
+
+// ActiveName 返回当前激活的 profile 名（解析优先级见包注释）。
+// 若未启用 profile 系统返回空字符串和 nil error，调用方应回退到旧布局。
+func ActiveName() (string, error) {
+	name, _, err := ResolveActive()
+	return name, err
 }
 
 // ActiveDir 返回当前激活 profile 的目录。
@@ -369,44 +446,6 @@ func UserCacheFilePath() (string, error) {
 	return filepath.Join(dir, userCacheName), nil
 }
 
-// Info 描述一个 profile 的元数据，用于 list 输出。
-type Info struct {
-	Name      string `json:"name"`
-	Path      string `json:"path"`
-	Active    bool   `json:"active"`
-	HasConfig bool   `json:"has_config"`
-	HasToken  bool   `json:"has_token"`
-}
-
-// Describe 返回所有 profile 的元数据列表。当未启用 profile 系统时返回空切片。
-func Describe() ([]Info, error) {
-	names, err := List()
-	if err != nil {
-		return nil, err
-	}
-	active, err := ActiveName()
-	if err != nil {
-		return nil, err
-	}
-	out := make([]Info, 0, len(names))
-	for _, name := range names {
-		dir, err := ProfileDir(name)
-		if err != nil {
-			return nil, err
-		}
-		info := Info{
-			Name:      name,
-			Path:      dir,
-			Active:    name == active,
-			HasConfig: fileExists(filepath.Join(dir, configFileName)),
-			HasToken:  fileExists(filepath.Join(dir, tokenFileName)),
-		}
-		out = append(out, info)
-	}
-	return out, nil
-}
-
-// fileExists 测试文件是否存在。
 // hasLegacyLayout 检测旧布局是否存在（~/.feishu-cli/config.yaml 或 token.json 任一即视为 legacy）。
 // 用于 ActiveName 在指针缺失时优先 legacy 而非自动切到字典序第一个 profile。
 func hasLegacyLayout() bool {
@@ -422,6 +461,7 @@ func hasLegacyLayout() bool {
 	return false
 }
 
+// fileExists 测试文件是否存在。
 func fileExists(path string) bool {
 	_, err := os.Stat(path)
 	return err == nil

--- a/internal/profile/store_test.go
+++ b/internal/profile/store_test.go
@@ -382,38 +382,6 @@ func TestEnvVarOverride(t *testing.T) {
 	}
 }
 
-func TestDescribe(t *testing.T) {
-	withTempHome(t)
-	if err := Create("work", CreateOpts{SwitchTo: true}); err != nil {
-		t.Fatalf("Create work: %v", err)
-	}
-	if err := Create("personal", CreateOpts{}); err != nil {
-		t.Fatalf("Create personal: %v", err)
-	}
-
-	infos, err := Describe()
-	if err != nil {
-		t.Fatalf("Describe: %v", err)
-	}
-	if len(infos) != 2 {
-		t.Fatalf("Describe len = %d, want 2", len(infos))
-	}
-	for _, info := range infos {
-		if info.Name == "work" && !info.Active {
-			t.Errorf("work should be active")
-		}
-		if info.Name == "personal" && info.Active {
-			t.Errorf("personal should not be active")
-		}
-		if !info.HasConfig {
-			t.Errorf("%s should have config.yaml", info.Name)
-		}
-		if info.HasToken {
-			t.Errorf("%s should not have token.json (not logged in)", info.Name)
-		}
-	}
-}
-
 func TestMigrateLegacy(t *testing.T) {
 	home := withTempHome(t)
 	legacyDir := filepath.Join(home, ".feishu-cli")

--- a/skills/feishu-cli-platform/SKILL.md
+++ b/skills/feishu-cli-platform/SKILL.md
@@ -11,7 +11,7 @@ description: >-
   这里的“全局搜索”仅指 `search docs/messages/apps`，不包括在审批、会议、邮箱等业务域内查询。
   请求出现 approval、approval_code、审批定义/实例/待办时绝对不要使用本 Skill，应使用
   feishu-cli-work；出现视频会议、妙记、minute、录制或逐字稿时应使用 feishu-cli-meetings。
-argument-hint: <auth|config|api|schema|search|user|dept> [args]
+argument-hint: <auth|config|profile|api|schema|search|user|dept> [args]
 user-invocable: true
 allowed-tools: Bash(feishu-cli:*), Bash(./feishu-cli:*), Bash(jq:*), Bash(curl:*), Bash(python3:*), Read, Write
 ---
@@ -38,8 +38,9 @@ Schema 只负责发现接口；API 负责执行请求。通常先查 schema，�
 
 1. 优先运行仓库当前编译产物 `./feishu-cli`；安装环境才使用 PATH 中的 `feishu-cli`。
 2. User Token 操作先执行 `auth check --scope`。不要在输出、文件或命令历史中暴露真实 Token。
-3. 写请求先用 `--dry-run`；API 不支持 dry-run 的端点需明确告知用户副作用。
-4. 搜索与通讯录结果默认只读取；用户要求后续写操作时再切换到对应领域 Skill。
+3. 多 Bot / 不确定当前是哪个应用时，先 `profile list --json`；单次目录/Token 选择用 `--profile <name>`，不要为一条命令去 `profile use`。若 `env_overrides.app_id/app_secret=true`，环境变量仍覆盖 App 凭证，需先提示用户 unset 对应变量。
+4. 写请求先用 `--dry-run`；API 不支持 dry-run 的端点需明确告知用户副作用。
+5. 搜索与通讯录结果默认只读取；用户要求后续写操作时再切换到对应领域 Skill。
 
 ## 领域边界
 

--- a/skills/feishu-cli-platform/evals/evals.json
+++ b/skills/feishu-cli-platform/evals/evals.json
@@ -48,6 +48,14 @@
       "expected_output": "使用 user search 与 dept children 的只读命令，并说明 ID 类型应显式指定。",
       "expectations": ["使用 user search --email user@example.com", "使用 dept children od_xxx", "明确只读查询且 ID 类型应根据实际输入显式设置，而非靠前缀猜测"],
       "files": []
+    },
+    {
+      "id": 7,
+      "workflows": ["auth"],
+      "prompt": "本机有多个飞书机器人，我不确定当前会打到哪个。先看能操作哪些 Bot，再用名为 work 的那个发一条消息，不要改默认 profile。",
+      "expected_output": "先 profile list --json，再用 --profile work 发消息，不执行 profile use。",
+      "expectations": ["先执行 profile list --json", "业务命令带 --profile work 或 FEISHU_PROFILE=work", "不使用 profile use"],
+      "files": []
     }
   ]
 }

--- a/skills/feishu-cli-platform/references/workflows/auth/workflow.md
+++ b/skills/feishu-cli-platform/references/workflows/auth/workflow.md
@@ -169,6 +169,12 @@ feishu-cli auth check --scope "search:docs:read" && feishu-cli search docs --que
 | `cached_user.open_id` / `.name` | **当前登录的是谁**——需要本人 open_id（发消息给自己、查自己任务）时从这里取（仅当本地有 user cache 时出现） |
 | `note` | 健康度提示文案（如 `missing_refresh_token` / `expired` 场景出现） |
 | `verified` / `verify_error` | 仅 `--verify`：在线调 `user_info` 核验 token 是否仍被服务端接受 |
+| `profile` / `profile_source` | 当前选中的 profile 及其选择来源（flag/env/pointer/fallback/legacy/none） |
+| `app_id` | 叠加 `--bot-app-*` / `FEISHU_APP_*` 后的生效 App ID |
+| `token_from_profile` | `token.json` 的候选目录（**不是**本次实际用的 token，见下） |
+| `env_overrides` / `flag_overrides` | 当前命令有哪些 App/Profile 覆盖来源 |
+| `profile_error` | 当前生效那套的配置/token 读取问题（配置损坏时仍会输出，便于排查） |
+| `hint` | App 凭证被覆盖时的说明 |
 
 未登录时返回 `{"logged_in": false, "identity": "bot", "note": "..."}`。
 
@@ -313,29 +319,54 @@ CI 用法：`feishu-cli doctor --offline --json | jq -e '.ok == true'`。
 
 已经明确是 scope 缺失时，不需要 doctor，直接 `auth check --scope "..."`。
 
-> **v1.27.1 新增**：使用 `--config <path>` 显式覆盖配置时，CLI 会在 stderr 打印 warning，提示 profile 系统被绕过（`token.json` 自动加载等行为失效）。AI Agent 调试时若看到该 warning，意味着当前命令未走 profile 体系，token 解析仅依赖该 `--config` 文件中的字段。
+> **v1.27.1 新增**：使用 `--config <path>` 显式覆盖配置时，CLI 会在 stderr 打印 warning：`--config` **只换 yaml，token 仍读当前 profile**。完整隔离请用 `--profile <name>` 或 `FEISHU_PROFILE`。此时 `profile list --json` / `profile current --json` 的 `effective`（app_id、base_url、has_secret）反映的是 `--config` 那份文件，而 `profiles[]` 仍是各 profile 目录里的原值，`token_from_profile` 不受影响。
 
 ## 多 App Profile（profile）
 
-用户需要在多个飞书租户、多个 App ID 或工作/个人账号之间切换时，用 profile 管理独立的 `config.yaml` 和 `token.json`：
+用户需要在多个飞书租户、多个 App ID 或工作/个人账号之间切换时，用 profile 管理独立的 `config.yaml` 和 `token.json`。
+
+**发现入口（Agent 必跑）**：`feishu-cli profile list --json`。这是 Bot 清单，不是目录清单。即使还没 `profile add`，也会给出 `effective`（环境变量 / 旧布局正在用的那一套），不要把空的 `profiles[]` 理解成「没有 Bot」。
 
 ```bash
 feishu-cli profile add work --app-id cli_xxx --app-secret secret_xxx --use
 feishu-cli profile list --json
-feishu-cli profile current
-feishu-cli profile use work
+feishu-cli profile current --json
+feishu-cli --profile work msg send ...     # 单次指定，不改指针（推荐）
+feishu-cli --bot-app-id cli_xxx --bot-app-secret xxx auth status -o json  # 仅本次覆盖 App 凭证
+feishu-cli profile use work                # 改默认指针；仅当用户要求「以后都用这个」
 feishu-cli profile use -                    # toggle 到上一个 profile（previous-profile 指针）
 feishu-cli profile rename old-name new-name
 feishu-cli profile remove old-name
 feishu-cli profile migrate --name work
 ```
 
-解析优先级：
+`profile list --json` 关键字段：
 
-1. `FEISHU_PROFILE=<name>` 环境变量强制覆盖。
-2. `~/.feishu-cli/active-profile` 指针。
-3. 指针缺失或失效时，回退到 `profiles/` 下字典序第一个（可能不是预期的那个）。
-4. 未启用 profile 系统时，继续使用旧布局 `~/.feishu-cli/config.yaml` 和 `~/.feishu-cli/token.json`。
+- `mode`: `profile` 或 `legacy`
+- `active` / `active_source`: `flag` / `env` / `pointer` / `fallback` / `legacy` / `none`
+- `env_overrides.app_id`: `true` 表示 `FEISHU_APP_ID` 会盖住所有 profile 的 app_id
+- `flag_overrides.app_id/app_secret`: `true` 表示对应 `--bot-app-*` 正在覆盖 App 凭证
+- `token_from_profile`: `token.json` 的**候选目录**；App 凭证覆盖不会改变它
+- `user_token_override`: `--user-access-token` / `FEISHU_USER_ACCESS_TOKEN` / 空。非空表示存在压过 `token.json` 的显式 User Token
+- `has_config_user_token`: 生效的 `config.yaml` 里是否配了静态 `user_access_token`（解析链最后一级，不输出明文）
+- `effective_error` / `profiles[].config_error` / `token_error` / `cache_error`: 各文件的读取问题；单个 profile 损坏不会让整张清单失败
+- `hint`: App 凭证与 User Token 来自不同解析链时的显式提醒
+- `effective`: 叠加环境变量后真正会拿去调 API 的那一套（含 `app_id`、`token_status`、`select_with`）
+- `profiles[]`: 磁盘上每一套；`app_id` 是文件里的值。`select_with` 形如 `--profile alert`
+
+两条解析链彼此正交：
+
+1. **目录 / User Token**：`--profile` > `FEISHU_PROFILE` > `~/.feishu-cli/active-profile` 指针 > 旧布局。指针缺失或失效且没有旧布局时，回退到 `profiles/` 下字典序第一个。
+2. **App 凭证**：`--bot-app-id` / `--bot-app-secret` > `FEISHU_APP_ID` / `FEISHU_APP_SECRET` > 上一条选中目录的 `config.yaml`。
+
+**不要把这些字段当成「本次命令实际用了哪个 token」**：本项目按命令分四类 token helper（读类 User 优先 Tenant 兜底、写类默认 Bot、必须 User Token、`--as` 显式切换），`--as bot`、默认 Bot 身份的写命令、只认 flag 的 `vc bot meeting-join`、固定读本地文件的 `auth status` 各走各的路径。CLI 只陈述可离线证明的事实（设置了哪些覆盖、候选目录是谁、文件在不在），实际身份要看目标命令自己的文档与 `--dry-run` 输出。
+
+`--profile` 不会压过 `FEISHU_APP_ID/FEISHU_APP_SECRET`，App 凭证覆盖也不会切换 `token.json`。`hint` 和 `token_from_profile` 任何时候都描述这组正交来源；stderr 只在**真错配**时出声，两种情形：
+
+- 覆盖来的 `app_id` 与所选目录 `config.yaml` 里的不是同一个应用（User Token 仍读该目录的 `token.json`）；
+- `app_id` 与 `app_secret` 落在不同层（例如只传了 `--bot-app-secret`），两半凭证可能不属于同一应用。
+
+单应用 `export FEISHU_APP_ID/FEISHU_APP_SECRET`（没有 profile，或与所选 profile 是同一个应用）不会有任何 stderr 输出——不要把「没有警告」理解成「没在用环境变量」，要判断覆盖关系一律读 `profile list --json` 的 `env_overrides` / `effective`。
 
 踩坑（违反直觉、可能丢数据，逐条留意）：
 
@@ -356,3 +387,7 @@ profile 名校验规则 `[A-Za-z0-9_-]{1,64}`（禁止 `.` / `..` / `profiles` /
 3. 授权成功后读 `authorization_complete` 的 `missing_scopes`：非空只是 warning，开通后按需补授（增量授权，补缺失的几个即可，不会丢已授 scope）。
 4. 不把 `user_access_token` / `device_code` 写入文档、代码或日志。
 5. 错误信息明确指向 scope/token 时直接 `auth check`；只有错误不明确（"突然不工作"/网络异常）才用 `doctor` 缩小问题面，不要混用。
+6. 用户可能有多个飞书 Bot、或没指明用哪个时，先 `feishu-cli profile list --json`。看 `effective` 和 `env_overrides`，不要猜。
+7. 单次指定用 `feishu-cli --profile <name> <cmd>`（或 `FEISHU_PROFILE=<name>`）。不要为了跑一条业务去 `profile use`——会改全局指针。
+8. `--as bot` 只选身份，不选 App。看到 `env_overrides.app_id/app_secret=true` 必须告诉用户：环境变量仍会覆盖所选 profile 的 App 凭证；要用 profile YAML 中的凭证必须先 unset 对应变量。
+9. `app_id` 可以出现在回复里；`app_secret` / 裸 token / `device_code` 禁止写入回复或文件。


### PR DESCRIPTION
## 做了什么

把「用哪个目录 / User Token」和「用哪套 App 凭证」拆成两条正交解析链，并新增三个全局 flag：

- 目录 / User Token：`--profile` > `FEISHU_PROFILE` > `active-profile` 指针 > 旧布局
- App 凭证：`--bot-app-id`/`--bot-app-secret` > `FEISHU_APP_ID`/`SECRET` > 选中目录的 `config.yaml`

`profile list` / `profile current` 升级为 Bot 清单——即使没执行过 `profile add`，也会输出环境变量/旧布局正在用的那套（`effective`），避免 Agent 误判「一个 Bot 都没有」。

## 兼容性

用基线 `c7f8094` 编译的二进制对三种典型环境（纯 legacy / profile 模式 / 空环境）做了差异对比：

| 项 | 结果 |
|---|---|
| `profile list --json` | 基线 5 个字段（name/path/active/has_config/has_token）**取值逐一相同**，只新增字段 |
| `auth status -o json` | **零字段丢失、零取值变化**，只新增 7 个键 |
| 所有命令退出码 | 13 组用例**全部一致** |

两处行为变更：

1. **人类可读输出**：`profile list` 表格列改为 ACTIVE/NAME/APP_ID/TOKEN/USER/SELECT，`profile current` 输出扩展为多行，`auth status` 新增 Profile/App ID 行并修正既有中文标签行的 1 列错位。解析输出的脚本请改用 `--json` / `-o json`（这两个契约完全兼容）。
2. **`active-profile` 指针失效且旧布局仍在时，改为优先旧布局**（原为回退到字典序第一个 profile）。指针缺失时优先旧布局本就是既定设计，此改动让「指针失效」与「指针缺失」这两种等价情况行为一致，且更保守——不会把仍在用 `~/.feishu-cli/` 的老用户静默切到另一套 Bot。

## 告警收窄

凭证告警此前只要设置了 `FEISHU_APP_ID` 就对每条命令打印，而这正是 README 推荐的单应用用法。现在只在「真错配」时出声：覆盖来的 app_id 与所选目录 config.yaml 不是同一个应用，或两半凭证落在不同层且无法确认同属一个应用。

身份字段只陈述可离线证明的事实（`user_token_override` / `has_config_user_token` / `token_from_profile`）。本项目按命令分四类 token helper，`--as bot`、默认 Bot 身份的写命令、只认 flag 的 `vc bot meeting-join`、固定读本地文件的 `auth status` 各有各的解析路径，root 层不断言「本次实际用了哪个 token」。

## 健壮性

- 单个 profile 的 config/token/cache 损坏不再击穿整张清单，按来源分别记录原因并在输出中点名
- `auth status`/`logout` 在 `config.yaml` 损坏时降级继续（业务命令保持 fail-fast）
- 表格按显示宽度对齐（uniseg，正确处理 CJK 与 ZWJ 表情）
- `commandOverride` 改用独立 mutex，不再复用保护文件写入的 `writeMu`

## 验证

`gofmt` / `go vet` / `go test` / `go test -race` / 黑盒测试 ×30 无 flake / `go mod tidy -diff` / `go mod verify` / `make build-all`（5 平台）/ `make check-skills` / 隐私扫描 全部通过。

新增 39 个测试函数（475 → 514），其中黑盒测试走真实 `rootCmd` 并同时捕获 stdout/stderr。